### PR TITLE
Problem: hacky build configuration for Frama-c

### DIFF
--- a/cmake/FramaC.cmake
+++ b/cmake/FramaC.cmake
@@ -38,22 +38,24 @@ function(add_framac)
             add_custom_target(framac)
         endif()
 
-        get_target_property(_include_directories ${FRAMAC_TARGET} INCLUDE_DIRECTORIES)
-
-        foreach(_include_directory ${_include_directories})
-            string(APPEND cpp_extra_args " -I ${_include_directory} ")
-        endforeach()
-
         foreach(_cflags ${FRAMAC_CFLAGS})
             string(APPEND cpp_extra_args ${_cflags})
         endforeach()
 
-        # FIXME: this is a hack until we figure out how to get all include directories
-        # for all dependencies of the target (because we'll need this anyway)
-        get_target_property(_libpgext_include_directories libpgext INCLUDE_DIRECTORIES)
+        get_target_property(_targets ${FRAMAC_TARGET} LINK_LIBRARIES)
+        list(APPEND _targets ${FRAMAC_TARGET})
 
-        foreach(include_dir ${_libpgext_include_directories})
-            string(APPEND cpp_extra_args " -I ${include_dir}")
+        foreach(target ${_targets})
+            get_target_property(_include_directories ${target} INCLUDE_DIRECTORIES)
+            get_target_property(_interface_include_directories ${target} INTERFACE_INCLUDE_DIRECTORIES)
+
+            foreach(_include_directory ${_include_directories})
+                string(APPEND cpp_extra_args " -I ${_include_directory} ")
+            endforeach()
+
+            foreach(_include_directory ${_interface_include_directories})
+                string(APPEND cpp_extra_args " -I ${_include_directory} ")
+            endforeach()
         endforeach()
 
         get_target_property(_sources ${FRAMAC_TARGET} SOURCES)

--- a/libgluepg_curl/CMakeLists.txt
+++ b/libgluepg_curl/CMakeLists.txt
@@ -13,10 +13,9 @@ find_package(PostgreSQL REQUIRED)
 find_package(CURL REQUIRED)
 
 add_library(libgluepg_curl STATIC libgluepg_curl.c)
-add_dependencies(libgluepg_curl libpgext)
 set_property(TARGET libgluepg_curl PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(libgluepg_curl
-        PRIVATE ${PostgreSQL_SERVER_INCLUDE_DIRS} ${curl_SOURCE_DIR}/include ${libpgext_SOURCE_DIR}
+        PRIVATE ${PostgreSQL_SERVER_INCLUDE_DIRS} ${curl_SOURCE_DIR}/include
         PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(libgluepg_curl PUBLIC libcurl)
+target_link_libraries(libgluepg_curl PUBLIC libcurl libpgext)
 add_framac(TARGET libgluepg_curl FUNCTIONS gluepg_curl_buffer_write_impl)


### PR DESCRIPTION
It requires on knowledge of libpgext and it doesn't support targets with dependencies with includes unless those includes are listed explicitly.

Solution: scan through all direct dependencies to figure out all includes