### PR TITLE
Problem: dependencies are dynamically linked

### DIFF
--- a/cmake/FindCURL.cmake
+++ b/cmake/FindCURL.cmake
@@ -2,5 +2,10 @@ include(CPM)
 include(OpenSSL)
 
 find_package(OpenSSL REQUIRED)
-CPMAddPackage(URL "https://github.com/curl/curl/releases/download/curl-7_87_0/curl-7.87.0.tar.bz2"
-    OPTIONS "BUILD_CURL_EXE OFF BUILD_SHARED_LIBS OFF CURL_USE_LIBSSH2 OFF CURL_ZLIB OFF CURL_DISABLE_LDAP ON OPENSSL_USE_STATIC_LIBS ON")
+
+set(BUILD_SHARED_LIBS OFF)
+set(CURL_USE_LIBSSH2 OFF)
+set(CURL_ZLIB OFF)
+set(CURL_DISABLE_LDAP ON)
+CPMAddPackage(URL "https://github.com/curl/curl/releases/download/curl-7_87_0/curl-7.87.0.tar.bz2")
+set_property(TARGET libcurl PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/cmake/FindYyjson.cmake
+++ b/cmake/FindYyjson.cmake
@@ -1,3 +1,3 @@
 include(CPM)
 
-CPMAddPackage("gh:ibireme/yyjson#0.6.0")
+CPMAddPackage(GITHUB_REPOSITORY "ibireme/yyjson" GIT_TAG "0.6.0" OPTIONS "BUILD_SHARED_LIBS OFF")

--- a/cmake/OpenSSL.cmake
+++ b/cmake/OpenSSL.cmake
@@ -9,3 +9,5 @@ if(APPLE)
         message(FATAL_ERROR "No OpenSSL found, use homebrew to install one")
     endif()
 endif()
+
+set(OPENSSL_USE_STATIC_LIBS ON)


### PR DESCRIPTION
This makes extension distribution more difficult.

Solution: make it statically linked against its dependencies

Not sure why `curl`'s CPM command didn't take OPTIONS well, but at
least this worked.