### PR TITLE
Problem: polluting .pg with extensions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,15 +37,15 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: .pg
-        key: ${{ matrix.os }}-pg-${{ matrix.pgver }}
+        key: ${{ matrix.os }}-pg-${{ matrix.pgver }}_V1
 
     - name: Configure
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: PGVER=${{ matrix.pgver }} cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
-    - name: Build and deploy
-      run: cmake --build ${{github.workspace}}/build --parallel --config ${{env.BUILD_TYPE}} -t deploy
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --parallel --config ${{env.BUILD_TYPE}}
 
     - name: Cache Docker images
       uses: ScribeMD/docker-cache@0.2.6

--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ Beware: this is currently more of a prototype and a lot is missing!
 
 ```shell
 # in the build directory
-CTEST_PARALLEL_LEVEL=$(nproc) make deploy test
+CTEST_PARALLEL_LEVEL=$(nproc) make -j $(nproc) all test
 ```


### PR DESCRIPTION
This makes it very difficult to work with independent builds.

Solution: deploy extensions within cmake build directory

The `deploy` and `deploy_NAME` targets are now gone.

This required a hack to make customizable PGSHAREDIR for testing purposes
but it seems to have work out alright.

Bumped up cache for .pg as it is now a patched version of Postgres.