### PR TITLE
Problem: testing on a Linux machine while on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: .pg
-        key: ${{ matrix.os }}-pg-${{ matrix.pgver }}_V1
+        key: ${{ matrix.os }}-pg-${{ matrix.pgver }}_V1.1
 
     - name: Configure
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .pg
 build
+build-linux
 cmake-build-debug
 .idea
 .vscode

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -77,7 +77,7 @@ else()
 endif()
 
 # This is where we manage all PostgreSQL installations
-set(PGDIR "${CMAKE_CURRENT_LIST_DIR}/../.pg")
+set(PGDIR "${CMAKE_CURRENT_LIST_DIR}/../.pg/${CMAKE_HOST_SYSTEM_NAME}")
 
 # This is where we manage selected PostgreSQL version's installations
 set(PGDIR_VERSION "${PGDIR}/${PGVER_ALIAS}")
@@ -321,7 +321,7 @@ function(add_postgresql_extension NAME)
     endforeach()
 
     set(_share_dir "${CMAKE_BINARY_DIR}/pg-share")
-    file(COPY "${_pg_sharedir}/" DESTINATION ${_share_dir})
+    file(COPY "${_pg_sharedir}/" DESTINATION "${_share_dir}")
     set(_ext_dir "${_share_dir}/extension")
     file(MAKE_DIRECTORY ${_ext_dir})
 

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:23.04
+
+RUN apt update -y
+RUN apt install -y git build-essential cmake flex libreadline-dev libz-dev libssl-dev
+RUN apt install -y sudo rsync
+# Using 501 to match Colima's default
+RUN adduser --uid 501 omni
+USER omni
+RUN git config --global --add safe.directory '*'
+ENV DOCKER_LINUX_BUILDER 1
+
+VOLUME /omni
+WORKDIR /omni


### PR DESCRIPTION
This is often requiring a trip to CI, which is not very ergonomic.

Solution: provide a simple builder Docker container

It seems to work, however, I am having difficulty making it work
with VirtioFS, when copying files, it seems to have a problem not
finding some files (spontaneously). Copying the source directory
away from a mounted volume helps. It also appears to work fine with
gRPC FUSE, but it is *extremely* slow.

That being said, [Colima](https://github.com/abiosoft/colima)-configured
context seems to work fine, a bit slower, but bearable.

This also changes the layout of the .pg directory, adding operating
system subdirectories to allow co-existence of Postgres builds for
different platforms.