### PR TITLE
Problem: setting dependency options within the higher scope

### DIFF
--- a/cmake/FindCURL.cmake
+++ b/cmake/FindCURL.cmake
@@ -5,9 +5,6 @@ include(OpenSSL)
 
 find_package(OpenSSL REQUIRED)
 
-set(BUILD_SHARED_LIBS OFF)
-set(CURL_USE_LIBSSH2 OFF)
-set(CURL_ZLIB OFF)
-set(CURL_DISABLE_LDAP ON)
-CPMAddPackage(URL "https://github.com/curl/curl/releases/download/curl-7_87_0/curl-7.87.0.tar.bz2")
+CPMAddPackage(URL "https://github.com/curl/curl/releases/download/curl-7_87_0/curl-7.87.0.tar.bz2"
+    OPTIONS "BUILD_SHARED_LIBS OFF" "CURL_USE_LIBSSH2 OFF" "CURL_ZLIB OFF" "CURL_DISABLE_LDAP ON" "BULD_CURL_EXE OFF")
 set_property(TARGET libcurl PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/cmake/FindSTC.cmake
+++ b/cmake/FindSTC.cmake
@@ -1,3 +1,3 @@
 include(CPM)
 
-CPMAddPackage(NAME stc GIT_REPOSITORY https://github.com/tylov/stc GIT_TAG 91e79fc OPTIONS "BUILD_TESTING OFF")
+CPMAddPackage(NAME stc GIT_REPOSITORY https://github.com/tylov/stc GIT_TAG 91e79fc VERSION 4.0-91e79fc OPTIONS "BUILD_TESTING OFF")


### PR DESCRIPTION
Solution: use CPM's `OPTIONS` parameter

I've previously failed to use it correctly by passing a single string,
it should have been multiple parameters.

While we're at it, set STC's version at something more appropriate than @91
guessed by CPM.