### PR TITLE
Problem: can't easily compile on NixOS

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -105,7 +105,9 @@ if(NOT EXISTS "${PGDIR_VERSION}/build/bin/postgres")
     file(WRITE "${PGDIR_VERSION}/postgresql-${PGVER_ALIAS}/src/port/pg_config_paths.h" ${FILE_CONTENTS})
 
     execute_process(
-        COMMAND make install
+        # Ensure we always set SHELL to /bin/sh to be used in pg_regress. Otherwise it has been observed to
+        # degrade to `sh` (at least, on NixOS) and pg_regress fails to start anything
+        COMMAND make SHELL=/bin/sh install
         WORKING_DIRECTORY "${PGDIR_VERSION}/postgresql-${PGVER_ALIAS}")
 endif()
 

--- a/cmake/OpenSSL.cmake
+++ b/cmake/OpenSSL.cmake
@@ -9,6 +9,9 @@ if(APPLE)
 
     message(STATUS "Found OpenSSL at ${OPENSSL_PREIX}")
     set(OPENSSL_ROOT_DIR ${OPENSSL_PREIX} CACHE INTERNAL "OpenSSL")
+elseif(UNIX)
+    find_package(PkgConfig)
+    pkg_check_modules(_OPENSSL openssl)
 endif()
 
 set(OPENSSL_USE_STATIC_LIBS ON)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "cmake_nixpkgs": {
+      "locked": {
+        "lastModified": 1673444646,
+        "narHash": "sha256-KXqUmmkX952jwl/3FO8DWCsQBfOjB0ED4unYCVOOIAk=",
+        "owner": "yrashk",
+        "repo": "nixpkgs",
+        "rev": "3003a72d0e5d1105e963cc3375e7176c2a91d5b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yrashk",
+        "ref": "cmake-3.25.1",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "cmake_nixpkgs": "cmake_nixpkgs",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  inputs = {
+    # Pending cmake 3.25.1 merge and release: https://github.com/NixOS/nixpkgs/pull/206799 
+    cmake_nixpkgs.url = "github:yrashk/nixpkgs?ref=cmake-3.25.1";
+    nixpkgs.url = "nixpkgs/nixos-22.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, cmake_nixpkgs, nixpkgs, flake-utils }:
+  flake-utils.lib.eachDefaultSystem
+  (system:
+      let cmake = cmake_nixpkgs.legacyPackages.${system}.cmake; in
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShell = pkgs.mkShell { buildInputs = [ pkgs.pkgsStatic.openssl pkgs.pkgconfig cmake pkgs.flex pkgs.readline
+                                                  pkgs.zlib]; };
+      });
+}


### PR DESCRIPTION
My Linux machine runs NixOS, and it's much easier to test Linux-specific bits on a real Linux machine as opposed to one in Docker. Especially when it comes to performance.

Solution: develop a Nix flake and adjust cmake to work with pkg-config