### PR TITLE
Problem: Dynpgext extensions can be useless without a loader

### DIFF
--- a/dynpgext/CMakeLists.txt
+++ b/dynpgext/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(dynpgext INTERFACE)
 target_include_directories(dynpgext
     INTERFACE ${PostgreSQL_SERVER_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_subdirectory(test)
+
 if(DOXYGEN_FOUND)
     set(DOXYGEN_PROJECT_BRIEF "Dynamic Postgres Extensions")
 

--- a/dynpgext/dynpgext.h
+++ b/dynpgext/dynpgext.h
@@ -10,6 +10,8 @@
 #include <postmaster/bgworker.h>
 // clang-format on
 
+#include <utils/guc.h>
+
 /**
  * @private
  * @brief Magic structure for compatibility checks
@@ -233,5 +235,24 @@ __attribute__((always_inline)) inline static void *dynpgext_lookup_shmem(const c
 #else
 extern void *dynpgext_lookup_shmem(const char *name);
 #endif
+
+/**
+ * @brief Tests if a Dynpgext loader is present
+ *
+ * This function can be used to handle extension initialization should a Dynpgext loader not be
+ * present. The functionality may be reduced but it can still be a functional extension.
+ *
+ * Loader must set `dynpgext.loader_present` to true to indicate its presence
+ *
+ * @return true if a loader present
+ * @return false if a loder is not present
+ */
+static bool dynpgext_loader_present() {
+  static bool is_dynpgext_loader_present = false;
+  DefineCustomBoolVariable(
+      "dynpgext.loader_present", "Flag indicating presence of a Dynpgext loader", NULL,
+      &is_dynpgext_loader_present, false, PGC_BACKEND, GUC_CUSTOM_PLACEHOLDER, NULL, NULL, NULL);
+  return is_dynpgext_loader_present;
+}
 
 #endif // DYNPGEXT_H

--- a/dynpgext/test/CMakeLists.txt
+++ b/dynpgext/test/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(dynpgext_test)
+
+include(CPM)
+include(CTest)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../../cmake)
+
+enable_testing()
+
+find_package(PostgreSQL REQUIRED)
+
+add_postgresql_extension(
+        dynpgext_test
+        VERSION 0.1
+        SCRIPTS dynpgext_test--0.1.sql
+        RELOCATABLE false
+        SOURCES dynpgext_test.c
+        REGRESS loader_present)
+
+target_link_libraries(dynpgext_test dynpgext)

--- a/dynpgext/test/dynpgext_test--0.1.sql
+++ b/dynpgext/test/dynpgext_test--0.1.sql
@@ -1,0 +1,4 @@
+CREATE FUNCTION loader_present()
+    RETURNS bool
+    AS 'MODULE_PATHNAME', 'loader_present'
+    LANGUAGE C;

--- a/dynpgext/test/dynpgext_test.c
+++ b/dynpgext/test/dynpgext_test.c
@@ -1,0 +1,17 @@
+#include <dirent.h>
+#include <limits.h>
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
+#include <utils/elog.h>
+
+#include <dynpgext.h>
+
+PG_MODULE_MAGIC;
+DYNPGEXT_MAGIC;
+
+PG_FUNCTION_INFO_V1(loader_present);
+Datum loader_present(PG_FUNCTION_ARGS) { PG_RETURN_BOOL(dynpgext_loader_present()); }

--- a/dynpgext/test/expected/loader_present.out
+++ b/dynpgext/test/expected/loader_present.out
@@ -1,0 +1,10 @@
+-- There should be no loader
+SHOW dynpgext.loader_present;
+ERROR:  unrecognized configuration parameter "dynpgext.loader_present"
+-- And dynpgext should indicate the same
+SELECT loader_present();
+ loader_present 
+----------------
+ f
+(1 row)
+

--- a/dynpgext/test/sql/loader_present.sql
+++ b/dynpgext/test/sql/loader_present.sql
@@ -1,0 +1,4 @@
+-- There should be no loader
+SHOW dynpgext.loader_present;
+-- And dynpgext should indicate the same
+SELECT loader_present();

--- a/extensions/omni_ext/init.c
+++ b/extensions/omni_ext/init.c
@@ -183,7 +183,13 @@ void shmem_hook() {
   LWLockRelease(AddinShmemInitLock);
 }
 
+static bool _dynpgext_loader_present = true;
+
 void _PG_init() {
+  DefineCustomBoolVariable("dynpgext.loader_present",
+                           "Flag indicating presence of a Dynpgext loader", NULL,
+                           &_dynpgext_loader_present, true, PGC_BACKEND, 0, NULL, NULL, NULL);
+
   DefineCustomIntVariable("omni_ext.shmem_size",
                           "Pre-allocated shared memory size, rounded to megabytes", NULL,
                           &shmem_size, 16, 0, MAX_KILOBYTES, PGC_POSTMASTER,


### PR DESCRIPTION
We can set a flag on `_Dynpgext_init` if the extension was loaded at a startup and use it to flag to `_PG_init` that there's no Dynpgext.

However, this won't work if the extension is loaded through the following sequence:

* CREATE EXTENSION
* SELECT omni_ext.load('extension_name') (or using other Dynpgext loader) This step may be a part of extension's SQL script.

At this point we can't tell if Dynpgext loader is present.

Solution: use a GUC variable to indicate Dynpgext loader presence

Open questions:

* How do we deal with multiple loaders present? Should this be possible?
* Can we expose loader function through Dynpgext interface so that `_PG_init` can call it so that we rely less on specific knowledge on how to load the extension.