### PR TITLE
Problem: CI actions take some time (not too bad, but still some)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,15 @@ jobs:
         path: .pg
         key: ${{ matrix.os }}-pg-${{ matrix.pgver }}_V2
 
+    - uses: actions/cache@v3
+      with:
+        path: .cache/CPM
+        key: CPM-deps-sources
+
     - name: Configure
+      env:
+        # Cache dependency sources
+        CPM_SOURCE_CACHE: .cache/CPM
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: PGVER=${{ matrix.pgver }} cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}


### PR DESCRIPTION
Solution: cache CPM dependency sources