### PR TITLE
Problem: exposing functionality of the database to the world

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        pgver: [15, 14, 13, 12]
+        pgver: [15, 14, 13]
         os: [ubuntu-latest, macos-12]
         exclude:
           - os: macos-12
@@ -43,6 +43,13 @@ jobs:
       run: |
         brew update
         brew install openssl@3
+
+    - name: Install recent curl on Linux
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        wget --retry-on-http-error=42 --retry-connrefused -c https://github.com/moparisthebest/static-curl/releases/download/v7.87.0/curl-amd64
+        chmod +x curl-amd64
+        mv curl-amd64 curl
 
     - name: Setup Docker on macOS using Colima, Lima-VM, and Homebrew.
       uses: douglascamata/setup-docker-macos-action@v1-alpha
@@ -74,7 +81,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -timeout 1000 --force-new-ctest-process --verbose --output-on-failure -j $(nproc) -C ${{env.BUILD_TYPE}}
+      run: env PATH=${{github.workspace}}:$PATH ctest -timeout 1000 --force-new-ctest-process --verbose --output-on-failure -j $(nproc) -C ${{env.BUILD_TYPE}}
 
     - uses: actions/upload-artifact@v3
       if: failure()

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PGVERS=15 14 13 12
+PGVERS=15 14 13
 ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 test: $(PGVERS)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Omnigres makes PostgreSQL a complete application platform. You can deploy a sing
 
 * [omni_containers](extensions/omni_containers/README.md)
 * [omni_ext](extensions/omni_ext/README.md)
+* [omni_httpd](extensions/omni_httpd/README.md)
 * [Dynpgext interface](dynpgext/README.md)
 
 ## Try it out

--- a/cmake/FindH2O.cmake
+++ b/cmake/FindH2O.cmake
@@ -1,0 +1,11 @@
+include(CPM)
+include(CheckCSourceCompiles)
+
+set(_h2o_options)
+list(APPEND _h2o_options "WITH_MRUBY OFF")
+list(APPEND _h2o_options "DISABLE_LIBUV ON")
+
+cmake_policy(SET CMP0042 NEW)
+CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG 9ab3feb VERSION 2.3.0-9ab3feb OPTIONS "${_h2o_options}")
+set_property(TARGET libh2o PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET libh2o-evloop PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/cmake/FindMetalang.cmake
+++ b/cmake/FindMetalang.cmake
@@ -1,0 +1,3 @@
+include(CPM)
+
+CPMAddPackage("gh:Hirrolot/metalang99@1.13.2")

--- a/dynpgext/CMakeLists.txt
+++ b/dynpgext/CMakeLists.txt
@@ -32,6 +32,7 @@ if(DOXYGEN_FOUND)
 
     if(NOT TARGET doxygen)
         add_custom_target(doxygen)
-        add_dependencies(doxygen doxygen_dynpgext)
     endif()
+
+    add_dependencies(doxygen doxygen_dynpgext)
 endif()

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -7,3 +7,4 @@ enable_testing()
 
 add_subdirectory(omni_ext)
 add_subdirectory(omni_containers)
+add_subdirectory(omni_httpd)

--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -1,0 +1,74 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(omni_httpd)
+
+include(CTest)
+include(FindPkgConfig)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+
+enable_testing()
+
+find_package(PostgreSQL REQUIRED)
+find_package(H2O REQUIRED)
+find_package(Metalang REQUIRED)
+
+pkg_check_modules(BROTLI_DEC libbrotlidec)
+pkg_check_modules(BROTLI_ENC libbrotlienc)
+
+add_postgresql_extension(
+        omni_httpd
+        VERSION 0.1
+        SCHEMA omni_httpd
+        RELOCATABLE false
+        SCRIPTS omni_httpd--0.1.sql
+        SOURCES omni_httpd.c master_worker.c http_worker.c fd.c
+        TESTS_REQUIRE omni_ext
+        REGRESS http)
+
+target_link_libraries(omni_httpd libh2o-evloop libpgaug libgluepg_stc dynpgext metalang99)
+
+# Disable full macro expansion backtraces for Metalang99.
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+        target_compile_options(omni_httpd PRIVATE -fmacro-backtrace-limit=1)
+elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(omni_httpd PRIVATE -ftrack-macro-expansion=0)
+endif()
+
+target_compile_definitions(omni_httpd PRIVATE H2O_USE_LIBUV=0)
+
+get_target_property(_h2o_deps libh2o INCLUDE_DIRECTORIES)
+target_include_directories(omni_httpd PUBLIC $<TARGET_PROPERTY:libh2o,INCLUDE_DIRECTORIES>)
+
+if(BROTLI_DEC_FOUND AND BROTLI_ENC_FOUND)
+        target_link_directories(omni_httpd PUBLIC ${BROTLI_DEC_LIBRARY_DIRS} ${BROTLI_ENC_LIBRARY_DIRS})
+endif()
+
+find_package(Doxygen)
+
+if(DOXYGEN_FOUND)
+        set(DOXYGEN_PROJECT_BRIEF "omni_httpd")
+
+        set(DOXYGEN_GENERATE_TREEVIEW YES)
+        set(DOXYGEN_FULL_SIDEBAR NO)
+
+        set(DOXYGEN_OUTPUT_FOR_C YES)
+        set(DOXYGEN_MARKDOWN_SUPPORT YES)
+        set(DOXYGEN_AUTOLINK_SUPPORT YES)
+        set(DOXYGEN_USE_MDFILE_AS_MAINPAGE docs/index.md)
+        set(DOXYGEN_EXTRACT_STATIC YES)
+        set(DOXYGEN_INLINE_SOURCES YES)
+        set(DOXYGEN_REFERENCES_RELATION YES)
+        set(DOXYGEN_REFERENCED_BY_RELATION YES)
+        set(DOXYGEN_SOURCE_BROWSER YES)
+
+        # TODO: add other doxygen-awesome extensions
+        set(DOXYGEN_HTML_EXTRA_STYLESHEET ${CMAKE_CURRENT_SOURCE_DIR}/../../.doxygen/doxygen-awesome.css)
+
+        doxygen_add_docs(doxygen_omni_httpd ${CMAKE_CURRENT_SOURCE_DIR})
+
+        if(NOT TARGET doxygen)
+                add_custom_target(doxygen)
+        endif()
+
+        add_dependencies(doxygen doxygen_omni_httpd)
+endif()

--- a/extensions/omni_httpd/README.md
+++ b/extensions/omni_httpd/README.md
@@ -1,0 +1,5 @@
+# omni_httpd
+
+## HTTP server
+
+Runs an HTTP server inside of Postgres.

--- a/extensions/omni_httpd/expected/http.out
+++ b/extensions/omni_httpd/expected/http.out
@@ -1,0 +1,47 @@
+CREATE TABLE users (
+    id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    handle text,
+    name text
+);
+INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
+INSERT INTO omni_httpd.listeners (port, query) VALUES (9000, $$
+SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!'), 1 AS priority
+       FROM request
+       INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
+UNION
+SELECT omni_httpd.http_response(body => request.headers::text), 1 AS priority FROM request WHERE request.path = '/headers'
+UNION
+SELECT omni_httpd.http_response(body => request.body), 1 AS priority FROM request WHERE request.path = '/echo'
+UNION
+SELECT omni_httpd.http_response(status => 404, body => json_build_object('method', request.method, 'path', request.path, 'query_string', request.query_string)), 0 AS priority
+       FROM request
+ORDER BY priority DESC
+$$);
+-- Now, the actual tests
+-- FIXME: for the time being, since there's no "request" extension yet, we're shelling out to curl
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9000/test?q=1
+{"method" : "GET", "path" : "/test", "query_string" : "q=1"}
+404
+Content-Type: text/json
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' -d 'hello world' http://localhost:9000/echo
+hello world
+200
+Content-Type: application/octet-stream
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9000/users/johndoe
+Hello, <b>John</b>!
+200
+Content-Type: text/html
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/headers
+{"(user-agent,test-agent,t)","(accept,*/*,t)"}-- Try changing configuration
+UPDATE omni_httpd.listeners SET port = 9001;
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9001/test?q=1
+{"method" : "GET", "path" : "/test", "query_string" : "q=1"}
+404
+Content-Type: text/json
+
+\! curl --silent -w '\n%{exitcode}' http://localhost:9000/test?q=1
+
+7

--- a/extensions/omni_httpd/fd.c
+++ b/extensions/omni_httpd/fd.c
@@ -1,0 +1,110 @@
+/*! \file */
+
+// from man 5 standards:
+// SUS (XPG4v2)
+// The application must define _XOPEN_SOURCE and set _XOPEN_SOURCE_EXTENDED=1. If _XOPEN_SOURCE is
+// defined with a value, the value must be less than 500.
+#ifdef __sun
+#define _XOPEN_SOURCE
+#define _XOPEN_SOURCE_EXTENDED 1
+#endif
+
+#include <assert.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#if defined(__FreeBSD__)
+#include <sys/param.h>
+#endif
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
+#include "fd.h"
+
+#define FD_BUFFER(n)                                                                               \
+  struct {                                                                                         \
+    struct cmsghdr h;                                                                              \
+    int fd[n];                                                                                     \
+  }
+
+static int send_fds_with_buffer(int sock, cvec_fd *fds, void *buffer) {
+  struct msghdr msghdr;
+  char nothing = '!';
+  struct iovec payload_ptr;
+  struct cmsghdr *cmsg;
+  int i;
+  unsigned n_fds = cvec_fd_size(fds);
+
+  payload_ptr.iov_base = &nothing;
+  payload_ptr.iov_len = 1;
+
+  msghdr.msg_name = NULL;
+  msghdr.msg_namelen = 0;
+  msghdr.msg_iov = &payload_ptr;
+  msghdr.msg_iovlen = 1;
+  msghdr.msg_flags = 0;
+  msghdr.msg_control = buffer;
+  msghdr.msg_controllen = sizeof(struct cmsghdr) + sizeof(int) * n_fds;
+  cmsg = CMSG_FIRSTHDR(&msghdr);
+  cmsg->cmsg_len = msghdr.msg_controllen;
+  cmsg->cmsg_level = SOL_SOCKET;
+  cmsg->cmsg_type = SCM_RIGHTS;
+  int c = 0;
+  c_FOREACH(i, cvec_fd, *fds) { ((int *)CMSG_DATA(cmsg))[c++] = *i.ref; }
+  return (sendmsg(sock, &msghdr, 0) >= 0 ? 0 : -1);
+}
+
+int send_fds(int sock, cvec_fd *fds) {
+  FD_BUFFER(MAX_N_FDS) buffer;
+
+  Assert(cvec_size(fds) <= MAX_N_FDS);
+  return send_fds_with_buffer(sock, fds, &buffer);
+}
+
+static cvec_fd recv_fds_with_buffer(int sock, void *buffer) {
+  struct msghdr msghdr;
+  char nothing;
+  unsigned n_fds;
+  struct iovec payload_ptr;
+  struct cmsghdr *cmsg;
+  int i;
+
+  payload_ptr.iov_base = &nothing;
+  payload_ptr.iov_len = 1;
+
+  msghdr.msg_name = NULL;
+  msghdr.msg_namelen = 0;
+  msghdr.msg_iov = &payload_ptr;
+  msghdr.msg_iovlen = 1;
+  msghdr.msg_flags = 0;
+  msghdr.msg_control = buffer;
+  msghdr.msg_controllen = sizeof(struct cmsghdr) + sizeof(int) * MAX_N_FDS;
+  cmsg = CMSG_FIRSTHDR(&msghdr);
+  cmsg->cmsg_len = msghdr.msg_controllen;
+  cmsg->cmsg_level = SOL_SOCKET;
+  cmsg->cmsg_type = SCM_RIGHTS;
+  n_fds = (cmsg->cmsg_len - sizeof(struct cmsghdr)) / sizeof(int);
+
+  for (i = 0; i < n_fds; i++)
+    ((int *)CMSG_DATA(cmsg))[i] = -1;
+
+  cvec_fd result = cvec_fd_with_capacity(n_fds);
+  if (recvmsg(sock, &msghdr, 0) < 0)
+    return result;
+
+  n_fds = (cmsg->cmsg_len - sizeof(struct cmsghdr)) / sizeof(int);
+  for (i = 0; i < n_fds; i++)
+    cvec_fd_push(&result, ((int *)CMSG_DATA(cmsg))[i]);
+
+  return result;
+}
+
+cvec_fd recv_fds(int sock) {
+  FD_BUFFER(MAX_N_FDS) buffer;
+
+  return recv_fds_with_buffer(sock, &buffer);
+}

--- a/extensions/omni_httpd/fd.h
+++ b/extensions/omni_httpd/fd.h
@@ -1,0 +1,24 @@
+/*! \file */
+
+#ifndef OMNI_HTTPD_FD_H
+#define OMNI_HTTPD_FD_H
+
+#include <libgluepg_stc.h>
+
+#define i_key int
+#define i_tag fd
+#include <stc/cvec.h>
+
+#ifndef SCM_MAX_FD
+#define SCM_MAX_FD 253
+#endif
+
+/**
+ * Maximum number of fds that can be sent or received
+ */
+#define MAX_N_FDS SCM_MAX_FD
+
+int send_fds(int sock, cvec_fd *fds);
+cvec_fd recv_fds(int sock);
+
+#endif // OMNI_HTTPD_FD_H

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -1,0 +1,667 @@
+/**
+ * @file http_worker.c
+ * @brief HTTP worker
+ *
+ * This file contains code that runs in omni_http http workers that serve requests. These
+ * workers are started by the master worker.
+ */
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+
+#include <h2o.h>
+#include <h2o/http1.h>
+#include <h2o/http2.h>
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
+#include <access/xact.h>
+#include <executor/spi.h>
+#include <funcapi.h>
+#include <miscadmin.h>
+#include <postmaster/bgworker.h>
+#include <storage/latch.h>
+#include <tcop/utility.h>
+#include <utils/builtins.h>
+#include <utils/inet.h>
+#include <utils/snapmgr.h>
+#include <utils/timestamp.h>
+#if PG_MAJORVERSION_NUM >= 13
+#include <postmaster/interrupt.h>
+#endif
+
+#include <metalang99.h>
+
+#include <libpgaug.h>
+
+#include "fd.h"
+#include "omni_httpd.h"
+
+#if H2O_USE_LIBUV == 1
+#error "only evloop is supported, ensure H2O_USE_LIBUV is not set to 1"
+#endif
+
+/**
+ * @brief Number of fields in http_request type
+ *
+ */
+#define REQUEST_PLAN_PARAMS 5
+/**
+ * @brief Parameter index in a prepared query
+ *
+ */
+#define REQUEST_PLAN_PARAM(x) ML99_STRINGIFY(ML99_INC(x))
+
+/**
+ * @brief Path parameter index
+ *
+ */
+#define REQUEST_PLAN_PATH 0
+/**
+ * @brief Method parameter index
+ *
+ */
+#define REQUEST_PLAN_METHOD 1
+/**
+ * @brief Query string parameter index
+ *
+ */
+#define REQUEST_PLAN_QUERY_STRING 2
+/**
+ * @brief Body parameter index
+ *
+ */
+#define REQUEST_PLAN_BODY 3
+/**
+ * @brief Headers parameter index
+ *
+ */
+#define REQUEST_PLAN_HEADERS 4
+
+/**
+ * @brief Each listener has a context
+ *
+ */
+typedef struct {
+  /**
+   * @brief Query plan
+   *
+   */
+  SPIPlanPtr plan;
+  /**
+   * @brief Associated socket
+   *
+   */
+  h2o_socket_t *socket;
+  /**
+   * @brief Underlying file descriptor
+   *
+   */
+  int fd;
+  /**
+   * @brief Accept context
+   *
+   */
+  h2o_accept_ctx_t accept_ctx;
+  /**
+   * @brief H2O context
+   *
+   * Inclusion of this context into `listener_ctx` allows us to retrieve `listener_ctx`:
+   *
+   * ```
+   * listener_ctx *lctx = H2O_STRUCT_FROM_MEMBER(listener_ctx, context, req->conn->ctx);
+   * ```
+   *
+   */
+  h2o_context_t context;
+} listener_ctx;
+
+static inline int listener_ctx_cmp(const listener_ctx *l, const listener_ctx *r) {
+  return (l->plan == r->plan && l->socket == r->socket && l->fd == r->fd) ? 0 : -1;
+}
+
+#define i_tag listener_contexts
+#define i_val listener_ctx
+#define i_eq c_memcmp_eq
+#define i_cmp listener_ctx_cmp
+#include <stc/clist.h>
+
+static h2o_globalconf_t config;
+static h2o_evloop_t *worker_event_loop;
+
+/**
+ * @brief Accept socket
+ *
+ * @param listener
+ * @param err
+ */
+static void on_accept(h2o_socket_t *listener, const char *err) {
+  h2o_socket_t *sock;
+
+  if (err != NULL) {
+    return;
+  }
+
+  if ((sock = h2o_evloop_socket_accept(listener)) == NULL) {
+    return;
+  }
+  h2o_accept(&((listener_ctx *)listener->data)->accept_ctx, sock);
+}
+
+/**
+ * @brief Create a listening socket
+ *
+ * @param family
+ * @param port
+ * @param address
+ * @return int
+ */
+int create_listening_socket(sa_family_t family, in_port_t port, char *address) {
+  struct sockaddr_in addr;
+  struct sockaddr_in6 addr6;
+  void *sockaddr;
+  size_t socksize;
+  int fd, reuseaddr_flag = 1;
+
+  if (family == AF_INET) {
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    inet_pton(AF_INET, address, &addr.sin_addr);
+    addr.sin_port = htons(port);
+    sockaddr = &addr;
+    socksize = sizeof(addr);
+  } else if (family == AF_INET6) {
+    memset(&addr6, 0, sizeof(addr6));
+    addr6.sin6_family = AF_INET;
+    inet_pton(AF_INET6, address, &addr6.sin6_addr);
+    addr6.sin6_port = htons(port);
+    sockaddr = &addr6;
+    socksize = sizeof(addr6);
+  } else {
+    return -1;
+  }
+
+  if ((fd = socket(AF_INET, SOCK_STREAM, 0)) == -1 ||
+      setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr_flag, sizeof(reuseaddr_flag)) != 0 ||
+      bind(fd, (struct sockaddr *)sockaddr, socksize) != 0 || listen(fd, SOMAXCONN) != 0) {
+    return -1;
+  }
+
+  return fd;
+}
+
+/**
+ * @brief Create a H2O listener socket
+ *
+ * @param fd
+ * @param listener_ctx
+ * @return int
+ */
+static int create_listener(int fd, listener_ctx *listener_ctx) {
+  h2o_socket_t *sock;
+
+  if (fd == -1) {
+    return -1;
+  }
+
+  sock = h2o_evloop_socket_create(worker_event_loop, fd, H2O_SOCKET_FLAG_DONT_READ);
+  sock->data = listener_ctx;
+  listener_ctx->socket = sock;
+  h2o_socket_read_start(sock, on_accept);
+
+  return 0;
+}
+
+/**
+ * @brief Request handler
+ *
+ * @param self
+ * @param req
+ * @return int
+ */
+static int handler(h2o_handler_t *self, h2o_req_t *req) {
+  SetCurrentStatementStartTimestamp();
+  StartTransactionCommand();
+  PushActiveSnapshot(GetTransactionSnapshot());
+  SPI_connect();
+
+  listener_ctx *lctx = H2O_STRUCT_FROM_MEMBER(listener_ctx, context, req->conn->ctx);
+  SPIPlanPtr plan = lctx->plan;
+
+  int ret;
+
+  MemoryContext memory_context = CurrentMemoryContext;
+  PG_TRY();
+  {
+    char nulls[REQUEST_PLAN_PARAMS] = {[REQUEST_PLAN_METHOD] = ' ',
+                                       [REQUEST_PLAN_PATH] = ' ',
+                                       [REQUEST_PLAN_QUERY_STRING] =
+                                           req->query_at == SIZE_MAX ? 'n' : ' ',
+                                       [REQUEST_PLAN_BODY] = ' ',
+                                       [REQUEST_PLAN_HEADERS] = ' '};
+    ret = SPI_execute_plan(
+        plan,
+        (Datum[REQUEST_PLAN_PARAMS]){
+            [REQUEST_PLAN_METHOD] =
+                PointerGetDatum(cstring_to_text_with_len(req->method.base, req->method.len)),
+            [REQUEST_PLAN_PATH] = PointerGetDatum(
+                cstring_to_text_with_len(req->path_normalized.base, req->path_normalized.len)),
+            [REQUEST_PLAN_QUERY_STRING] =
+                req->query_at == SIZE_MAX
+                    ? PointerGetDatum(NULL)
+                    : PointerGetDatum(cstring_to_text_with_len(req->path.base + req->query_at + 1,
+                                                               req->path.len - req->query_at - 1)),
+            [REQUEST_PLAN_BODY] = ({
+              while (req->proceed_req != NULL) {
+                req->proceed_req(req, NULL);
+              }
+              bytea *result = (bytea *)palloc(req->entity.len + VARHDRSZ);
+              SET_VARSIZE(result, req->entity.len + VARHDRSZ);
+              memcpy(VARDATA(result), req->entity.base, req->entity.len);
+              PointerGetDatum(result);
+            }),
+            [REQUEST_PLAN_HEADERS] = ({
+              TupleDesc header_tupledesc = TypeGetTupleDesc(http_header_oid(), NULL);
+              BlessTupleDesc(header_tupledesc);
+
+              Datum *elems = (Datum *)palloc(sizeof(Datum) * req->headers.size);
+              bool *nulls = (bool *)palloc(sizeof(bool) * req->headers.size);
+              for (int i = 0; i < req->headers.size; i++) {
+                h2o_header_t header = req->headers.entries[i];
+                nulls[i] = 0;
+                HeapTuple header_tuple =
+                    heap_form_tuple(header_tupledesc,
+                                    (Datum[3]){
+                                        PointerGetDatum(cstring_to_text_with_len(header.name->base,
+                                                                                 header.name->len)),
+                                        PointerGetDatum(cstring_to_text_with_len(header.value.base,
+                                                                                 header.value.len)),
+                                        BoolGetDatum(true),
+                                    },
+                                    (bool[3]){false, false, false});
+                elems[i] = HeapTupleGetDatum(header_tuple);
+              }
+              ArrayType *result =
+                  construct_md_array(elems, nulls, 1, (int[1]){req->headers.size}, (int[1]){1},
+                                     http_header_oid(), -1, false, TYPALIGN_DOUBLE);
+              PointerGetDatum(result);
+            })},
+        nulls, false, 1);
+  }
+  PG_CATCH();
+  {
+    MemoryContextSwitchTo(memory_context);
+    WITH_TEMP_MEMCXT {
+      ErrorData *error = CopyErrorData();
+      ereport(WARNING, errmsg("Error executing query"),
+              errdetail("%s: %s", error->message, error->detail));
+    }
+
+    FlushErrorState();
+
+    // Abort the transaction
+    AbortCurrentTransaction();
+    req->res.status = 500;
+    h2o_send_inline(req, H2O_STRLIT("Internal server error"));
+    goto cleanup;
+  }
+  PG_END_TRY();
+  int proc = SPI_processed;
+  if (ret == SPI_OK_SELECT && proc > 0) {
+    TupleDesc tupdesc = SPI_tuptable->tupdesc;
+    SPITupleTable *tuptable = SPI_tuptable;
+    HeapTuple tuple = tuptable->vals[0];
+
+    int c = 1;
+    for (int i = 0; i < tupdesc->natts; i++) {
+      if (http_response_oid() == tupdesc->attrs[i].atttypid) {
+        c = i + 1;
+        break; // TODO: continue but issue a warning if another response is found?
+      }
+    }
+
+    bool isnull = false;
+    Datum response = SPI_getbinval(tuple, tupdesc, c, &isnull);
+    if (!isnull) {
+      HeapTupleHeader response_tuple = DatumGetHeapTupleHeader(response);
+
+      // Status
+      req->res.status = DatumGetUInt16(GetAttributeByNum(response_tuple, 1, &isnull));
+      if (isnull) {
+        req->res.status = 200;
+      }
+
+      // Headers
+      Datum array_datum = GetAttributeByNum(response_tuple, 2, &isnull);
+      if (!isnull) {
+        ArrayType *headers = DatumGetArrayTypeP(array_datum);
+        ArrayIterator iter = array_create_iterator(headers, 0, NULL);
+        Datum header;
+        while (array_iterate(iter, &header, &isnull)) {
+          if (!isnull) {
+            HeapTupleHeader header_tuple = DatumGetHeapTupleHeader(header);
+            Datum name = GetAttributeByNum(header_tuple, 1, &isnull);
+            if (!isnull) {
+              text *name_text = DatumGetTextPP(name);
+              Datum value = GetAttributeByNum(header_tuple, 2, &isnull);
+              if (!isnull) {
+                text *value_text = DatumGetTextPP(value);
+                Datum append = GetAttributeByNum(header_tuple, 3, &isnull);
+                if (isnull || !DatumGetBool(append)) {
+                  h2o_set_header_by_str(&req->pool, &req->res.headers, VARDATA_ANY(name_text),
+                                        VARSIZE_ANY_EXHDR(name_text), 0, VARDATA_ANY(value_text),
+                                        VARSIZE_ANY_EXHDR(value_text), true);
+                } else {
+                  h2o_add_header_by_str(&req->pool, &req->res.headers, VARDATA_ANY(name_text),
+                                        VARSIZE_ANY_EXHDR(name_text), 0, NULL,
+                                        VARDATA_ANY(value_text), VARSIZE_ANY_EXHDR(value_text));
+                }
+              }
+            }
+          }
+        }
+        array_free_iterator(iter);
+      }
+
+      // Body
+      Datum body = GetAttributeByNum(response_tuple, 3, &isnull);
+
+      if (!isnull) {
+        bytea *body_content = DatumGetByteaPP(body);
+        h2o_send_inline(req, VARDATA_ANY(body_content), VARSIZE_ANY_EXHDR(body_content));
+      } else {
+        h2o_send_inline(req, "", 0);
+      }
+
+    } else {
+      h2o_send_inline(req, "", 0);
+    }
+  } else {
+    if (ret == SPI_OK_SELECT) {
+      // No result
+      req->res.status = 204;
+      h2o_send_inline(req, H2O_STRLIT(""));
+    } else {
+      req->res.status = 500;
+      ereport(WARNING, errmsg("Error executing query: %s", SPI_result_code_string(ret)));
+      h2o_send_inline(req, H2O_STRLIT("Internal server error"));
+    }
+  }
+cleanup:
+  SPI_finish();
+  PopActiveSnapshot();
+  CommitTransactionCommand();
+  return 0;
+}
+
+static h2o_pathconf_t *register_handler(h2o_hostconf_t *hostconf, const char *path,
+                                        int (*on_req)(h2o_handler_t *, h2o_req_t *)) {
+  h2o_pathconf_t *pathconf = h2o_config_register_path(hostconf, path, 0);
+  h2o_handler_t *request_handler = h2o_create_handler(pathconf, sizeof(h2o_handler_t));
+  request_handler->on_req = on_req;
+  return pathconf;
+}
+
+static void setup_server() {
+  h2o_hostconf_t *hostconf;
+
+  h2o_config_init(&config);
+  config.server_name = h2o_iovec_init(H2O_STRLIT("omni_httpd-" EXT_VERSION));
+  hostconf = h2o_config_register_host(&config, h2o_iovec_init(H2O_STRLIT("default")), 65535);
+
+  worker_event_loop = h2o_evloop_create();
+
+  h2o_pathconf_t *pathconf = register_handler(hostconf, "/", handler);
+}
+
+#define i_val int
+#define i_tag fd
+#include <stc/cset.h>
+
+static cvec_fd accept_fds(char *socket_name) {
+  struct sockaddr_un address;
+  int socket_fd;
+
+  socket_fd = socket(PF_UNIX, SOCK_STREAM, 0);
+  if (socket_fd < 0) {
+    ereport(ERROR, errmsg("can't create sharing socket"));
+  }
+
+  memset(&address, 0, sizeof(struct sockaddr_un));
+
+  address.sun_family = AF_UNIX;
+  snprintf(address.sun_path, sizeof(address.sun_path), "%s", socket_name);
+
+try_connect:
+  if (connect(socket_fd, (struct sockaddr *)&address, sizeof(struct sockaddr_un)) != 0) {
+    int e = errno;
+    if (e == ECONNREFUSED) {
+      goto try_connect;
+    }
+    ereport(ERROR, errmsg("error connecting to sharing socket: %s", strerror(e)));
+  }
+
+  cvec_fd result = recv_fds(socket_fd);
+  int l = cvec_fd_size(&result);
+  close(socket_fd);
+
+  return result;
+}
+
+static bool worker_running = true;
+static bool worker_reload = false;
+static void reload_worker() { worker_reload = true; }
+static void stop_worker() { worker_running = false; }
+
+static clist_listener_contexts listener_contexts;
+
+void http_worker(Datum db_oid) {
+#if PG_MAJORVERSION_NUM >= 13
+  pqsignal(SIGHUP, SignalHandlerForConfigReload);
+#else
+#warning "TODO: SignalHandlerForConfigReload for Postgres 12"
+#endif
+  pqsignal(SIGTERM, die);
+
+  BackgroundWorkerUnblockSignals();
+  BackgroundWorkerInitializeConnectionByOid(db_oid, InvalidOid, 0);
+
+  setup_server();
+  pqsignal(SIGTERM, stop_worker);
+  pqsignal(SIGUSR2, reload_worker);
+
+  listener_contexts = clist_listener_contexts_init();
+
+  while (worker_running) {
+    worker_reload = false;
+    cvec_fd fds = accept_fds(MyBgworkerEntry->bgw_extra);
+
+    // Disposing allocated listener/query pairs and their associated data
+    // (such as sockets)
+    {
+      clist_listener_contexts_iter iter = clist_listener_contexts_begin(&listener_contexts);
+      while (iter.ref != NULL) {
+        if (cvec_fd_get(&fds, iter.ref->fd) != NULL) {
+          // We still have this fd, don't dispose it
+          clist_listener_contexts_next(&iter);
+          continue;
+        }
+        if (iter.ref->plan != NULL) {
+          SPI_freeplan(iter.ref->plan);
+        }
+        if (iter.ref->socket != NULL) {
+          h2o_socket_t *socket = iter.ref->socket;
+          h2o_socket_read_stop(socket);
+          h2o_socket_export_t info;
+          h2o_socket_export(socket, &info);
+          h2o_evloop_run(worker_event_loop, 0);
+          close(info.fd);
+        }
+        h2o_context_dispose(&iter.ref->context);
+        iter = clist_listener_contexts_erase_at(&listener_contexts, iter);
+      }
+    }
+
+    c_FOREACH(i, cvec_fd, fds) {
+      int fd = *i.ref;
+
+      listener_ctx c = {.fd = fd,
+                        .socket = NULL,
+                        .plan = NULL,
+                        .accept_ctx = (h2o_accept_ctx_t){.hosts = config.hosts}};
+
+      listener_ctx *lctx = clist_listener_contexts_push(&listener_contexts, c);
+
+    try_create_listener:
+        if (create_listener(fd, lctx) == 0) {
+          h2o_context_init(&(lctx->context), worker_event_loop, &config);
+          lctx->accept_ctx.ctx = &lctx->context;
+        } else {
+          if (errno == EINTR) {
+            goto try_create_listener; // retry
+          }
+          int e = errno;
+          ereport(WARNING, errmsg("socket error: %s", strerror(e)));
+        }
+    }
+
+    cvec_fd_drop(&fds);
+
+    SetCurrentStatementStartTimestamp();
+    StartTransactionCommand();
+    PushActiveSnapshot(GetTransactionSnapshot());
+
+    SPI_connect();
+
+    int ret = SPI_execute("SELECT addr, port, query FROM omni_httpd.listeners", false, 0);
+    if (ret == SPI_OK_SELECT) {
+      TupleDesc tupdesc = SPI_tuptable->tupdesc;
+      SPITupleTable *tuptable = SPI_tuptable;
+      for (int i = 0; i < SPI_processed; i++) {
+        HeapTuple tuple = tuptable->vals[i];
+        bool addr_is_null = false;
+        Datum addr = SPI_getbinval(tuple, tupdesc, 1, &addr_is_null);
+        bool port_is_null = false;
+        Datum port = SPI_getbinval(tuple, tupdesc, 2, &port_is_null);
+        bool query_is_null = false;
+        Datum query = SPI_getbinval(tuple, tupdesc, 3, &query_is_null);
+
+        c_FOREACH(iter, clist_listener_contexts, listener_contexts) {
+            int fd = iter.ref->fd;
+            struct sockaddr_in sin;
+            socklen_t len = sizeof(sin);
+            struct sockaddr_in6 sin6;
+            socklen_t len6 = sizeof(sin6);
+
+            socklen_t socklen;
+            void *sockaddr;
+
+            const char *fdaddr;
+            int port_no;
+
+            char _address[MAX_ADDRESS_SIZE];
+            char _address1[MAX_ADDRESS_SIZE];
+
+            int family = 0;
+            if (getsockname(fd, (struct sockaddr *)&sin, &len) == 0) {
+            family = sin.sin_family;
+          }
+
+          if (family == AF_INET) {
+            sockaddr = &sin;
+            socklen = len;
+          } else if (family == AF_INET6) {
+            sockaddr = &sin6;
+            socklen = len6;
+          } else {
+            continue;
+          }
+
+          if (getsockname(fd, (struct sockaddr *)sockaddr, &len) == 0) {
+            if (family == AF_INET) {
+              port_no = ntohs(sin.sin_port);
+              fdaddr = inet_ntop(AF_INET, &sin.sin_addr, _address, sizeof(_address));
+            } else if (family == AF_INET6) {
+              port_no = ntohs(sin6.sin6_port);
+              fdaddr = inet_ntop(AF_INET6, &sin6.sin6_addr, _address, sizeof(_address));
+            } else {
+              continue;
+            }
+          } else {
+            continue;
+          }
+
+          inet *inet_address = DatumGetInetPP(addr);
+          char *address = pg_inet_net_ntop(ip_family(inet_address), ip_addr(inet_address),
+                                           ip_bits(inet_address), _address1, sizeof(_address1));
+
+          if (strncmp(address, fdaddr, strlen(address)) == 0) {
+            // Found matching socket
+            char *query_string = text_to_cstring(DatumGetTextPP(query));
+            MemoryContext memory_context = CurrentMemoryContext;
+            PG_TRY();
+            {
+              SPIPlanPtr plan = SPI_prepare(
+                  psprintf(
+                      // clang-format off
+                      "WITH request AS (SELECT $" REQUEST_PLAN_PARAM(REQUEST_PLAN_PATH) " AS path, "
+                       "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_METHOD) "::text::omni_httpd.http_method AS method, "
+                       "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_QUERY_STRING) " AS query_string, "
+                       "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_BODY) " AS body, "
+                       "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_HEADERS) " AS headers "
+                       ") SELECT * FROM "
+                       "(%s) query",
+                      // clang-format on
+                      query_string),
+                  REQUEST_PLAN_PARAMS,
+                  (Oid[REQUEST_PLAN_PARAMS]){
+                      [REQUEST_PLAN_METHOD] = TEXTOID,
+                      [REQUEST_PLAN_PATH] = TEXTOID,
+                      [REQUEST_PLAN_QUERY_STRING] = TEXTOID,
+                      [REQUEST_PLAN_BODY] = BYTEAOID,
+                      [REQUEST_PLAN_HEADERS] = http_header_array_oid(),
+                  });
+              pfree(query_string);
+
+              // We have to keep the plan as we're going to disconnect from SPI
+              SPI_keepplan(plan);
+              iter.ref->plan = plan;
+            }
+            PG_CATCH();
+            {
+              MemoryContextSwitchTo(memory_context);
+              WITH_TEMP_MEMCXT {
+                ErrorData *error = CopyErrorData();
+                ereport(WARNING, errmsg("Error preparing query"),
+                        errdetail("%s: %s", error->message, error->detail));
+              }
+
+              FlushErrorState();
+            }
+            PG_END_TRY();
+          }
+        }
+      }
+    } else {
+      ereport(WARNING, errmsg("Error fetching configuration: %s", SPI_result_code_string(ret)));
+    }
+
+    SPI_finish();
+    AbortCurrentTransaction();
+
+    while (worker_running && !worker_reload && h2o_evloop_run(worker_event_loop, INT32_MAX) == 0)
+      ;
+  }
+
+  clist_listener_contexts_drop(&listener_contexts);
+}

--- a/extensions/omni_httpd/master_worker.c
+++ b/extensions/omni_httpd/master_worker.c
@@ -1,0 +1,366 @@
+/**
+ * @file master_worker.c
+ * @brief Master worker manages listening sockets and http workers
+ *
+ */
+#include <dirent.h>
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
+#include <access/xact.h>
+#include <common/int.h>
+#include <executor/spi.h>
+#include <funcapi.h>
+#include <miscadmin.h>
+#include <port.h>
+#include <postmaster/bgworker.h>
+#include <postmaster/interrupt.h>
+#include <storage/latch.h>
+#include <tcop/utility.h>
+#include <utils/builtins.h>
+#include <utils/inet.h>
+#include <utils/json.h>
+#include <utils/jsonb.h>
+#include <utils/memutils.h>
+#include <utils/snapmgr.h>
+#if PG_MAJORVERSION_NUM >= 14
+#include <utils/wait_event.h>
+#else
+#include <pgstat.h>
+#endif
+
+#include <h2o.h>
+
+#include <dynpgext.h>
+#include <libpgaug.h>
+
+#include <libgluepg_stc.h>
+
+#include "fd.h"
+#include "omni_httpd.h"
+
+/**
+ * @brief UNIX socket that is used to share rights to the listening sockets
+ *
+ */
+static int socket_fd;
+
+/**
+ * @brief Path to the UNIX socket
+ *
+ * @see socket_fd
+ */
+static char *socket_path;
+
+/**
+ * @brief UNIX socket's address
+ *
+ * @see socket_fd
+ */
+static struct sockaddr_un address;
+
+/**
+ * @brief UNIX socket's address length
+ *
+ * @see socket_fd
+ */
+static socklen_t address_length;
+
+/**
+ * @brief Master worker's event loop
+ *
+ */
+static h2o_evloop_t *event_loop;
+
+/**
+ * @brief List of currently active sockets
+ *
+ * Maintained and used by the master worker
+ *
+ */
+static cvec_fd sockets;
+
+/**
+ * @brief UNIX socket connection accept handler
+ *
+ * @param listener
+ * @param err
+ * @see socket_fd
+ */
+static void on_accept(h2o_socket_t *listener, const char *err) {
+  h2o_socket_t *sock;
+
+  if (err != NULL) {
+    return;
+  }
+
+  if ((sock = h2o_evloop_socket_accept(listener)) == NULL) {
+    return;
+  }
+  int fd = h2o_socket_get_fd(sock);
+  if (send_fds(fd, &sockets) != 0) {
+    int e = errno;
+    ereport(ERROR, errmsg("error sending listening socket descriptor: %s", strerror(e)));
+  }
+  h2o_socket_close(sock);
+}
+
+/**
+ * @brief Prepares `socket_fd` for accepting on and attaches it to `event_loop`
+ *
+ */
+void prepare_share_fd() {
+  address_length = sizeof(address);
+
+  socket_fd = socket(PF_UNIX, SOCK_STREAM, 0);
+  if (socket_fd < 0) {
+    ereport(ERROR, errmsg("can't create sharing socket"));
+  }
+
+  int enable = 1;
+  setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+
+  memset(&address, 0, sizeof(struct sockaddr_un));
+  address.sun_family = AF_UNIX;
+  snprintf(address.sun_path, sizeof(address.sun_path), "%s", socket_path);
+
+  if (bind(socket_fd, (struct sockaddr *)&address, sizeof(struct sockaddr_un)) != 0) {
+    int e = errno;
+    ereport(ERROR, errmsg("bind() failed: %s", strerror(e)));
+  }
+
+  if (listen(socket_fd, SOMAXCONN) != 0) {
+    int e = errno;
+    ereport(ERROR, errmsg("listen() failed: %s", strerror(e)));
+  }
+
+  h2o_socket_t *sock;
+
+  sock = h2o_evloop_socket_create(event_loop, socket_fd, H2O_SOCKET_FLAG_DONT_READ);
+  h2o_socket_read_start(sock, on_accept);
+}
+
+static Latch *latch;
+
+static bool shutdown_worker = false;
+void worker_shutdown() {
+  shutdown_worker = true;
+  close(socket_fd);
+  SetLatch(latch);
+}
+
+/**
+ * @brief Flag indicating the need for the master worker to be reload
+ *
+ * It is important that it starts as `true` as we use it for the initial
+ * configuration.
+ */
+static bool worker_reload = true;
+
+/**
+ * @brief Called by SIGUSR2 handler
+ *
+ */
+void reload() {
+
+  // This is to ensure that if the reload is requested during the initial wait, we're setting
+  // the latch we're on
+  SetLatch(latch);
+
+  worker_reload = true;
+}
+
+#define i_key int
+#define i_val int
+#define i_tag portsock
+#include <stc/cmap.h>
+
+#define i_val BackgroundWorkerHandle *
+#define i_tag bgwhandle
+#include <stc/cvec.h>
+
+#define i_val int
+#define i_tag port
+#include <stc/cset.h>
+/**
+ * @brief Master httpd worker
+ *
+ * @param db_oid Database OID
+ */
+void master_worker(Datum db_oid) {
+  char socket_path_template[] = "omni_httpdXXXXXX";
+  char *tmpname = mkdtemp(socket_path_template);
+  socket_path = psprintf("%s/socket.%d", tmpname, getpid());
+
+#if PG_MAJORVERSION_NUM >= 13
+  pqsignal(SIGHUP, SignalHandlerForConfigReload);
+#else
+#warning "TODO: SignalHandlerForConfigReload for Postgres 12"
+#endif
+  pqsignal(SIGTERM, worker_shutdown);
+  // NB: It is important to set up the reload handler before owning the latch
+  // as reload_configuration trigger would use it if the latch shows as owned.
+  pqsignal(SIGUSR2, reload);
+
+  BackgroundWorkerUnblockSignals();
+  BackgroundWorkerInitializeConnectionByOid(db_oid, InvalidOid, 0);
+
+  latch = (Latch *)dynpgext_lookup_shmem(LATCH);
+  OwnLatch(latch);
+
+  // Start the transaction
+  SetCurrentStatementStartTimestamp();
+  StartTransactionCommand();
+  PushActiveSnapshot(GetTransactionSnapshot());
+
+  // Prepare the event loop
+  event_loop = h2o_evloop_create();
+  prepare_share_fd();
+
+  sockets = cvec_fd_init();
+  cmap_portsock portsocks = cmap_portsock_init();
+  cvec_bgwhandle http_workers = cvec_bgwhandle_init();
+
+  bool http_workers_started = false;
+  bool port_ready = false;
+  SPI_connect();
+
+  while (!shutdown_worker) {
+    // We clear this list every time to prepare an up-to-date version
+    cvec_fd_clear(&sockets);
+
+    // If HTTP workes have already been started, notify them of the upcoming change.
+    // It is okay to notify them at this time as they will try to connect to the UNIX socket
+    // which will be served as soon as we're done getting the new configuration and restart
+    // the event loop.
+    if (http_workers_started) {
+      c_FOREACH(i, cvec_bgwhandle, http_workers) {
+        pid_t pid;
+        if (GetBackgroundWorkerPid(*i.ref, &pid) == BGWH_STARTED) {
+          kill(pid, SIGUSR2);
+        }
+      }
+    }
+
+    // Get listeners
+    while (worker_reload) {
+      worker_reload = false;
+      if (SPI_execute("SELECT addr, port FROM omni_httpd.listeners", false, 0) == SPI_OK_SELECT) {
+        TupleDesc tupdesc = SPI_tuptable->tupdesc;
+        SPITupleTable *tuptable = SPI_tuptable;
+        cset_port ports = cset_port_init();
+        // If there are no listeners, don't serve sockets (anymore), wait until
+        // some will appear.
+        if (SPI_processed == 0) {
+          port_ready = false;
+        }
+        for (int i = 0; i < SPI_processed; i++) {
+          if (cvec_fd_size(&sockets) == MAX_N_FDS) {
+            ereport(WARNING,
+                    errmsg("Reached maximum number of fds limit (%d). This restriction "
+                           "will be removed in the future. No more sockets will be created.",
+                           MAX_N_FDS));
+            break;
+          }
+          HeapTuple tuple = tuptable->vals[i];
+          bool addr_is_null = false;
+          Datum addr = SPI_getbinval(tuple, tupdesc, 1, &addr_is_null);
+          bool port_is_null = false;
+          Datum port = SPI_getbinval(tuple, tupdesc, 2, &port_is_null);
+          if (!port_is_null) {
+            int port_no = DatumGetInt32(port);
+            inet *inet_address = DatumGetInetPP(addr);
+            char _address[MAX_ADDRESS_SIZE];
+            char *address_str = pg_inet_net_ntop(ip_family(inet_address), ip_addr(inet_address),
+                                                 ip_bits(inet_address), _address, sizeof(_address));
+
+            const cmap_portsock_value *portsock = cmap_portsock_get(&portsocks, port_no);
+            if (portsock == NULL) {
+              // At least some ports are ready to be listened on
+              port_ready = true;
+              // Create a listening socket
+              int sock = create_listening_socket(
+                  ip_family(inet_address) == PGSQL_AF_INET ? AF_INET : AF_INET6, port_no,
+                  address_str);
+              cmap_portsock_insert(&portsocks, port_no, sock);
+              cset_port_push(&ports, port_no);
+              cvec_fd_push_back(&sockets, sock);
+              ereport(LOG, errmsg("omni_httpd: Established listener on %d", port_no));
+            } else {
+              // This socket already exists
+              cset_port_push(&ports, port_no);
+              cvec_fd_push_back(&sockets, portsock->second);
+            }
+          }
+        }
+
+        // Scan for sockets that no longer match any listeners and remove them
+        cmap_portsock_iter iter = cmap_portsock_begin(&portsocks);
+        while (iter.ref) {
+          int port = iter.ref->first;
+          int fd = iter.ref->second;
+          if (!cset_port_contains(&ports, port)) {
+            close(fd);
+            ereport(LOG, errmsg("omni_httpd: Removed listener on %d", port));
+            iter = cmap_portsock_erase_at(&portsocks, iter);
+          } else {
+            cmap_portsock_next(&iter);
+          }
+        }
+        cset_port_drop(&ports);
+      }
+      if (port_ready) {
+        break;
+      }
+      (void)WaitLatch(latch, WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH, 1000L,
+                      PG_WAIT_EXTENSION);
+      ResetLatch(latch);
+      if (shutdown_worker) {
+        SPI_finish();
+        DisownLatch(latch);
+        return;
+      }
+      }
+      HandleMainLoopInterrupts();
+
+      // Start HTTP workers if they aren't already
+      if (!http_workers_started) {
+      BackgroundWorker worker = {.bgw_name = "omni_httpd worker",
+                                 .bgw_type = "omni_httpd worker",
+                                 .bgw_function_name = "http_worker",
+                                 .bgw_notify_pid = getpid(),
+                                 .bgw_main_arg = db_oid,
+                                 .bgw_flags =
+                                     BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION,
+                                 .bgw_start_time = BgWorkerStart_RecoveryFinished};
+      strncpy(worker.bgw_extra, socket_path, BGW_EXTRALEN - 1);
+      strncpy(worker.bgw_library_name, MyBgworkerEntry->bgw_library_name, BGW_MAXLEN - 1);
+      for (int i = 0; i < num_http_workers; i++) {
+        BackgroundWorkerHandle *handle;
+        RegisterDynamicBackgroundWorker(&worker, &handle);
+        pid_t worker_pid;
+        if (WaitForBackgroundWorkerStartup(handle, &worker_pid) == BGWH_POSTMASTER_DIED) {
+          return;
+        }
+        cvec_bgwhandle_push(&http_workers, handle);
+      }
+        http_workers_started = true;
+    }
+
+    // Share the socket over a unix socket until terminated
+    while (!shutdown_worker && !worker_reload && h2o_evloop_run(event_loop, INT32_MAX) == 0)
+        ;
+  }
+  SPI_finish();
+  AbortCurrentTransaction();
+  DisownLatch(latch);
+}

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -1,0 +1,55 @@
+CREATE TYPE http_method AS ENUM ('GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH');
+
+CREATE TYPE http_header AS (
+    name text,
+    value text,
+    append bool
+);
+
+CREATE TYPE http_request AS (
+    method http_method,
+    path text,
+    query_string text,
+    body bytea,
+    headers http_header[]
+);
+
+CREATE FUNCTION http_header(name text, value text, append bool DEFAULT false) RETURNS http_header AS $$
+SELECT ROW(name, value, append) AS result;
+$$
+LANGUAGE SQL;
+
+CREATE TYPE http_response AS (
+    status smallint,
+    headers http_header[],
+    body bytea
+);
+
+CREATE FUNCTION http_response(
+    status int DEFAULT 200,
+    headers http_header[] DEFAULT array[]::http_header[],
+    body anycompatible DEFAULT ''::bytea
+)
+    RETURNS http_response
+    AS 'MODULE_PATHNAME', 'http_response'
+    LANGUAGE C;
+
+CREATE DOMAIN port integer CHECK (VALUE > 0 AND VALUE <= 65535);
+
+CREATE TABLE listeners (
+    id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    port port NOT NULL DEFAULT 80,
+    addr inet NOT NULL DEFAULT '127.0.0.1',
+    query text
+);
+
+CREATE FUNCTION reload_configuration_trigger() RETURNS trigger
+    AS 'MODULE_PATHNAME', 'reload_configuration'
+    LANGUAGE C;
+
+CREATE FUNCTION reload_configuration() RETURNS bool
+    AS 'MODULE_PATHNAME', 'reload_configuration'
+    LANGUAGE C;
+
+CREATE TRIGGER listeners_updated AFTER UPDATE OR DELETE OR INSERT ON listeners
+EXECUTE FUNCTION reload_configuration_trigger();

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -1,0 +1,185 @@
+/**
+ * @file omni_httpd.c
+ * @brief Extension initialization and exported functions
+ *
+ */
+#include <dirent.h>
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
+#include <common/int.h>
+#include <executor/spi.h>
+#include <funcapi.h>
+#include <miscadmin.h>
+#include <port.h>
+#include <postmaster/bgworker.h>
+#if PG_MAJORVERSION_NUM >= 13
+#include <postmaster/interrupt.h>
+#endif
+#include <storage/latch.h>
+#include <tcop/utility.h>
+#include <utils/builtins.h>
+#include <utils/inet.h>
+#include <utils/json.h>
+#include <utils/jsonb.h>
+#include <utils/memutils.h>
+#include <utils/snapmgr.h>
+#if PG_MAJORVERSION_NUM >= 14
+#include <utils/wait_event.h>
+#else
+#include <pgstat.h>
+#endif
+
+#include <h2o.h>
+
+#include <dynpgext.h>
+#include <libpgaug.h>
+
+#include <libgluepg_stc.h>
+
+#include "fd.h"
+#include "omni_httpd.h"
+
+PG_MODULE_MAGIC;
+DYNPGEXT_MAGIC;
+
+#ifndef EXT_VERSION
+#error "Extension version (VERSION) is not defined!"
+#endif
+
+CACHED_OID(http_header);
+CACHED_OID(http_method);
+CACHED_OID(http_response);
+
+int num_http_workers;
+
+/**
+ * @brief Initializes allocated shared latch
+ *
+ * @param latch uninitialized latch
+ * @param data unused
+ */
+static void init_latch(Latch *latch, void *data) { InitSharedLatch(latch); }
+
+void _Dynpgext_init(const dynpgext_handle *handle) {
+  DefineCustomIntVariable("omni_httpd.http_workers", "Number of HTTP workers", NULL,
+                          &num_http_workers, 10, 1, INT_MAX, PGC_SIGHUP, 0, NULL, NULL, NULL);
+  // Allocates memory for the worker latch
+  handle->allocate_shmem(handle, LATCH, sizeof(Latch), (void (*)(void *ptr, void *data))init_latch,
+                         NULL, DYNPGEXT_SCOPE_DATABASE_LOCAL);
+
+  // Prepares and registers the main background worker
+  BackgroundWorker bgw = {.bgw_name = "omni_httpd",
+                          .bgw_type = "omni_httpd",
+                          .bgw_function_name = "master_worker",
+                          .bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION,
+                          .bgw_start_time = BgWorkerStart_RecoveryFinished};
+  strncpy(bgw.bgw_library_name, handle->library_name, BGW_MAXLEN);
+  handle->register_bgworker(handle, &bgw, NULL, NULL,
+                            DYNPGEXT_REGISTER_BGWORKER_NOTIFY | DYNPGEXT_SCOPE_DATABASE_LOCAL);
+}
+
+PG_FUNCTION_INFO_V1(reload_configuration);
+
+/**
+ * @brief Triggers to be called on configuration update
+ *
+ * @return Datum
+ */
+Datum reload_configuration(PG_FUNCTION_ARGS) {
+  Latch *worker_latch = (Latch *)dynpgext_lookup_shmem(LATCH);
+  if (worker_latch == NULL) {
+    ereport(NOTICE, errmsg("omni_httpd hasn't been properly loaded"));
+    PG_RETURN_BOOL(false);
+  }
+  pg_memory_barrier();
+  SetLatch(worker_latch);
+  if (worker_latch->owner_pid != 0) {
+    kill(worker_latch->owner_pid, SIGUSR2);
+  }
+  if (CALLED_AS_TRIGGER(fcinfo)) {
+    return PointerGetDatum(((TriggerData *)(fcinfo->context))->tg_newtuple);
+  } else {
+    PG_RETURN_BOOL(true);
+  }
+}
+
+/**
+ * @brief Adds or appends a header
+ *
+ * @param headers 1-dim array of http_header
+ * @param name header name
+ * @param value header value
+ * @param append append if true, otherwise set
+ * @return new 1-dim array of http_header with the new http_header prepended.
+ */
+static inline Datum add_header(Datum headers, char *name, char *value, bool append) {
+  TupleDesc header_tupledesc = TypeGetTupleDesc(http_header_oid(), NULL);
+  BlessTupleDesc(header_tupledesc);
+
+  HeapTuple header = heap_form_tuple(header_tupledesc,
+                                     (Datum[3]){
+                                         PointerGetDatum(cstring_to_text(name)),
+                                         PointerGetDatum(cstring_to_text(value)),
+                                         BoolGetDatum(append),
+                                     },
+                                     (bool[3]){false, false, false});
+
+  ExpandedArrayHeader *eah = DatumGetExpandedArray(headers);
+
+  int *lb = eah->lbound;
+
+  int indx;
+
+  if (pg_sub_s32_overflow(lb[0], 1, &indx))
+    ereport(ERROR, (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE), errmsg("integer out of range")));
+
+  return array_set_element(EOHPGetRWDatum(&eah->hdr), /* subscripts */ 1, &indx,
+                           HeapTupleGetDatum(header),
+                           /* isnull */ false, -1, -1, false, TYPALIGN_INT);
+}
+
+PG_FUNCTION_INFO_V1(http_response);
+
+Datum http_response(PG_FUNCTION_ARGS) {
+  TupleDesc response_tupledesc = TypeGetTupleDesc(http_response_oid(), NULL);
+  BlessTupleDesc(response_tupledesc);
+
+  Oid body_element_type = get_fn_expr_argtype(fcinfo->flinfo, 2);
+
+  Datum values[3] = {PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), PG_GETARG_DATUM(2)};
+
+  Jsonb *jb;
+  switch (body_element_type) {
+  case TEXTOID:
+  case VARCHAROID:
+  case CHAROID:
+    values[1] = add_header(values[1], "content-type", "text/plain; charset=utf-8", false);
+  case BYTEAOID:
+    values[1] = add_header(values[1], "content-type", "application/octet-stream", false);
+    break;
+  case JSONBOID:
+    jb = PG_GETARG_JSONB_P(2);
+    char *out = JsonbToCString(NULL, &jb->root, VARSIZE(jb));
+    values[2] = PointerGetDatum(cstring_to_text(out));
+  case JSONOID:
+    values[1] = add_header(values[1], "content-type", "text/json", false);
+    break;
+  default:
+    ereport(ERROR, errmsg("Can't (yet) cast %s to bytea",
+                          format_type_extended(body_element_type, -1, FORMAT_TYPE_ALLOW_INVALID)));
+  }
+
+  HeapTuple response = heap_form_tuple(response_tupledesc, values, (bool[3]){false, false, false});
+
+  PG_RETURN_DATUM(HeapTupleGetDatum(response));
+}

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -1,0 +1,35 @@
+/*! \file */
+#ifndef OMNI_HTTPD_H
+#define OMNI_HTTPD_H
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <libgluepg_stc.h>
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
+Oid http_method_oid();
+Oid http_response_oid();
+Oid http_header_oid();
+Oid http_header_array_oid();
+
+int create_listening_socket(sa_family_t family, in_port_t port, char *address);
+
+#define MAX_ADDRESS_SIZE sizeof("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:255.255.255.255/128")
+
+/**
+ * @brief This latch is used to notify the workers that the configuration has changed.
+ *
+ * Used to `SetLatch` if it is not owned yet, otherwise using owner's PID to set a SIGUSR2
+ * directly.
+ *
+ */
+static const char *LATCH = "omni_httpd:latch:" EXT_VERSION;
+
+extern int num_http_workers;
+
+#endif //  OMNI_HTTPD_H

--- a/extensions/omni_httpd/sql/http.sql
+++ b/extensions/omni_httpd/sql/http.sql
@@ -1,0 +1,41 @@
+CREATE TABLE users (
+    id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    handle text,
+    name text
+);
+
+INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
+
+INSERT INTO omni_httpd.listeners (port, query) VALUES (9000, $$
+SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!'), 1 AS priority
+       FROM request
+       INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
+UNION
+SELECT omni_httpd.http_response(body => request.headers::text), 1 AS priority FROM request WHERE request.path = '/headers'
+UNION
+SELECT omni_httpd.http_response(body => request.body), 1 AS priority FROM request WHERE request.path = '/echo'
+UNION
+SELECT omni_httpd.http_response(status => 404, body => json_build_object('method', request.method, 'path', request.path, 'query_string', request.query_string)), 0 AS priority
+       FROM request
+ORDER BY priority DESC
+$$);
+
+-- Now, the actual tests
+
+-- FIXME: for the time being, since there's no "request" extension yet, we're shelling out to curl
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9000/test?q=1
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' -d 'hello world' http://localhost:9000/echo
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9000/users/johndoe
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/headers
+
+-- Try changing configuration
+
+UPDATE omni_httpd.listeners SET port = 9001;
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9001/test?q=1
+
+\! curl --silent -w '\n%{exitcode}' http://localhost:9000/test?q=1


### PR DESCRIPTION
These days it typically means running a web server or an application server of some kind that would connect to the database and interact with it to produce an output. This creates an overhead in operations and overall complexity.

Solution: make it possible to embed an HTTP server in Postgres

This is based on H2O, a "new generation HTTP server" with support for HTTP/1, HTTP/2 and (experimentally) HTTP/3. I have not yet enabled support for HTTP/3. It is also worth mentioning that even though HTTP/2 does work, it's not parallelizing multiple streams due to the current workers architecture. However, I do foresee this changing, just need to spend more time refining it.

Also, there's currently no support for SSL (coming) and building write AND read handlers may be problematic at the moment due to the fact that only top-level CTEs are allowed to write, and we're currently wrapping query as a subquery. I have an idea for introduction of an SQL query type with functional modifications, but I wanted to separate that work.

Bear in mind that this is just the first iteration, making it (barely) work.

There is also a need to improve fd.c code with the ideas and notes from https://gist.github.com/kentonv/bc7592af98c68ba2738f4436920868dc and https://github.com/capnproto/capnproto/blob/7c8802fb9bec8818f289a44b0ec22419a845b249/c++/src/kj/async-io-unix.c++#L559