### PR TITLE
Problem: it's easy to forget to test against all Postgres versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .pg
 build
+.b-*
 build-linux
 cmake-build-debug
 .idea

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+PGVERS=15 14 13 12
+ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+test: $(PGVERS)
+
+$(PGVERS):
+	mkdir -p .b-$@
+	cd .b-$@ && cmake "${ROOT_DIR}" -DPGVER=$@ && CTEST_PARALLEL_LEVEL=8 $(MAKE) -j 8 all test
+


### PR DESCRIPTION
This is related to #36

Solution: add make test that will do it

Why did I name the directories `.b-VER`? It looks like I was running into path length restrictions in Postgres so I tried to cut down on these. It should be done more reliably.

But at least for now, run `make test` before you push so that you can potentially know the result sooner than CI telling you.