### PR TITLE
Problem: omni_httpd listening on different addresses

### DIFF
--- a/extensions/omni_httpd/expected/http.out
+++ b/extensions/omni_httpd/expected/http.out
@@ -4,7 +4,7 @@ CREATE TABLE users (
     name text
 );
 INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
-INSERT INTO omni_httpd.listeners (port, query) VALUES (9000, $$
+INSERT INTO omni_httpd.listeners (listen, query) VALUES (array[row('127.0.0.1', 9000)::omni_httpd.listenaddress], $$
 SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!'), 1 AS priority
        FROM request
        INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
@@ -36,8 +36,15 @@ Content-Type: text/html
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/headers
 {"(user-agent,test-agent,t)","(accept,*/*,t)"}-- Try changing configuration
-UPDATE omni_httpd.listeners SET port = 9001;
+UPDATE omni_httpd.listeners SET listen = array[row('127.0.0.1', 9001)::omni_httpd.listenaddress,
+                                               row('127.0.0.1', 9002)::omni_httpd.listenaddress
+];
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9001/test?q=1
+{"method" : "GET", "path" : "/test", "query_string" : "q=1"}
+404
+Content-Type: text/json
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9002/test?q=1
 {"method" : "GET", "path" : "/test", "query_string" : "q=1"}
 404
 Content-Type: text/json

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -543,7 +543,9 @@ void http_worker(Datum db_oid) {
 
     SPI_connect();
 
-    int ret = SPI_execute("SELECT addr, port, query FROM omni_httpd.listeners", false, 0);
+    int ret = SPI_execute("SELECT listen.addr, listen.port, query FROM omni_httpd.listeners, "
+                          "unnest(omni_httpd.listeners.listen) AS listen",
+                          false, 0);
     if (ret == SPI_OK_SELECT) {
       TupleDesc tupdesc = SPI_tuptable->tupdesc;
       SPITupleTable *tuptable = SPI_tuptable;

--- a/extensions/omni_httpd/master_worker.c
+++ b/extensions/omni_httpd/master_worker.c
@@ -254,7 +254,9 @@ void master_worker(Datum db_oid) {
     // Get listeners
     while (worker_reload) {
       worker_reload = false;
-      if (SPI_execute("SELECT addr, port FROM omni_httpd.listeners", false, 0) == SPI_OK_SELECT) {
+      if (SPI_execute("SELECT listen.addr, listen.port FROM omni_httpd.listeners, "
+                      "unnest(omni_httpd.listeners.listen) AS listen",
+                      false, 0) == SPI_OK_SELECT) {
         TupleDesc tupdesc = SPI_tuptable->tupdesc;
         SPITupleTable *tuptable = SPI_tuptable;
         cset_port ports = cset_port_init();

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -36,10 +36,14 @@ CREATE FUNCTION http_response(
 
 CREATE DOMAIN port integer CHECK (VALUE > 0 AND VALUE <= 65535);
 
+CREATE TYPE listenaddress AS (
+    addr inet,
+    port port
+);
+
 CREATE TABLE listeners (
     id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    port port NOT NULL DEFAULT 80,
-    addr inet NOT NULL DEFAULT '127.0.0.1',
+    listen listenaddress[] NOT NULL DEFAULT array[ROW('127.0.0.1', 80)::listenaddress],
     query text
 );
 


### PR DESCRIPTION
Currently, if one wants to listen on different addresses at the same
time, responding with the same query, they'd have to copy the query
to every listener.

Solution: make listeners take an array of 'listenaddress'es
to serve multiple addresses with the same query