### PR TITLE
Problem: omni_httpd uses database's super user to run queries

### DIFF
--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -24,7 +24,7 @@ add_postgresql_extension(
         SOURCES omni_httpd.c master_worker.c http_worker.c fd.c
         REQUIRES omni_sql
         TESTS_REQUIRE omni_ext
-        REGRESS http)
+        REGRESS http role_name)
 
 target_link_libraries(omni_httpd libh2o-evloop libpgaug libgluepg_stc dynpgext metalang99)
 

--- a/extensions/omni_httpd/expected/role_name.out
+++ b/extensions/omni_httpd/expected/role_name.out
@@ -1,0 +1,44 @@
+CREATE ROLE test_user INHERIT IN ROLE current_user;
+CREATE ROLE test_user1 INHERIT IN ROLE current_user;
+SET ROLE test_user;
+-- Should use current_user as a default role_name
+INSERT INTO omni_httpd.listeners (listen, query) VALUES (array[row('127.0.0.1', 9003)::omni_httpd.listenaddress], $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$) RETURNING role_name;
+ role_name 
+-----------
+ test_user
+(1 row)
+
+-- Can't update it to an arbitrary name
+UPDATE omni_httpd.listeners SET role_name = 'some_role' WHERE role_name = 'test_user';
+ERROR:  new row for relation "listeners" violates check constraint "listeners_role_name_check"
+DETAIL:  Failing row contains (3, {"(127.0.0.1,9003)"}, SELECT omni_httpd.http_response(body => current_user::text) FROM..., some_role).
+-- Can't update it to a name that is not a current user
+UPDATE omni_httpd.listeners SET role_name = 'test_user1' WHERE role_name = 'test_user';
+ERROR:  new row for relation "listeners" violates check constraint "listeners_role_name_check"
+DETAIL:  Failing row contains (3, {"(127.0.0.1,9003)"}, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1).
+-- Can update it to a name that is a current user
+SET ROLE test_user1;
+UPDATE omni_httpd.listeners SET role_name = 'test_user1' WHERE role_name = 'test_user';
+-- When changing the query, should always set current user
+SET ROLE test_user;
+UPDATE omni_httpd.listeners SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$
+    WHERE role_name = 'test_user1' RETURNING role_name;
+ERROR:  new row for relation "listeners" violates check constraint "listeners_role_name_check"
+DETAIL:  Failing row contains (3, {"(127.0.0.1,9003)"}, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1).
+  -- This will work
+UPDATE omni_httpd.listeners SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$,
+    role_name = 'test_user'
+    WHERE role_name = 'test_user1' RETURNING role_name;
+ role_name 
+-----------
+ test_user
+(1 row)
+
+SELECT omni_httpd.reload_configuration();
+ reload_configuration 
+----------------------
+ t
+(1 row)
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/
+test_user

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -44,7 +44,8 @@ CREATE TYPE listenaddress AS (
 CREATE TABLE listeners (
     id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     listen listenaddress[] NOT NULL DEFAULT array[ROW('127.0.0.1', 80)::listenaddress],
-    query text
+    query text,
+    role_name name NOT NULL DEFAULT current_user CHECK (current_user = role_name)
 );
 
 CREATE FUNCTION reload_configuration_trigger() RETURNS trigger

--- a/extensions/omni_httpd/sql/role_name.sql
+++ b/extensions/omni_httpd/sql/role_name.sql
@@ -1,0 +1,30 @@
+CREATE ROLE test_user INHERIT IN ROLE current_user;
+CREATE ROLE test_user1 INHERIT IN ROLE current_user;
+
+SET ROLE test_user;
+
+-- Should use current_user as a default role_name
+INSERT INTO omni_httpd.listeners (listen, query) VALUES (array[row('127.0.0.1', 9003)::omni_httpd.listenaddress], $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$) RETURNING role_name;
+
+-- Can't update it to an arbitrary name
+UPDATE omni_httpd.listeners SET role_name = 'some_role' WHERE role_name = 'test_user';
+
+-- Can't update it to a name that is not a current user
+UPDATE omni_httpd.listeners SET role_name = 'test_user1' WHERE role_name = 'test_user';
+
+-- Can update it to a name that is a current user
+SET ROLE test_user1;
+UPDATE omni_httpd.listeners SET role_name = 'test_user1' WHERE role_name = 'test_user';
+
+-- When changing the query, should always set current user
+SET ROLE test_user;
+UPDATE omni_httpd.listeners SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$
+    WHERE role_name = 'test_user1' RETURNING role_name;
+  -- This will work
+UPDATE omni_httpd.listeners SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$,
+    role_name = 'test_user'
+    WHERE role_name = 'test_user1' RETURNING role_name;
+
+SELECT omni_httpd.reload_configuration();
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/


### PR DESCRIPTION
This can be problematic when more complicated setups are used (outside of one user for everything, basically) and lead to security issues.

Solution: lower worker to a requested & validated user

`omni_httpd.listeners` table now takes a current user (and validates that it is current, therefore authorized) and http worker will set its role to the correct one when needed.