### PR TITLE
Problem: omni_httpd's reload_configuration ends before the configuration is loaded

### DIFF
--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -26,6 +26,8 @@ add_postgresql_extension(
         TESTS_REQUIRE omni_ext
         REGRESS http)
 
+set_property(TARGET omni_httpd PROPERTY C_STANDARD 11)
+
 target_link_libraries(omni_httpd libh2o-evloop libpgaug libgluepg_stc dynpgext metalang99)
 
 # Disable full macro expansion backtraces for Metalang99.

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -30,6 +30,13 @@ int create_listening_socket(sa_family_t family, in_port_t port, char *address);
  */
 static const char *LATCH = "omni_httpd:latch:" EXT_VERSION;
 
+/**
+ * @brief This counter is used to indicate the iteration of configuration change the worker has went
+ * through
+ *
+ */
+static const char *COUNTER = "omni_httpd:config_reload_counter:" EXT_VERSION;
+
 extern int num_http_workers;
 
 #endif //  OMNI_HTTPD_H


### PR DESCRIPTION
Solution: ensure the configuration is read before returning 
at the risk of setting the latch a number of times.