### PR TITLE
Problem: long-running transactions in omni_ext

### DIFF
--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -117,6 +117,7 @@ function(add_postgresql_extension NAME)
     endif()
 
     target_compile_definitions(${NAME} PUBLIC "$<$<NOT:$<STREQUAL:${CMAKE_BUILD_TYPE},Release>>:DEBUG>")
+    target_compile_definitions(${NAME} PUBLIC "$<$<NOT:$<STREQUAL:${CMAKE_BUILD_TYPE},Release>>:USE_ASSERT_CHECKING>")
     target_compile_definitions(${NAME} PUBLIC "EXT_VERSION=\"${_ext_VERSION}\"")
     target_compile_definitions(${NAME} PUBLIC "EXT_SCHEMA=\"${_ext_SCHEMA}\"")
 

--- a/extensions/omni_httpd/fd.c
+++ b/extensions/omni_httpd/fd.c
@@ -61,7 +61,7 @@ static int send_fds_with_buffer(int sock, cvec_fd *fds, void *buffer) {
 int send_fds(int sock, cvec_fd *fds) {
   FD_BUFFER(MAX_N_FDS) buffer;
 
-  Assert(cvec_size(fds) <= MAX_N_FDS);
+  Assert(cvec_fd_size(fds) <= MAX_N_FDS);
   return send_fds_with_buffer(sock, fds, &buffer);
 }
 


### PR DESCRIPTION
Long-running transactions are problematic as they
can cause issues with database vacuuming.

Solution: ensure transactions are short-lived
but don't allocate a new XID.

This ensures we'll use `Assert` functionality from Postgres and fixes a bug from a misuse of it in omni_httpd while we're at it (otherwise it won't compile)