### PR TITLE
Problem: using unreleased version of STC

### DIFF
--- a/cmake/FindSTC.cmake
+++ b/cmake/FindSTC.cmake
@@ -1,3 +1,3 @@
 include(CPM)
 
-CPMAddPackage(NAME stc GIT_REPOSITORY https://github.com/tylov/stc GIT_TAG 91e79fc VERSION 4.0-91e79fc OPTIONS "BUILD_TESTING OFF")
+CPMAddPackage(NAME stc GIT_REPOSITORY https://github.com/tylov/stc GIT_TAG v4.1.1 VERSION 4.1.1 OPTIONS "BUILD_TESTING OFF")


### PR DESCRIPTION
Solution: switch to recently released 4.1.1

It doesn't take advantaged of per-container custom allocators (https://github.com/tylov/STC/discussions/44#discussioncomment-4891925) but we can do this as a separate step to keep things simple.