### PR TITLE
Problem: not clear why omni_httpd requires omni_sql

### DIFF
--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -22,11 +22,10 @@ add_postgresql_extension(
         RELOCATABLE false
         SCRIPTS omni_httpd--0.1.sql
         SOURCES omni_httpd.c master_worker.c http_worker.c fd.c
-        REQUIRES omni_sql
         TESTS_REQUIRE omni_ext
         REGRESS http role_name)
 
-target_link_libraries(omni_httpd libh2o-evloop libpgaug libgluepg_stc dynpgext metalang99)
+target_link_libraries(omni_httpd libh2o-evloop libpgaug libomnisql libgluepg_stc dynpgext metalang99)
 
 # Disable full macro expansion backtraces for Metalang99.
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")

--- a/extensions/omni_sql/CMakeLists.txt
+++ b/extensions/omni_sql/CMakeLists.txt
@@ -10,14 +10,22 @@ enable_testing()
 
 find_package(PostgreSQL REQUIRED)
 
+add_library(libomnisql STATIC
+        deparse.c deparse_15.c deparse_14.c deparse_13.c
+        lib.c)
+set_property(TARGET libomnisql PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(libomnisql
+        PRIVATE ${PostgreSQL_SERVER_INCLUDE_DIRS}
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_postgresql_extension(
         omni_sql
         VERSION 0.1
         SCHEMA omni_sql
         RELOCATABLE false
         SCRIPTS omni_sql--0.1.sql
-        SOURCES omni_sql.c deparse.c deparse_15.c deparse_14.c deparse_13.c
+        SOURCES omni_sql.c
         REGRESS deparse cte parameterized
 )
 
-target_link_libraries(omni_sql libpgaug)
+target_link_libraries(omni_sql libpgaug libomnisql)

--- a/extensions/omni_sql/deparse.c
+++ b/extensions/omni_sql/deparse.c
@@ -21,7 +21,7 @@ char *omni_sql_deparse_statement(List *stmts) {
     if (lnext(stmts, lc))
       appendStringInfoString(&str, "; ");
   }
-  result = strdup(str.data);
+  result = pstrdup(str.data);
 
   return result;
 }

--- a/extensions/omni_sql/lib.c
+++ b/extensions/omni_sql/lib.c
@@ -1,0 +1,128 @@
+/**
+ * @file lib.c
+ *
+ */
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
+#include <funcapi.h>
+#include <parser/parser.h>
+#include <utils/builtins.h>
+
+#include <nodes/nodeFuncs.h>
+
+#include "deparse.h"
+
+List *omni_sql_parse_statement(char *statement) {
+#if PG_MAJORVERSION_NUM == 13
+  List *stmts = raw_parser(statement);
+#else
+  List *stmts = raw_parser(statement, RAW_PARSE_DEFAULT);
+#endif
+  return stmts;
+}
+
+List *omni_sql_add_cte(List *stmts, text *cte_name, List *cte_stmts, bool recursive, bool prepend) {
+
+  if (list_length(stmts) != 1) {
+    ereport(ERROR, errmsg("Statement should contain one and only one statement"));
+  }
+
+  if (list_length(cte_stmts) != 1) {
+    ereport(ERROR, errmsg("CTE should contain one and only one statement"));
+  }
+
+  void *node = linitial(stmts);
+
+  CommonTableExpr *cte_node = palloc0(sizeof(*cte_node));
+
+  *cte_node = (CommonTableExpr) {
+    .type = T_CommonTableExpr, .ctename = text_to_cstring(cte_name), .aliascolnames = NULL,
+    .ctematerialized = CTEMaterializeDefault, .ctequery = linitial_node(RawStmt, cte_stmts)->stmt,
+#if PG_VERSION_MAJORNUM >= 14
+    .search_clause = NULL, .cycle_clause = NULL,
+#endif
+    .location = -1, // unknown location
+        .cterecursive = recursive, .cterefcount = 0, .ctecolnames = NULL, .ctecoltypes = NULL,
+    .ctecoltypmods = NULL, .ctecolcollations = NULL
+  };
+
+  WithClause **with = NULL;
+dispatch:
+  switch (nodeTag(node)) {
+  case T_RawStmt: {
+    RawStmt *stmt = castNode(RawStmt, node);
+    node = stmt->stmt;
+    goto dispatch;
+  }
+  case T_SelectStmt: {
+    SelectStmt *select = castNode(SelectStmt, node);
+    with = &select->withClause;
+    break;
+  }
+  case T_InsertStmt: {
+    InsertStmt *insert = castNode(InsertStmt, node);
+    with = &insert->withClause;
+    break;
+  }
+  case T_UpdateStmt: {
+    UpdateStmt *update = castNode(UpdateStmt, node);
+    with = &update->withClause;
+    break;
+  }
+  case T_DeleteStmt: {
+    DeleteStmt *delete = castNode(DeleteStmt, node);
+    with = &delete->withClause;
+    break;
+  }
+  default:
+    ereport(ERROR, errmsg("no supported statement found"));
+  }
+
+  if (*with == NULL) {
+    WithClause *new_with = palloc(sizeof(*new_with));
+    new_with->type = T_WithClause;
+    new_with->location = -1;
+    new_with->recursive = recursive;
+    new_with->ctes = list_make1(cte_node);
+    *with = new_with;
+  } else {
+    List *ctes = (*with)->ctes;
+    if (prepend) {
+      ctes = list_insert_nth(ctes, 0, cte_node);
+    } else {
+      ctes = lappend(ctes, cte_node);
+    }
+  }
+
+  return stmts;
+}
+
+static bool contains_param_walker(Node *node, bool *contains) {
+  if (node != NULL) {
+    if (nodeTag(node) == T_ParamRef) {
+      *contains = true;
+      return true;
+    } else {
+      return raw_expression_tree_walker(node, contains_param_walker, contains);
+    }
+  }
+  return false;
+}
+
+bool omni_sql_is_parameterized(List *stmts) {
+
+  ListCell *stmt;
+  foreach (stmt, stmts) {
+    bool contains = false;
+    raw_expression_tree_walker(castNode(RawStmt, lfirst(stmt))->stmt, contains_param_walker,
+                               &contains);
+    if (contains) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/extensions/omni_sql/omni_sql.c
+++ b/extensions/omni_sql/omni_sql.c
@@ -8,24 +8,9 @@
 #include <fmgr.h>
 // clang-format on
 
-#include <funcapi.h>
-#include <parser/parser.h>
-#include <utils/builtins.h>
-
-#include <nodes/nodeFuncs.h>
-
-#include "deparse.h"
+#include "omni_sql.h"
 
 PG_MODULE_MAGIC;
-
-static List *parse_statement(char *statement) {
-#if PG_MAJORVERSION_NUM == 13
-  List *stmts = raw_parser(statement);
-#else
-  List *stmts = raw_parser(statement, RAW_PARSE_DEFAULT);
-#endif
-  return stmts;
-}
 
 PG_FUNCTION_INFO_V1(statement_in);
 
@@ -34,7 +19,7 @@ Datum statement_in(PG_FUNCTION_ARGS) {
     ereport(ERROR, errmsg("statement can't be NULL"));
   }
   char *statement = PG_GETARG_CSTRING(0);
-  List *stmts = parse_statement(statement);
+  List *stmts = omni_sql_parse_statement(statement);
   char *deparsed = omni_sql_deparse_statement(stmts);
   text *deparsed_statement = cstring_to_text(deparsed);
   PG_RETURN_TEXT_P(deparsed_statement);
@@ -66,93 +51,19 @@ Datum add_cte(PG_FUNCTION_ARGS) {
 
   text *statement = PG_GETARG_TEXT_PP(0);
   char *cstatement = text_to_cstring(statement);
-  List *stmts = parse_statement(cstatement);
-
-  if (list_length(stmts) != 1) {
-    ereport(ERROR, errmsg("Statement should contain one and only one statement"));
-  }
+  List *stmts = omni_sql_parse_statement(cstatement);
 
   text *cte_name = PG_GETARG_TEXT_PP(1);
 
   text *cte = PG_GETARG_TEXT_PP(2);
   char *ccte = text_to_cstring(cte);
-  List *cte_stmts = parse_statement(ccte);
-
-  if (list_length(cte_stmts) != 1) {
-    ereport(ERROR, errmsg("CTE should contain one and only one statement"));
-  }
-
-  void *node = linitial(stmts);
+  List *cte_stmts = omni_sql_parse_statement(ccte);
 
   bool recursive = PG_GETARG_BOOL(3);
   bool prepend = PG_GETARG_BOOL(4);
 
-  CommonTableExpr cte_node = {
-    .type = T_CommonTableExpr,
-    .ctename = text_to_cstring(cte_name),
-    .aliascolnames = NULL,
-    .ctematerialized = CTEMaterializeDefault,
-    .ctequery = linitial_node(RawStmt, cte_stmts)->stmt,
-#if PG_VERSION_MAJORNUM >= 14
-    .search_clause = NULL,
-    .cycle_clause = NULL,
-#endif
-    .location = -1, // unknown location
-    .cterecursive = recursive,
-    .cterefcount = 0,
-    .ctecolnames = NULL,
-    .ctecoltypes = NULL,
-    .ctecoltypmods = NULL,
-    .ctecolcollations = NULL
-  };
+  stmts = omni_sql_add_cte(stmts, cte_name, cte_stmts, recursive, prepend);
 
-  WithClause **with = NULL;
-dispatch:
-  switch (nodeTag(node)) {
-  case T_RawStmt: {
-    RawStmt *stmt = castNode(RawStmt, node);
-    node = stmt->stmt;
-    goto dispatch;
-  }
-  case T_SelectStmt: {
-    SelectStmt *select = castNode(SelectStmt, node);
-    with = &select->withClause;
-    break;
-  }
-  case T_InsertStmt: {
-    InsertStmt *insert = castNode(InsertStmt, node);
-    with = &insert->withClause;
-    break;
-  }
-  case T_UpdateStmt: {
-    UpdateStmt *update = castNode(UpdateStmt, node);
-    with = &update->withClause;
-    break;
-  }
-  case T_DeleteStmt: {
-    DeleteStmt *delete = castNode(DeleteStmt, node);
-    with = &delete->withClause;
-    break;
-  }
-  default:
-    ereport(ERROR, errmsg("no supported statement found"));
-  }
-
-  if (*with == NULL) {
-    WithClause *new_with = palloc(sizeof(*new_with));
-    new_with->type = T_WithClause;
-    new_with->location = -1;
-    new_with->recursive = recursive;
-    new_with->ctes = list_make1(&cte_node);
-    *with = new_with;
-  } else {
-    List *ctes = (*with)->ctes;
-    if (prepend) {
-      ctes = list_insert_nth(ctes, 0, &cte_node);
-    } else {
-      ctes = lappend(ctes, &cte_node);
-    }
-  }
   char *deparsed = omni_sql_deparse_statement(stmts);
   text *deparsed_statement = cstring_to_text(deparsed);
 
@@ -161,33 +72,12 @@ dispatch:
 
 PG_FUNCTION_INFO_V1(is_parameterized);
 
-static bool contains_param_walker(Node *node, bool *contains) {
-  if (node != NULL) {
-    if (nodeTag(node) == T_ParamRef) {
-      *contains = true;
-      return true;
-    } else {
-      return raw_expression_tree_walker(node, contains_param_walker, contains);
-    }
-  }
-  return false;
-}
-
 Datum is_parameterized(PG_FUNCTION_ARGS) {
   if (PG_ARGISNULL(0)) {
     ereport(ERROR, errmsg("statement can't be NULL"));
   }
   text *statement = PG_GETARG_TEXT_PP(0);
-  List *stmts = parse_statement(text_to_cstring(statement));
+  List *stmts = omni_sql_parse_statement(text_to_cstring(statement));
 
-  ListCell *stmt;
-  foreach (stmt, stmts) {
-    bool contains = false;
-    raw_expression_tree_walker(castNode(RawStmt, lfirst(stmt))->stmt, contains_param_walker,
-                               &contains);
-    if (contains) {
-      PG_RETURN_BOOL(true);
-    }
-  }
-  PG_RETURN_BOOL(false);
+  PG_RETURN_BOOL(omni_sql_is_parameterized(stmts));
 }

--- a/extensions/omni_sql/omni_sql.h
+++ b/extensions/omni_sql/omni_sql.h
@@ -1,0 +1,20 @@
+#ifndef OMNI_SQL_H
+#define OMNI_SQL_H
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
+#include <funcapi.h>
+#include <parser/parser.h>
+#include <utils/builtins.h>
+
+#include <nodes/nodeFuncs.h>
+
+#include "deparse.h"
+
+List *omni_sql_parse_statement(char *statement);
+List *omni_sql_add_cte(List *stmts, text *cte_name, List *cte_stmts, bool recursive, bool prepend);
+bool omni_sql_is_parameterized(List *stmts);
+
+#endif // OMNI_SQL_H


### PR DESCRIPTION
omni_httpd doesn't publicly use any of omni_sql interface and therefore it is confusing why would it need to depend on omni_sql

Solution: extract libomnisql static library
and make omni_httpd use it directly instead of relying on an extension as it is indeed a bit more of an internal implementation detail, at least for now.

This also fixes a bug in deparsing where strings were duplicated with stdup instead of pstrdup (won't work with pfree and can lead to memory leaks otherwise)