### PR TITLE
Problem: make fix-format doesn't work on NixOS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "cmake_nixpkgs": {
-      "locked": {
-        "lastModified": 1673444646,
-        "narHash": "sha256-KXqUmmkX952jwl/3FO8DWCsQBfOjB0ED4unYCVOOIAk=",
-        "owner": "yrashk",
-        "repo": "nixpkgs",
-        "rev": "3003a72d0e5d1105e963cc3375e7176c2a91d5b4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "yrashk",
-        "ref": "cmake-3.25.1",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -46,11 +30,26 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_master": {
+      "locked": {
+        "lastModified": 1677852170,
+        "narHash": "sha256-OTSjXBTg/9HUgL7Wy8cU2cmOnS2tSvJqGyOpS5DPOmc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e7d00dfbd3988f4e6916bc5c88dc375bbfd7b42c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "cmake_nixpkgs": "cmake_nixpkgs",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs_master": "nixpkgs_master"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,18 +1,18 @@
 {
   inputs = {
-    # Pending cmake 3.25.1 merge and release: https://github.com/NixOS/nixpkgs/pull/206799 
-    cmake_nixpkgs.url = "github:yrashk/nixpkgs?ref=cmake-3.25.1";
+    nixpkgs_master.url = "github:NixOS/nixpkgs";
     nixpkgs.url = "nixpkgs/nixos-22.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, cmake_nixpkgs, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs_master, nixpkgs, flake-utils }:
   flake-utils.lib.eachDefaultSystem
   (system:
-      let cmake = cmake_nixpkgs.legacyPackages.${system}.cmake; in
+      let cmake = nixpkgs_master.legacyPackages.${system}.cmake; in
+      let clang-tools = nixpkgs_master.legacyPackages.${system}.clang-tools_15; in
       let pkgs = nixpkgs.legacyPackages.${system};
       in {
         devShell = pkgs.mkShell { buildInputs = [ pkgs.pkgsStatic.openssl pkgs.pkgconfig cmake pkgs.flex pkgs.readline
-                                                  pkgs.zlib]; };
+                                                  pkgs.zlib clang-tools pkgs.python]; };
       });
 }


### PR DESCRIPTION
Format.cmake reports that clang-format and/or Python are not found.

Solution: include these in the Nix flake

Also, use the mainstream repo for nixpkgs as cmake 3.25.1 has been merged.