### PR TITLE
Problem: merged PRs leave cache items in GitHub Actions

### DIFF
--- a/.github/workflows/gh-cleanup.yml
+++ b/.github/workflows/gh-cleanup.yml
@@ -1,0 +1,29 @@
+name: GH Actions Cleanup
+
+on:
+  schedule:
+    - cron: '30 * * * *'
+
+jobs:
+  cleanup:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Prepare tools
+        run: sudo apt install jq
+
+      - name: Authenticate GH
+        run: echo ${{GITHUB_TOKEN}} | gh auth login --with-token
+
+      - name: Clean up
+        run: ./ci/github-actions-storage-cleanup
+

--- a/ci/github-actions-storage-cleanup
+++ b/ci/github-actions-storage-cleanup
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+# This script requires `bash` >= v4, `gh` and `js` to be installed and `gh` authenticated.
+
+[ "${BASH_VERSINFO:-0}" -ge 4 ] || (echo "bash >= 4 required"; exit 1)
+
+total_storage=$(gh api /repos/omnigres/omnigres/actions/cache/usage | jq '.active_caches_size_in_bytes / (1024 * 1024 * 1024) * 100 | round / 100')
+echo "Total storage used: ${total_storage} GB (info can be delayed by up to 5 mins)"
+
+non_master_items=$(gh api "/repos/omnigres/omnigres/actions/caches?per_page=100"  | jq '.actions_caches[] | select(.ref != "refs/heads/master") | "\(.id),\(.ref),\(.key),\(.size_in_bytes / (1024 * 1024) * 100 | round / 100)"' -r)
+
+declare -A PR
+
+for item in ${non_master_items} ; do
+  itemArr=(${item//,/ })
+  id=${itemArr[0]}
+  ref=${itemArr[1]}
+  key=${itemArr[2]}
+  size=${itemArr[3]}
+  refArr=(${ref//\// })
+  pr=${refArr[2]}
+  if [ -z "${PR[${pr}]}" ]; then
+    echo -n "Checking PR #${pr} status: "
+    status=$(gh issue -R omnigres/omnigres view --json state --jq '.state' ${pr})
+    echo "${status}"
+    PR["${pr}"]=${status}
+  fi
+  if [[ "${PR[${pr}]}" == "MERGED" ]]; then
+    echo "Removing $key (${size} MB) [PR #${pr}]"
+    gh api --method DELETE "/repos/omnigres/omnigres/actions/caches/${id}"
+  fi
+done


### PR DESCRIPTION
These count against the 10GB quota and they can be pretty big.

Solution: have a script to easily clean them up