### PR TITLE
Problem: reload_configuration trigger fragility

### DIFF
--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -25,6 +25,7 @@
 #if PG_MAJORVERSION_NUM >= 13
 #include <postmaster/interrupt.h>
 #endif
+#include <commands/async.h>
 #include <storage/latch.h>
 #include <tcop/utility.h>
 #include <utils/builtins.h>
@@ -101,11 +102,8 @@ Datum reload_configuration(PG_FUNCTION_ARGS) {
     ereport(NOTICE, errmsg("omni_httpd hasn't been properly loaded"));
     PG_RETURN_BOOL(false);
   }
-  pg_memory_barrier();
-  SetLatch(worker_latch);
-  if (worker_latch->owner_pid != 0) {
-    kill(worker_latch->owner_pid, SIGUSR2);
-  }
+  Async_Notify(OMNI_HTTPD_CONFIGURATION_NOTIFY_CHANNEL, NULL);
+
   if (CALLED_AS_TRIGGER(fcinfo)) {
     return PointerGetDatum(((TriggerData *)(fcinfo->context))->tg_newtuple);
   } else {

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -32,4 +32,6 @@ static const char *LATCH = "omni_httpd:latch:" EXT_VERSION;
 
 extern int num_http_workers;
 
+static const char *OMNI_HTTPD_CONFIGURATION_NOTIFY_CHANNEL = "omni_httpd_configuration";
+
 #endif //  OMNI_HTTPD_H


### PR DESCRIPTION
It often works incorrectly as it is executed within the transaction, however, it communicates with master_worker and the worker is expected to pick up the configuration changes. If it will happen to process the configuration change *after* the commit, then all is good. Otherwise, the change won't be detected.

The trigger would notify the worker even if the transaction with the change will revert. It's probably not a big deal (since no changes will be visible to the worker) but it triggers the worker to go into the reload mode unnecessarily.

Solution: switch to using NOTIFY/LISTEN mechanism

This is a better mechanism as it will only be executed when the transaction succeeds and will not be duplicated (which may be important when the configuration will grow beyond just one table.)