### PR TITLE
Problem: omni_httpd's master_worker latch

### DIFF
--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -63,20 +63,9 @@ CACHED_OID(http_response);
 
 int num_http_workers;
 
-/**
- * @brief Initializes allocated shared latch
- *
- * @param latch uninitialized latch
- * @param data unused
- */
-static void init_latch(Latch *latch, void *data) { InitSharedLatch(latch); }
-
 void _Dynpgext_init(const dynpgext_handle *handle) {
   DefineCustomIntVariable("omni_httpd.http_workers", "Number of HTTP workers", NULL,
                           &num_http_workers, 10, 1, INT_MAX, PGC_SIGHUP, 0, NULL, NULL, NULL);
-  // Allocates memory for the worker latch
-  handle->allocate_shmem(handle, LATCH, sizeof(Latch), (void (*)(void *ptr, void *data))init_latch,
-                         NULL, DYNPGEXT_SCOPE_DATABASE_LOCAL);
 
   // Prepares and registers the main background worker
   BackgroundWorker bgw = {.bgw_name = "omni_httpd",
@@ -97,11 +86,6 @@ PG_FUNCTION_INFO_V1(reload_configuration);
  * @return Datum
  */
 Datum reload_configuration(PG_FUNCTION_ARGS) {
-  Latch *worker_latch = (Latch *)dynpgext_lookup_shmem(LATCH);
-  if (worker_latch == NULL) {
-    ereport(NOTICE, errmsg("omni_httpd hasn't been properly loaded"));
-    PG_RETURN_BOOL(false);
-  }
   Async_Notify(OMNI_HTTPD_CONFIGURATION_NOTIFY_CHANNEL, NULL);
 
   if (CALLED_AS_TRIGGER(fcinfo)) {

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -21,15 +21,6 @@ int create_listening_socket(sa_family_t family, in_port_t port, char *address);
 
 #define MAX_ADDRESS_SIZE sizeof("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:255.255.255.255/128")
 
-/**
- * @brief This latch is used to notify the workers that the configuration has changed.
- *
- * Used to `SetLatch` if it is not owned yet, otherwise using owner's PID to set a SIGUSR2
- * directly.
- *
- */
-static const char *LATCH = "omni_httpd:latch:" EXT_VERSION;
-
 extern int num_http_workers;
 
 static const char *OMNI_HTTPD_CONFIGURATION_NOTIFY_CHANNEL = "omni_httpd_configuration";


### PR DESCRIPTION
After we've started using Notify/Listen mechanism, the use-case for the dedicated shared latch is seemingly gone. What's even worse, is that it is relatively fragile. If the worker crashes, the latch doesn't get disowned and therefore, on a subsequent restart, it can't be re-owned again. This makes code really fragile.

Solution: remove the latch altogether