### PR TITLE
Problem: omni_httpd's test is flaky

### DIFF
--- a/extensions/omni_httpd/expected/http.out
+++ b/extensions/omni_httpd/expected/http.out
@@ -59,8 +59,8 @@ Content-Type: text/json
 404
 Content-Type: text/json
 
-\! curl --silent -w '%{exitcode}\n' http://localhost:9000/test?q=1
-7
+\! curl --silent http://localhost:9000/test?q=1 || echo "failed as it should"
+failed as it should
 INSERT INTO omni_httpd.listeners (listen, query) VALUES (array[row('127.0.0.1', 9001)::omni_httpd.listenaddress], $$
 SELECT omni_httpd.http_response(body => 'another port') FROM request
 $$);

--- a/extensions/omni_httpd/sql/http.sql
+++ b/extensions/omni_httpd/sql/http.sql
@@ -52,7 +52,7 @@ UPDATE omni_httpd.listeners SET listen = array[row('127.0.0.1', 9001)::omni_http
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9002/test?q=1
 
-\! curl --silent -w '%{exitcode}\n' http://localhost:9000/test?q=1
+\! curl --silent http://localhost:9000/test?q=1 || echo "failed as it should"
 
 INSERT INTO omni_httpd.listeners (listen, query) VALUES (array[row('127.0.0.1', 9001)::omni_httpd.listenaddress], $$
 SELECT omni_httpd.http_response(body => 'another port') FROM request


### PR DESCRIPTION
This test  sometimes returns 56 exitcode instead of 7 (connection refused):

```
\! curl --silent -w '%{exitcode}\n' http://localhost:9000/test?q=1
```

Solution: test for request failure instead of specific code

Most likely, the flakiness is introduced by how (soon) the socket is closed during the asynchronous omni_httpd configuration update.