### PR TITLE
Problem: updating Dockerfile triggers `build` to be rebuilt

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .*
 build*
+Dockerfile


### PR DESCRIPTION
Solution: don't include Dockerfile in the context