### PR TITLE
Problem: omni_httpd.listeners table is not great

### DIFF
--- a/extensions/omni_httpd/expected/http.out
+++ b/extensions/omni_httpd/expected/http.out
@@ -4,6 +4,7 @@ CREATE TABLE users (
     name text
 );
 INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
+BEGIN;
 WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9000) RETURNING id),
      sqlet AS (INSERT INTO omni_httpd.sqlets (query) VALUES (
 $$
@@ -32,6 +33,9 @@ $$) RETURNING id)
 INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id)
 SELECT listener.id, sqlet.id
 FROM listener, sqlet;
+DELETE FROM omni_httpd.configuration_reloads;
+END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
 -- Now, the actual tests
 -- FIXME: for the time being, since there's no "request" extension yet, we're shelling out to curl
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9000/test?q=1
@@ -57,7 +61,9 @@ WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.
      sqlet AS (SELECT ls.sqlet_id AS id FROM omni_httpd.listeners INNER JOIN omni_httpd.listeners_sqlets ls ON ls.listener_id = listeners.id WHERE port = 9001)
 INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id)
  SELECT listener.id, sqlet.id FROM listener, sqlet;
+DELETE FROM omni_httpd.configuration_reloads;
 END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9001/test?q=1
 {"method" : "GET", "path" : "/test", "query_string" : "q=1"}
 404

--- a/extensions/omni_httpd/expected/http.out
+++ b/extensions/omni_httpd/expected/http.out
@@ -4,7 +4,9 @@ CREATE TABLE users (
     name text
 );
 INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
-INSERT INTO omni_httpd.listeners (listen, query) VALUES (array[row('127.0.0.1', 9000)::omni_httpd.listenaddress], $$
+WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9000) RETURNING id),
+     sqlet AS (INSERT INTO omni_httpd.sqlets (query) VALUES (
+$$
 WITH
 hello AS
 (SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!')
@@ -26,7 +28,10 @@ UNION ALL
 SELECT * FROM echo WHERE NOT EXISTS (SELECT 1 from headers)
 UNION ALL
 SELECT * FROM not_found WHERE NOT EXISTS (SELECT 1 from echo)
-$$);
+$$) RETURNING id)
+INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id)
+SELECT listener.id, sqlet.id
+FROM listener, sqlet;
 -- Now, the actual tests
 -- FIXME: for the time being, since there's no "request" extension yet, we're shelling out to curl
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9000/test?q=1
@@ -46,9 +51,13 @@ Content-Type: text/html
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/headers
 {"(user-agent,test-agent,t)","(accept,*/*,t)"}-- Try changing configuration
-UPDATE omni_httpd.listeners SET listen = array[row('127.0.0.1', 9001)::omni_httpd.listenaddress,
-                                               row('127.0.0.1', 9002)::omni_httpd.listenaddress
-];
+BEGIN;
+UPDATE omni_httpd.listeners SET port = 9001 WHERE port = 9000;
+WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9002) RETURNING id),
+     sqlet AS (SELECT ls.sqlet_id AS id FROM omni_httpd.listeners INNER JOIN omni_httpd.listeners_sqlets ls ON ls.listener_id = listeners.id WHERE port = 9001)
+INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id)
+ SELECT listener.id, sqlet.id FROM listener, sqlet;
+END;
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9001/test?q=1
 {"method" : "GET", "path" : "/test", "query_string" : "q=1"}
 404
@@ -61,9 +70,3 @@ Content-Type: text/json
 
 \! curl --silent http://localhost:9000/test?q=1 || echo "failed as it should"
 failed as it should
-INSERT INTO omni_httpd.listeners (listen, query) VALUES (array[row('127.0.0.1', 9001)::omni_httpd.listenaddress], $$
-SELECT omni_httpd.http_response(body => 'another port') FROM request
-$$);
--- Ensure we serve correct query for a different listener
-\! curl --retry-connrefused --retry 10 --retry-max-time 10 --silent http://localhost:9001
-another port

--- a/extensions/omni_httpd/expected/http.out
+++ b/extensions/omni_httpd/expected/http.out
@@ -6,7 +6,7 @@ CREATE TABLE users (
 INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
 BEGIN;
 WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9000) RETURNING id),
-     sqlet AS (INSERT INTO omni_httpd.sqlets (query) VALUES (
+     handler AS (INSERT INTO omni_httpd.handlers (query) VALUES (
 $$
 WITH
 hello AS
@@ -30,9 +30,9 @@ SELECT * FROM echo WHERE NOT EXISTS (SELECT 1 from headers)
 UNION ALL
 SELECT * FROM not_found WHERE NOT EXISTS (SELECT 1 from echo)
 $$) RETURNING id)
-INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id)
-SELECT listener.id, sqlet.id
-FROM listener, sqlet;
+INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
+SELECT listener.id, handler.id
+FROM listener, handler;
 DELETE FROM omni_httpd.configuration_reloads;
 END;
 CALL omni_httpd.wait_for_configuration_reloads(1);
@@ -58,9 +58,9 @@ Content-Type: text/html
 BEGIN;
 UPDATE omni_httpd.listeners SET port = 9001 WHERE port = 9000;
 WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9002) RETURNING id),
-     sqlet AS (SELECT ls.sqlet_id AS id FROM omni_httpd.listeners INNER JOIN omni_httpd.listeners_sqlets ls ON ls.listener_id = listeners.id WHERE port = 9001)
-INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id)
- SELECT listener.id, sqlet.id FROM listener, sqlet;
+     handler AS (SELECT ls.handler_id AS id FROM omni_httpd.listeners INNER JOIN omni_httpd.listeners_handlers ls ON ls.listener_id = listeners.id WHERE port = 9001)
+INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
+ SELECT listener.id, handler.id FROM listener, handler;
 DELETE FROM omni_httpd.configuration_reloads;
 END;
 CALL omni_httpd.wait_for_configuration_reloads(1);

--- a/extensions/omni_httpd/expected/role_name.out
+++ b/extensions/omni_httpd/expected/role_name.out
@@ -2,28 +2,47 @@ CREATE ROLE test_user INHERIT IN ROLE current_user;
 CREATE ROLE test_user1 INHERIT IN ROLE current_user;
 SET ROLE test_user;
 -- Should use current_user as a default role_name
+BEGIN;
 WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9003) RETURNING id),
      sqlet AS (INSERT INTO omni_httpd.sqlets (query) VALUES (
 $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$) RETURNING id)
 INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id) SELECT listener.id, sqlet.id FROM listener, sqlet;
+DELETE FROM omni_httpd.configuration_reloads;
+END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
 -- Can't update it to an arbitrary name
+BEGIN;
 UPDATE omni_httpd.sqlets SET role_name = 'some_role' WHERE role_name = 'test_user';
 ERROR:  new row for relation "sqlets" violates check constraint "sqlets_role_name_check"
 DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., some_role).
+DELETE FROM omni_httpd.configuration_reloads;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
 -- Can't update it to a name that is not a current user
+BEGIN;
 UPDATE omni_httpd.sqlets SET role_name = 'test_user1' WHERE role_name = 'test_user';
 ERROR:  new row for relation "sqlets" violates check constraint "sqlets_role_name_check"
 DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1).
+DELETE FROM omni_httpd.configuration_reloads;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
 -- Can update it to a name that is a current user
 SET ROLE test_user1;
+BEGIN;
 UPDATE omni_httpd.sqlets SET role_name = 'test_user1' WHERE role_name = 'test_user';
+DELETE FROM omni_httpd.configuration_reloads;
+END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
 -- When changing the query, should always set current user
 SET ROLE test_user;
 UPDATE omni_httpd.sqlets SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$
     WHERE role_name = 'test_user1' RETURNING role_name;
 ERROR:  new row for relation "sqlets" violates check constraint "sqlets_role_name_check"
 DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1).
-  -- This will work
+-- This will work
+BEGIN;
 UPDATE omni_httpd.sqlets SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$,
     role_name = 'test_user'
     WHERE role_name = 'test_user1' RETURNING role_name;
@@ -32,11 +51,8 @@ UPDATE omni_httpd.sqlets SET query = $$SELECT omni_httpd.http_response(body => c
  test_user
 (1 row)
 
-SELECT omni_httpd.reload_configuration();
- reload_configuration 
-----------------------
- t
-(1 row)
-
+DELETE FROM omni_httpd.configuration_reloads;
+END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/
 test_user

--- a/extensions/omni_httpd/expected/role_name.out
+++ b/extensions/omni_httpd/expected/role_name.out
@@ -2,31 +2,29 @@ CREATE ROLE test_user INHERIT IN ROLE current_user;
 CREATE ROLE test_user1 INHERIT IN ROLE current_user;
 SET ROLE test_user;
 -- Should use current_user as a default role_name
-INSERT INTO omni_httpd.listeners (listen, query) VALUES (array[row('127.0.0.1', 9003)::omni_httpd.listenaddress], $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$) RETURNING role_name;
- role_name 
------------
- test_user
-(1 row)
-
+WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9003) RETURNING id),
+     sqlet AS (INSERT INTO omni_httpd.sqlets (query) VALUES (
+$$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$) RETURNING id)
+INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id) SELECT listener.id, sqlet.id FROM listener, sqlet;
 -- Can't update it to an arbitrary name
-UPDATE omni_httpd.listeners SET role_name = 'some_role' WHERE role_name = 'test_user';
-ERROR:  new row for relation "listeners" violates check constraint "listeners_role_name_check"
-DETAIL:  Failing row contains (4, {"(127.0.0.1,9003)"}, SELECT omni_httpd.http_response(body => current_user::text) FROM..., some_role).
+UPDATE omni_httpd.sqlets SET role_name = 'some_role' WHERE role_name = 'test_user';
+ERROR:  new row for relation "sqlets" violates check constraint "sqlets_role_name_check"
+DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., some_role).
 -- Can't update it to a name that is not a current user
-UPDATE omni_httpd.listeners SET role_name = 'test_user1' WHERE role_name = 'test_user';
-ERROR:  new row for relation "listeners" violates check constraint "listeners_role_name_check"
-DETAIL:  Failing row contains (4, {"(127.0.0.1,9003)"}, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1).
+UPDATE omni_httpd.sqlets SET role_name = 'test_user1' WHERE role_name = 'test_user';
+ERROR:  new row for relation "sqlets" violates check constraint "sqlets_role_name_check"
+DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1).
 -- Can update it to a name that is a current user
 SET ROLE test_user1;
-UPDATE omni_httpd.listeners SET role_name = 'test_user1' WHERE role_name = 'test_user';
+UPDATE omni_httpd.sqlets SET role_name = 'test_user1' WHERE role_name = 'test_user';
 -- When changing the query, should always set current user
 SET ROLE test_user;
-UPDATE omni_httpd.listeners SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$
+UPDATE omni_httpd.sqlets SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$
     WHERE role_name = 'test_user1' RETURNING role_name;
-ERROR:  new row for relation "listeners" violates check constraint "listeners_role_name_check"
-DETAIL:  Failing row contains (4, {"(127.0.0.1,9003)"}, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1).
+ERROR:  new row for relation "sqlets" violates check constraint "sqlets_role_name_check"
+DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1).
   -- This will work
-UPDATE omni_httpd.listeners SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$,
+UPDATE omni_httpd.sqlets SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$,
     role_name = 'test_user'
     WHERE role_name = 'test_user1' RETURNING role_name;
  role_name 

--- a/extensions/omni_httpd/expected/role_name.out
+++ b/extensions/omni_httpd/expected/role_name.out
@@ -4,16 +4,16 @@ SET ROLE test_user;
 -- Should use current_user as a default role_name
 BEGIN;
 WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9003) RETURNING id),
-     sqlet AS (INSERT INTO omni_httpd.sqlets (query) VALUES (
+     handler AS (INSERT INTO omni_httpd.handlers (query) VALUES (
 $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$) RETURNING id)
-INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id) SELECT listener.id, sqlet.id FROM listener, sqlet;
+INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id) SELECT listener.id, handler.id FROM listener, handler;
 DELETE FROM omni_httpd.configuration_reloads;
 END;
 CALL omni_httpd.wait_for_configuration_reloads(1);
 -- Can't update it to an arbitrary name
 BEGIN;
-UPDATE omni_httpd.sqlets SET role_name = 'some_role' WHERE role_name = 'test_user';
-ERROR:  new row for relation "sqlets" violates check constraint "sqlets_role_name_check"
+UPDATE omni_httpd.handlers SET role_name = 'some_role' WHERE role_name = 'test_user';
+ERROR:  new row for relation "handlers" violates check constraint "handlers_role_name_check"
 DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., some_role).
 DELETE FROM omni_httpd.configuration_reloads;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
@@ -21,8 +21,8 @@ END;
 CALL omni_httpd.wait_for_configuration_reloads(1);
 -- Can't update it to a name that is not a current user
 BEGIN;
-UPDATE omni_httpd.sqlets SET role_name = 'test_user1' WHERE role_name = 'test_user';
-ERROR:  new row for relation "sqlets" violates check constraint "sqlets_role_name_check"
+UPDATE omni_httpd.handlers SET role_name = 'test_user1' WHERE role_name = 'test_user';
+ERROR:  new row for relation "handlers" violates check constraint "handlers_role_name_check"
 DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1).
 DELETE FROM omni_httpd.configuration_reloads;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
@@ -31,19 +31,19 @@ CALL omni_httpd.wait_for_configuration_reloads(1);
 -- Can update it to a name that is a current user
 SET ROLE test_user1;
 BEGIN;
-UPDATE omni_httpd.sqlets SET role_name = 'test_user1' WHERE role_name = 'test_user';
+UPDATE omni_httpd.handlers SET role_name = 'test_user1' WHERE role_name = 'test_user';
 DELETE FROM omni_httpd.configuration_reloads;
 END;
 CALL omni_httpd.wait_for_configuration_reloads(1);
 -- When changing the query, should always set current user
 SET ROLE test_user;
-UPDATE omni_httpd.sqlets SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$
+UPDATE omni_httpd.handlers SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$
     WHERE role_name = 'test_user1' RETURNING role_name;
-ERROR:  new row for relation "sqlets" violates check constraint "sqlets_role_name_check"
+ERROR:  new row for relation "handlers" violates check constraint "handlers_role_name_check"
 DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1).
 -- This will work
 BEGIN;
-UPDATE omni_httpd.sqlets SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$,
+UPDATE omni_httpd.handlers SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$,
     role_name = 'test_user'
     WHERE role_name = 'test_user1' RETURNING role_name;
  role_name 

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -156,10 +156,10 @@ void http_worker(Datum db_oid) {
     SPI_connect();
 
     int ret = SPI_execute(
-        "SELECT listeners.address, listeners.port, sqlets.query, sqlets.role_name FROM "
-        "omni_httpd.listeners_sqlets "
-        "INNER JOIN omni_httpd.listeners ON listeners.id = listeners_sqlets.listener_id "
-        "INNER JOIN omni_httpd.sqlets sqlets ON sqlets.id = listeners_sqlets.sqlet_id",
+        "SELECT listeners.address, listeners.port, handlers.query, handlers.role_name FROM "
+        "omni_httpd.listeners_handlers "
+        "INNER JOIN omni_httpd.listeners ON listeners.id = listeners_handlers.listener_id "
+        "INNER JOIN omni_httpd.handlers handlers ON handlers.id = listeners_handlers.handler_id",
         false, 0);
     if (ret == SPI_OK_SELECT) {
       TupleDesc tupdesc = SPI_tuptable->tupdesc;

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -155,10 +155,12 @@ void http_worker(Datum db_oid) {
 
     SPI_connect();
 
-    int ret =
-        SPI_execute("SELECT listen.addr, listen.port, query, role_name FROM omni_httpd.listeners, "
-                    "unnest(omni_httpd.listeners.listen) AS listen",
-                    false, 0);
+    int ret = SPI_execute(
+        "SELECT listeners.address, listeners.port, sqlets.query, sqlets.role_name FROM "
+        "omni_httpd.listeners_sqlets "
+        "INNER JOIN omni_httpd.listeners ON listeners.id = listeners_sqlets.listener_id "
+        "INNER JOIN omni_httpd.sqlets sqlets ON sqlets.id = listeners_sqlets.sqlet_id",
+        false, 0);
     if (ret == SPI_OK_SELECT) {
       TupleDesc tupdesc = SPI_tuptable->tupdesc;
       SPITupleTable *tuptable = SPI_tuptable;

--- a/extensions/omni_httpd/master_worker.c
+++ b/extensions/omni_httpd/master_worker.c
@@ -256,9 +256,10 @@ void master_worker(Datum db_oid) {
     while (worker_reload) {
       worker_reload = false;
       if (SPI_execute(
-              "SELECT listeners.address, listeners.port FROM omni_httpd.listeners_sqlets  "
-              "INNER JOIN omni_httpd.listeners ON listeners.id = listeners_sqlets.listener_id "
-              "INNER JOIN omni_httpd.sqlets sqlets ON sqlets.id = listeners_sqlets.sqlet_id",
+              "SELECT listeners.address, listeners.port FROM omni_httpd.listeners_handlers  "
+              "INNER JOIN omni_httpd.listeners ON listeners.id = listeners_handlers.listener_id "
+              "INNER JOIN omni_httpd.handlers handlers ON handlers.id = "
+              "listeners_handlers.handler_id",
               false, 0) == SPI_OK_SELECT) {
         TupleDesc tupdesc = SPI_tuptable->tupdesc;
         SPITupleTable *tuptable = SPI_tuptable;

--- a/extensions/omni_httpd/master_worker.c
+++ b/extensions/omni_httpd/master_worker.c
@@ -255,9 +255,11 @@ void master_worker(Datum db_oid) {
     // Get listeners
     while (worker_reload) {
       worker_reload = false;
-      if (SPI_execute("SELECT listen.addr, listen.port FROM omni_httpd.listeners, "
-                      "unnest(omni_httpd.listeners.listen) AS listen",
-                      false, 0) == SPI_OK_SELECT) {
+      if (SPI_execute(
+              "SELECT listeners.address, listeners.port FROM omni_httpd.listeners_sqlets  "
+              "INNER JOIN omni_httpd.listeners ON listeners.id = listeners_sqlets.listener_id "
+              "INNER JOIN omni_httpd.sqlets sqlets ON sqlets.id = listeners_sqlets.sqlet_id",
+              false, 0) == SPI_OK_SELECT) {
         TupleDesc tupdesc = SPI_tuptable->tupdesc;
         SPITupleTable *tuptable = SPI_tuptable;
         cset_port ports = cset_port_init();

--- a/extensions/omni_httpd/master_worker.c
+++ b/extensions/omni_httpd/master_worker.c
@@ -218,11 +218,6 @@ void master_worker(Datum db_oid) {
     CommitTransactionCommand();
   }
 
-  // Start the transaction
-  SetCurrentStatementStartTimestamp();
-  StartTransactionCommand();
-  PushActiveSnapshot(GetTransactionSnapshot());
-
   // Prepare the event loop
   event_loop = h2o_evloop_create();
   prepare_share_fd();
@@ -233,9 +228,14 @@ void master_worker(Datum db_oid) {
 
   bool http_workers_started = false;
   bool port_ready = false;
-  SPI_connect();
 
   while (!shutdown_worker) {
+    // Start the transaction
+    SPI_connect();
+    SetCurrentStatementStartTimestamp();
+    StartTransactionCommand();
+    PushActiveSnapshot(GetTransactionSnapshot());
+
     // We clear this list every time to prepare an up-to-date version
     cvec_fd_clear(&sockets);
 
@@ -342,6 +342,19 @@ void master_worker(Datum db_oid) {
     }
     HandleMainLoopInterrupts();
 
+    // When the configuration is loaded, insert a reload event
+    // Next time http workers serve requests, they will be already using new data
+    int insert_retcode =
+        SPI_execute("INSERT INTO omni_httpd.configuration_reloads VALUES (DEFAULT)", false, 0);
+    if (insert_retcode != SPI_OK_INSERT) {
+      ereport(WARNING, errmsg("can't insert into omni_httpd.configuration_reloads: %s",
+                              SPI_result_code_string(insert_retcode)));
+    }
+
+    SPI_finish();
+    PopActiveSnapshot();
+    CommitTransactionCommand();
+
     // Start HTTP workers if they aren't already
     if (!http_workers_started) {
       BackgroundWorker worker = {.bgw_name = "omni_httpd worker",
@@ -370,6 +383,4 @@ void master_worker(Datum db_oid) {
     while (!shutdown_worker && !worker_reload && h2o_evloop_run(event_loop, INT32_MAX) == 0)
       ;
   }
-  SPI_finish();
-  AbortCurrentTransaction();
 }

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -130,7 +130,7 @@ WITH config AS
                      <p class="title">Welcome!</p>
                      <p class="subtitle">What's next?</p>
                      <div class="content">
-                     <p>You can update the query in the <code>omni_httpd.listeners</code> table to change this default page.</p>
+                     <p>You can update the query in the <code>omni_httpd.sqlets</code> table to change this default page.</p>
 
                      <p><a href="https://docs.omnigres.org">Documentation</a></p>
                      </div>

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -58,6 +58,23 @@ CREATE TABLE listeners_sqlets (
 );
 CREATE INDEX listeners_sqlets_index ON listeners_sqlets (listener_id, sqlet_id);
 
+CREATE TABLE configuration_reloads (
+    id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    happened_at timestamp NOT NULL DEFAULT now()
+);
+
+-- Wait for the number of configuration reloads to be `n` or greater
+-- Useful for testing
+CREATE PROCEDURE wait_for_configuration_reloads(n int) AS $$
+DECLARE
+c int;
+BEGIN
+LOOP
+ SELECT count(*) INTO c  FROM omni_httpd.configuration_reloads;
+ EXIT WHEN c >= n;
+END LOOP;
+END;
+$$ LANGUAGE plpgsql;
 
 CREATE FUNCTION reload_configuration_trigger() RETURNS trigger
     AS 'MODULE_PATHNAME', 'reload_configuration'

--- a/extensions/omni_httpd/sql/http.sql
+++ b/extensions/omni_httpd/sql/http.sql
@@ -8,7 +8,7 @@ INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
 
 BEGIN;
 WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9000) RETURNING id),
-     sqlet AS (INSERT INTO omni_httpd.sqlets (query) VALUES (
+     handler AS (INSERT INTO omni_httpd.handlers (query) VALUES (
 $$
 WITH
 hello AS
@@ -32,9 +32,9 @@ SELECT * FROM echo WHERE NOT EXISTS (SELECT 1 from headers)
 UNION ALL
 SELECT * FROM not_found WHERE NOT EXISTS (SELECT 1 from echo)
 $$) RETURNING id)
-INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id)
-SELECT listener.id, sqlet.id
-FROM listener, sqlet;
+INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
+SELECT listener.id, handler.id
+FROM listener, handler;
 DELETE FROM omni_httpd.configuration_reloads;
 END;
 
@@ -58,9 +58,9 @@ BEGIN;
 
 UPDATE omni_httpd.listeners SET port = 9001 WHERE port = 9000;
 WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9002) RETURNING id),
-     sqlet AS (SELECT ls.sqlet_id AS id FROM omni_httpd.listeners INNER JOIN omni_httpd.listeners_sqlets ls ON ls.listener_id = listeners.id WHERE port = 9001)
-INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id)
- SELECT listener.id, sqlet.id FROM listener, sqlet;
+     handler AS (SELECT ls.handler_id AS id FROM omni_httpd.listeners INNER JOIN omni_httpd.listeners_handlers ls ON ls.listener_id = listeners.id WHERE port = 9001)
+INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
+ SELECT listener.id, handler.id FROM listener, handler;
 
 DELETE FROM omni_httpd.configuration_reloads;
 END;

--- a/extensions/omni_httpd/sql/http.sql
+++ b/extensions/omni_httpd/sql/http.sql
@@ -6,7 +6,9 @@ CREATE TABLE users (
 
 INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
 
-INSERT INTO omni_httpd.listeners (listen, query) VALUES (array[row('127.0.0.1', 9000)::omni_httpd.listenaddress], $$
+WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9000) RETURNING id),
+     sqlet AS (INSERT INTO omni_httpd.sqlets (query) VALUES (
+$$
 WITH
 hello AS
 (SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!')
@@ -28,7 +30,10 @@ UNION ALL
 SELECT * FROM echo WHERE NOT EXISTS (SELECT 1 from headers)
 UNION ALL
 SELECT * FROM not_found WHERE NOT EXISTS (SELECT 1 from echo)
-$$);
+$$) RETURNING id)
+INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id)
+SELECT listener.id, sqlet.id
+FROM listener, sqlet;
 
 -- Now, the actual tests
 
@@ -44,19 +49,18 @@ $$);
 
 -- Try changing configuration
 
-UPDATE omni_httpd.listeners SET listen = array[row('127.0.0.1', 9001)::omni_httpd.listenaddress,
-                                               row('127.0.0.1', 9002)::omni_httpd.listenaddress
-];
+BEGIN;
+
+UPDATE omni_httpd.listeners SET port = 9001 WHERE port = 9000;
+WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9002) RETURNING id),
+     sqlet AS (SELECT ls.sqlet_id AS id FROM omni_httpd.listeners INNER JOIN omni_httpd.listeners_sqlets ls ON ls.listener_id = listeners.id WHERE port = 9001)
+INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id)
+ SELECT listener.id, sqlet.id FROM listener, sqlet;
+
+END;
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9001/test?q=1
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9002/test?q=1
 
 \! curl --silent http://localhost:9000/test?q=1 || echo "failed as it should"
-
-INSERT INTO omni_httpd.listeners (listen, query) VALUES (array[row('127.0.0.1', 9001)::omni_httpd.listenaddress], $$
-SELECT omni_httpd.http_response(body => 'another port') FROM request
-$$);
-
--- Ensure we serve correct query for a different listener
-\! curl --retry-connrefused --retry 10 --retry-max-time 10 --silent http://localhost:9001

--- a/extensions/omni_httpd/sql/role_name.sql
+++ b/extensions/omni_httpd/sql/role_name.sql
@@ -4,24 +4,27 @@ CREATE ROLE test_user1 INHERIT IN ROLE current_user;
 SET ROLE test_user;
 
 -- Should use current_user as a default role_name
-INSERT INTO omni_httpd.listeners (listen, query) VALUES (array[row('127.0.0.1', 9003)::omni_httpd.listenaddress], $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$) RETURNING role_name;
+WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9003) RETURNING id),
+     sqlet AS (INSERT INTO omni_httpd.sqlets (query) VALUES (
+$$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$) RETURNING id)
+INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id) SELECT listener.id, sqlet.id FROM listener, sqlet;
 
 -- Can't update it to an arbitrary name
-UPDATE omni_httpd.listeners SET role_name = 'some_role' WHERE role_name = 'test_user';
+UPDATE omni_httpd.sqlets SET role_name = 'some_role' WHERE role_name = 'test_user';
 
 -- Can't update it to a name that is not a current user
-UPDATE omni_httpd.listeners SET role_name = 'test_user1' WHERE role_name = 'test_user';
+UPDATE omni_httpd.sqlets SET role_name = 'test_user1' WHERE role_name = 'test_user';
 
 -- Can update it to a name that is a current user
 SET ROLE test_user1;
-UPDATE omni_httpd.listeners SET role_name = 'test_user1' WHERE role_name = 'test_user';
+UPDATE omni_httpd.sqlets SET role_name = 'test_user1' WHERE role_name = 'test_user';
 
 -- When changing the query, should always set current user
 SET ROLE test_user;
-UPDATE omni_httpd.listeners SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$
+UPDATE omni_httpd.sqlets SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$
     WHERE role_name = 'test_user1' RETURNING role_name;
   -- This will work
-UPDATE omni_httpd.listeners SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$,
+UPDATE omni_httpd.sqlets SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$,
     role_name = 'test_user'
     WHERE role_name = 'test_user1' RETURNING role_name;
 

--- a/extensions/omni_httpd/sql/role_name.sql
+++ b/extensions/omni_httpd/sql/role_name.sql
@@ -4,30 +4,51 @@ CREATE ROLE test_user1 INHERIT IN ROLE current_user;
 SET ROLE test_user;
 
 -- Should use current_user as a default role_name
+BEGIN;
 WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9003) RETURNING id),
      sqlet AS (INSERT INTO omni_httpd.sqlets (query) VALUES (
 $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$) RETURNING id)
 INSERT INTO omni_httpd.listeners_sqlets (listener_id, sqlet_id) SELECT listener.id, sqlet.id FROM listener, sqlet;
+DELETE FROM omni_httpd.configuration_reloads;
+END;
+
+CALL omni_httpd.wait_for_configuration_reloads(1);
 
 -- Can't update it to an arbitrary name
+BEGIN;
 UPDATE omni_httpd.sqlets SET role_name = 'some_role' WHERE role_name = 'test_user';
+DELETE FROM omni_httpd.configuration_reloads;
+END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
 
 -- Can't update it to a name that is not a current user
+BEGIN;
 UPDATE omni_httpd.sqlets SET role_name = 'test_user1' WHERE role_name = 'test_user';
+DELETE FROM omni_httpd.configuration_reloads;
+END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
 
 -- Can update it to a name that is a current user
 SET ROLE test_user1;
+BEGIN;
 UPDATE omni_httpd.sqlets SET role_name = 'test_user1' WHERE role_name = 'test_user';
+DELETE FROM omni_httpd.configuration_reloads;
+END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
 
 -- When changing the query, should always set current user
 SET ROLE test_user;
 UPDATE omni_httpd.sqlets SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$
     WHERE role_name = 'test_user1' RETURNING role_name;
-  -- This will work
+-- This will work
+BEGIN;
 UPDATE omni_httpd.sqlets SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$,
     role_name = 'test_user'
     WHERE role_name = 'test_user1' RETURNING role_name;
 
-SELECT omni_httpd.reload_configuration();
+DELETE FROM omni_httpd.configuration_reloads;
+END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
+
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/


### PR DESCRIPTION
It conflates listeners and queries to execute and will not work well when HTTPS support will be added.

Solution: normalize omni_httpd configuration

Now there are three tables (`listeners`,`sqlets` and `listeners_sqlets`) that serve the same purpose. It gets a little noisier to work with these but this shouldn't happen often.