### PR TITLE
Problem: changes in script files don't make it

### DIFF
--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -136,7 +136,7 @@ function(add_postgresql_extension NAME)
     set(_script_files)
 
     foreach(_script_file ${_ext_SCRIPTS})
-        file(CREATE_LINK "${CMAKE_CURRENT_SOURCE_DIR}/${_script_file}" "${_ext_dir}/${_script_file}")
+        file(CREATE_LINK "${CMAKE_CURRENT_SOURCE_DIR}/${_script_file}" "${_ext_dir}/${_script_file}" SYMBOLIC)
         list(APPEND _script_files ${_ext_dir}/${_script_file})
     endforeach()
 


### PR DESCRIPTION
When I change script file in an extension, and build the extension, the new version of the script file does not get picked up.

Solution: ensure it is symbolically linked
instead of being a hard link

I've noticed that previously, only rerunning `cmake` was updating the file.

The original intention was to have this file symlinked, but I did not understand CREATE_LINK's default behaviour.