### PR TITLE
Problem: writing cascading routing queries by hand

### DIFF
--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -21,9 +21,9 @@ add_postgresql_extension(
         SCHEMA omni_httpd
         RELOCATABLE false
         SCRIPTS omni_httpd--0.1.sql
-        SOURCES omni_httpd.c master_worker.c http_worker.c fd.c
+        SOURCES omni_httpd.c master_worker.c http_worker.c fd.c cascading_query.c
         TESTS_REQUIRE omni_ext
-        REGRESS http role_name)
+        REGRESS http role_name cascading_query)
 
 target_link_libraries(omni_httpd libh2o-evloop libpgaug libomnisql libgluepg_stc dynpgext metalang99)
 

--- a/extensions/omni_httpd/cascading_query.c
+++ b/extensions/omni_httpd/cascading_query.c
@@ -137,15 +137,15 @@ Datum cascading_query_reduce(PG_FUNCTION_ARGS) {
     const ListCell *lc = NULL;
     // Rename every sub-CTE to include the CTE name
     foreach (lc, (*withClause)->ctes) {
-        CommonTableExpr *cte = castNode(CommonTableExpr, lfirst(lc));
-        char *from = cte->ctename;
-        // Rename references by aliasing CTE references. To mitigate the risk of the name
-        // collision with a relation defined outside of the query, we'll prefix them.
-        // But a more sophisticated approach can be used to detect collisions (TODO)
-        cte->ctename = psprintf("__omni_httpd_%s_%s", text_to_cstring(name), cte->ctename);
-        struct rename rename = {.from = from, .len = strlen(from), .to = cte->ctename};
-        raw_expression_tree_walker(castNode(RawStmt, linitial(parsed_query))->stmt, renaming_walker,
-                                   &rename);
+      CommonTableExpr *cte = castNode(CommonTableExpr, lfirst(lc));
+      char *from = cte->ctename;
+      // Rename references by aliasing CTE references. To mitigate the risk of the name
+      // collision with a relation defined outside of the query, we'll prefix them.
+      // But a more sophisticated approach can be used to detect collisions (TODO)
+      cte->ctename = psprintf("__omni_httpd_%s_%s", text_to_cstring(name), cte->ctename);
+      struct rename rename = {.from = from, .len = strlen(from), .to = cte->ctename};
+      raw_expression_tree_walker(castNode(RawStmt, linitial(parsed_query))->stmt, renaming_walker,
+                                 &rename);
     }
     // Move the CTEs to the top level
     if ((*stmtWithClause)->ctes == NULL) {

--- a/extensions/omni_httpd/cascading_query.c
+++ b/extensions/omni_httpd/cascading_query.c
@@ -91,6 +91,7 @@ Datum cascading_query_reduce(PG_FUNCTION_ARGS) {
     setop->larg = original_select_stmt;
     setop->rarg = select;
     setop->withClause = original_select_stmt->withClause;
+    setop->all = true;
     original_select_stmt->withClause = NULL;
 
     original_stmt->stmt = (Node *)setop;

--- a/extensions/omni_httpd/cascading_query.c
+++ b/extensions/omni_httpd/cascading_query.c
@@ -1,0 +1,115 @@
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
+#include <omni_sql.h>
+
+PG_FUNCTION_INFO_V1(cascading_query_reduce);
+
+PG_FUNCTION_INFO_V1(cascading_query_final);
+
+#define ARG_STATE 0
+#define ARG_NAME 1
+#define ARG_QUERY 2
+
+Datum cascading_query_reduce(PG_FUNCTION_ARGS) {
+  List *stmts;
+
+  MemoryContext memory_context;
+  if (AggCheckCallContext(fcinfo, &memory_context) != 1) {
+    ereport(ERROR, errmsg("must be called as a regular aggregate"));
+  }
+
+  MemoryContext old_context = MemoryContextSwitchTo(memory_context);
+
+  if PG_ARGISNULL (ARG_NAME) {
+    ereport(ERROR, errmsg("name can't be NULL"));
+  }
+
+  if PG_ARGISNULL (ARG_QUERY) {
+    ereport(ERROR, errmsg("query can't be NULL"));
+  }
+
+  // We already have the query
+  bool initialized = true;
+
+  if PG_ARGISNULL (ARG_STATE) {
+    stmts = omni_sql_parse_statement("SELECT");
+    initialized = false;
+  } else {
+    stmts = (List *)PG_GETARG_POINTER(ARG_STATE);
+  }
+
+  text *name = PG_GETARG_TEXT_PP(ARG_NAME);
+  char *query = text_to_cstring(PG_GETARG_TEXT_PP(ARG_QUERY));
+
+  RawStmt *original_stmt = castNode(RawStmt, linitial(stmts));
+  SelectStmt *original_select_stmt = castNode(SelectStmt, original_stmt->stmt);
+
+  // SELECT * FROM {name}
+  SelectStmt *select = makeNode(SelectStmt);
+  ResTarget *resTarget = makeNode(ResTarget);
+  ColumnRef *star = makeNode(ColumnRef);
+  star->fields = list_make1(makeNode(A_Star));
+  resTarget->val = (Node *)star;
+  select->targetList = list_make1(resTarget);
+  RangeVar *from = makeNode(RangeVar);
+  from->inh = true;
+  from->relname = text_to_cstring(name);
+  select->fromClause = list_make1(from);
+
+  if (!initialized) {
+    original_stmt->stmt = (Node *)select;
+  } else {
+    char *previous_name =
+        llast_node(CommonTableExpr, original_select_stmt->withClause->ctes)->ctename;
+
+    // SELECT true FROM {previous_name}
+    SelectStmt *subQuery = makeNode(SelectStmt);
+    ResTarget *subResTarget = makeNode(ResTarget);
+    ColumnRef *subRes = makeNode(ColumnRef);
+    subResTarget->val = (Node *)star;
+    RangeVar *subFrom = makeNode(RangeVar);
+    subFrom->inh = true;
+    subFrom->relname = previous_name;
+    subQuery->fromClause = list_make1(subFrom);
+
+    // NOT EXISTS (SELECT FROM {previous_name})
+    BoolExpr *parent = makeNode(BoolExpr);
+    parent->boolop = NOT_EXPR;
+    SubLink *subLink = makeNode(SubLink);
+    subLink->subLinkType = EXISTS_SUBLINK;
+    subLink->subselect = (Node *)subQuery;
+    parent->args = list_make1(subLink);
+    select->whereClause = (Node *)parent;
+
+    // {existing_query} UNION ALL SELECT * FROM {name} WHERE NOT EXISTS (SELECT FROM {previous_name}
+    SelectStmt *setop = castNode(SelectStmt, makeNode(SelectStmt));
+
+    setop->op = SETOP_UNION;
+    setop->larg = original_select_stmt;
+    setop->rarg = select;
+    setop->withClause = original_select_stmt->withClause;
+    original_select_stmt->withClause = NULL;
+
+    original_stmt->stmt = (Node *)setop;
+  }
+
+  omni_sql_add_cte(stmts, name, omni_sql_parse_statement(query), false, false);
+
+  MemoryContextSwitchTo(old_context);
+
+  PG_RETURN_POINTER(stmts);
+}
+
+Datum cascading_query_final(PG_FUNCTION_ARGS) {
+  List *stmts;
+
+  if PG_ARGISNULL (ARG_STATE) {
+    stmts = omni_sql_parse_statement("SELECT");
+  } else {
+    stmts = (List *)PG_GETARG_POINTER(ARG_STATE);
+  }
+  PG_RETURN_TEXT_P(cstring_to_text(omni_sql_deparse_statement(stmts)));
+}

--- a/extensions/omni_httpd/docs/intro.md
+++ b/extensions/omni_httpd/docs/intro.md
@@ -1,0 +1,91 @@
+# Intro
+
+omni_httpd is an embedded HTTP server for Postgres. It allows one to write HTTP request handling in SQL.
+This approach lends to less indirection that is common in traditional application architectures, where applications
+are interacting with the database directly.
+
+## Getting started.
+
+By default, `omni_httpd`, once installed, will provide a default page on port `8080`.
+
+You can change the handler by updating the `query` column in the `handlers` table. Currently, the idiomatic way
+to write this query is to use `omni_httpd.cascading_query` aggregate function (though, of course, one can roll their
+own SQL completely by hand). This function simplifies building priority-sorted request handling:
+
+```sql
+UPDATE omni_httpd.handlers SET query = 
+(SELECT omni_httpd.cascading_query(name, query) FROM (VALUES
+      ('headers',
+      $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$),
+      ('not_found',
+      $$SELECT omni_httpd.http_response(status => 404, body => 'Not found') FROM request$$))
+     AS routes(name,query));
+```
+
+The query called `headers` will dump request's headers, `not_found` will return HTTP 404. We can test it with `curl`:
+
+```shell
+$ curl http://localhost:8080
+Not found
+$ curl http://localhost:8080/headers
+{"(user-agent,curl/7.86.0,t)","(accept,*/*,t)"}
+```
+
+The above method of defining the handler can work well when the queries that it is composed of are either stored in a
+database
+or can be retrieved during deployment (say, from a Git repository or any other source.)
+
+??? question "What did you mean by "priority-sorted" request handling?"
+
+    If you look at the order of handlers we added (`headers` followed by
+    `not_found`), it means that `cascading_query`-built query will first try to get results from `headers` and if none available, will
+    attempt `not_found`. Suppose we changed the order:
+
+    ```sql
+    UPDATE omni_httpd.handlers SET query = 
+    (SELECT omni_httpd.cascading_query(name, query) FROM (VALUES 
+          ('not_found',
+          $$SELECT omni_httpd.http_response(status => 404, body => 'Not found') FROM request$$),
+          ('headers',
+          $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$))
+         AS routes(name,query));
+    ```
+    
+    Then `not_found` will always take the precedence:
+    
+    ```shell
+    $ curl http://localhost:8080
+    Not found
+    $ curl http://localhost:8080/headers
+    Not found
+    ```
+
+??? question "What does `cascading_query` do?"
+
+    The idea behind `cascading_query` is that it aggregates named queries in a `UNION` query where all given queries
+    will become common table expressions (CTEs) and the `UNION` will be used to cascade over them, something like:
+
+    ```sql
+    WITH headers AS (...),
+         not_found AS (...)
+    SELECT * FROM headers
+    UNION ALL
+    SELECT * FROM not_found WHERE NOT EXISTS (SELECT FROM headers)
+    ```
+
+All good. But looking back into the queries itself, they mention `request` which is nowhere to be found. Where does this
+come from? This is actually a CTE that `omni_httpd` supplies in runtime that has the following `omni_httpd.http_request`
+signature:
+
+```sql
+method omni_httpd.http_method,
+path text,
+query_string text,
+body bytea,
+headers omni_httpd.http_header[]
+```
+
+!!! tip
+
+    If this signature seem a little incomplete (where's the source IP address, can the body by streamed, etc.?),
+    that's because it is still work in progress. Please consider contributing if you feel up to it.

--- a/extensions/omni_httpd/expected/cascading_query.out
+++ b/extensions/omni_httpd/expected/cascading_query.out
@@ -15,8 +15,8 @@ SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORD
 --------------------------------------------------------------------------------
  WITH test AS (SELECT omni_httpd.http_response(body := 'test') FROM request WHE.
 .RE request.path = '/test'), ping AS (SELECT omni_httpd.http_response(body := '.
-.pong') FROM request WHERE request.path = '/ping') SELECT * FROM test UNION SEL.
-.ECT * FROM ping WHERE NOT EXISTS (SELECT FROM test)
+.pong') FROM request WHERE request.path = '/ping') SELECT * FROM test UNION ALL.
+. SELECT * FROM ping WHERE NOT EXISTS (SELECT FROM test)
 (1 row)
 
 \pset format aligned

--- a/extensions/omni_httpd/expected/cascading_query.out
+++ b/extensions/omni_httpd/expected/cascading_query.out
@@ -1,0 +1,38 @@
+CREATE TABLE routes (
+   name text NOT NULL,
+   query text NOT NULL,
+   priority INT NOT NULL
+);
+INSERT INTO routes (name, query, priority) VALUES
+  ('test', $$SELECT omni_httpd.http_response(body => 'test') FROM request WHERE request.path = '/test'$$, 1);
+INSERT INTO routes (name, query, priority) VALUES
+  ('ping', $$SELECT omni_httpd.http_response(body => 'pong') FROM request WHERE request.path = '/ping'$$, 1);
+\pset format wrapped
+\pset columns 80
+-- Preview the query
+SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORDER BY priority DESC;
+                                cascading_query                                 
+--------------------------------------------------------------------------------
+ WITH test AS (SELECT omni_httpd.http_response(body := 'test') FROM request WHE.
+.RE request.path = '/test'), ping AS (SELECT omni_httpd.http_response(body := '.
+.pong') FROM request WHERE request.path = '/ping') SELECT * FROM test UNION SEL.
+.ECT * FROM ping WHERE NOT EXISTS (SELECT FROM test)
+(1 row)
+
+\pset format aligned
+-- Try it
+BEGIN;
+WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9100) RETURNING id),
+     handler AS (INSERT INTO omni_httpd.handlers (query) SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORDER BY priority DESC RETURNING id)
+INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
+SELECT listener.id, handler.id
+FROM listener, handler;
+DELETE FROM omni_httpd.configuration_reloads;
+END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 -w '\n\n' --silent http://localhost:9100/test
+test
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 -w '\n\n' --silent http://localhost:9100/ping
+pong
+

--- a/extensions/omni_httpd/expected/cascading_query.out
+++ b/extensions/omni_httpd/expected/cascading_query.out
@@ -4,8 +4,7 @@ CREATE TABLE routes (
    priority INT NOT NULL
 );
 INSERT INTO routes (name, query, priority) VALUES
-  ('test', $$SELECT omni_httpd.http_response(body => 'test') FROM request WHERE request.path = '/test'$$, 1);
-INSERT INTO routes (name, query, priority) VALUES
+  ('test', $$SELECT omni_httpd.http_response(body => 'test') FROM request WHERE request.path = '/test'$$, 1),
   ('ping', $$SELECT omni_httpd.http_response(body => 'pong') FROM request WHERE request.path = '/ping'$$, 1);
 \pset format wrapped
 \pset columns 80
@@ -36,3 +35,23 @@ test
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 -w '\n\n' --silent http://localhost:9100/ping
 pong
 
+-- CTE handling
+\pset format wrapped
+\pset columns 80
+SELECT omni_httpd.cascading_query(name, query) FROM (
+  VALUES
+  ('test', $$WITH test AS (SELECT 1 AS val) SELECT omni_httpd.http_response(body => 'test') FROM request, Test WHERE request.path = '/test' and test.val = 1$$, 1),
+  ('ping', $$WITH test AS (SELECT 1 AS val) SELECT omni_httpd.http_response(body => 'pong') FROM request, Test WHERE request.path = '/ping' and test.val = 1$$, 1))
+  AS routes(name, query, priority) GROUP BY priority ORDER BY priority DESC;
+                                cascading_query                                 
+--------------------------------------------------------------------------------
+ WITH __omni_httpd_test_test AS (SELECT 1 AS val), test AS (WITH SELECT omni_ht.
+.tpd.http_response(body := 'test') FROM request, __omni_httpd_test_test test WH.
+.ERE request.path = '/test' AND test.val = 1), __omni_httpd_ping_test AS (SELEC.
+.T 1 AS val), ping AS (WITH SELECT omni_httpd.http_response(body := 'pong') FRO.
+.M request, __omni_httpd_ping_test test WHERE request.path = '/ping' AND test.v.
+.al = 1) SELECT * FROM test UNION ALL SELECT * FROM ping WHERE NOT EXISTS (SELE.
+.CT FROM test)
+(1 row)
+
+ \pset format aligned

--- a/extensions/omni_httpd/expected/http.out
+++ b/extensions/omni_httpd/expected/http.out
@@ -6,30 +6,22 @@ CREATE TABLE users (
 INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
 BEGIN;
 WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9000) RETURNING id),
-     handler AS (INSERT INTO omni_httpd.handlers (query) VALUES (
-$$
-WITH
-hello AS
-(SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!')
+     handler AS (INSERT INTO omni_httpd.handlers (query)
+     SELECT omni_httpd.cascading_query(name, query) FROM (VALUES
+      ('hello',
+      $$SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!')
        FROM request
        INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
-),
-headers AS
-(SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'),
-echo AS
-(SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'),
-not_found AS
-(
-SELECT omni_httpd.http_response(status => 404, body => json_build_object('method', request.method, 'path', request.path, 'query_string', request.query_string))
-       FROM request)
-SELECT * FROM hello
-UNION ALL
-SELECT * FROM headers WHERE NOT EXISTS (SELECT 1 from hello)
-UNION ALL
-SELECT * FROM echo WHERE NOT EXISTS (SELECT 1 from headers)
-UNION ALL
-SELECT * FROM not_found WHERE NOT EXISTS (SELECT 1 from echo)
-$$) RETURNING id)
+      $$),
+      ('headers',
+      $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$),
+      ('echo',
+      $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$),
+      ('not_found',
+      $$SELECT omni_httpd.http_response(status => 404, body => json_build_object('method', request.method, 'path', request.path, 'query_string', request.query_string))
+       FROM request$$)
+     ) AS routes(name,query)
+RETURNING id)
 INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
 SELECT listener.id, handler.id
 FROM listener, handler;

--- a/extensions/omni_httpd/mkdocs.yml
+++ b/extensions/omni_httpd/mkdocs.yml
@@ -1,0 +1,2 @@
+INHERIT: ../../mkdocs.base.yml
+site_name: omni_httpd

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -99,6 +99,18 @@ CREATE TRIGGER listeners_handlers_updated
     ON listeners_handlers
 EXECUTE FUNCTION reload_configuration_trigger();
 
+CREATE FUNCTION cascading_query_reduce(internal, name text, query text) RETURNS internal
+ AS 'MODULE_PATHNAME', 'cascading_query_reduce' LANGUAGE C;
+
+CREATE FUNCTION cascading_query_final(internal) RETURNS text
+ AS 'MODULE_PATHNAME', 'cascading_query_final' LANGUAGE C;
+
+CREATE AGGREGATE cascading_query (name text, query text) (
+  sfunc = cascading_query_reduce,
+  finalfunc = cascading_query_final,
+  stype = internal
+ );
+
 -- Initialization
 WITH config AS
          (SELECT coalesce(NOT current_setting('omni_httpd.no_init', true)::bool, true)     AS should_init,

--- a/extensions/omni_httpd/sql/cascading_query.sql
+++ b/extensions/omni_httpd/sql/cascading_query.sql
@@ -1,0 +1,35 @@
+CREATE TABLE routes (
+   name text NOT NULL,
+   query text NOT NULL,
+   priority INT NOT NULL
+);
+
+INSERT INTO routes (name, query, priority) VALUES
+  ('test', $$SELECT omni_httpd.http_response(body => 'test') FROM request WHERE request.path = '/test'$$, 1);
+
+INSERT INTO routes (name, query, priority) VALUES
+  ('ping', $$SELECT omni_httpd.http_response(body => 'pong') FROM request WHERE request.path = '/ping'$$, 1);
+
+\pset format wrapped
+\pset columns 80
+
+-- Preview the query
+SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORDER BY priority DESC;
+
+\pset format aligned
+
+-- Try it
+BEGIN;
+WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9100) RETURNING id),
+     handler AS (INSERT INTO omni_httpd.handlers (query) SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORDER BY priority DESC RETURNING id)
+INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
+SELECT listener.id, handler.id
+FROM listener, handler;
+DELETE FROM omni_httpd.configuration_reloads;
+END;
+
+CALL omni_httpd.wait_for_configuration_reloads(1);
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 -w '\n\n' --silent http://localhost:9100/test
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 -w '\n\n' --silent http://localhost:9100/ping

--- a/extensions/omni_httpd/sql/cascading_query.sql
+++ b/extensions/omni_httpd/sql/cascading_query.sql
@@ -5,9 +5,7 @@ CREATE TABLE routes (
 );
 
 INSERT INTO routes (name, query, priority) VALUES
-  ('test', $$SELECT omni_httpd.http_response(body => 'test') FROM request WHERE request.path = '/test'$$, 1);
-
-INSERT INTO routes (name, query, priority) VALUES
+  ('test', $$SELECT omni_httpd.http_response(body => 'test') FROM request WHERE request.path = '/test'$$, 1),
   ('ping', $$SELECT omni_httpd.http_response(body => 'pong') FROM request WHERE request.path = '/ping'$$, 1);
 
 \pset format wrapped
@@ -33,3 +31,16 @@ CALL omni_httpd.wait_for_configuration_reloads(1);
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 -w '\n\n' --silent http://localhost:9100/test
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 -w '\n\n' --silent http://localhost:9100/ping
+
+-- CTE handling
+
+\pset format wrapped
+\pset columns 80
+
+SELECT omni_httpd.cascading_query(name, query) FROM (
+  VALUES
+  ('test', $$WITH test AS (SELECT 1 AS val) SELECT omni_httpd.http_response(body => 'test') FROM request, Test WHERE request.path = '/test' and test.val = 1$$, 1),
+  ('ping', $$WITH test AS (SELECT 1 AS val) SELECT omni_httpd.http_response(body => 'pong') FROM request, Test WHERE request.path = '/ping' and test.val = 1$$, 1))
+  AS routes(name, query, priority) GROUP BY priority ORDER BY priority DESC;
+
+ \pset format aligned

--- a/extensions/omni_sql/lib.c
+++ b/extensions/omni_sql/lib.c
@@ -54,7 +54,7 @@ dispatch:
     *with = &delete->withClause;
     break;
   }
-#if PG_VERSION_NUM >= 15
+#if PG_MAJORVERSION_NUM >= 15
   case T_MergeStmt: {
     MergeStmt *delete = castNode(MergeStmt, curNode);
     *with = &delete->withClause;

--- a/extensions/omni_sql/lib.c
+++ b/extensions/omni_sql/lib.c
@@ -25,6 +25,48 @@ List *omni_sql_parse_statement(char *statement) {
   return stmts;
 }
 
+bool omni_sql_get_with_clause(Node *node, WithClause ***with) {
+  Node *curNode = node;
+dispatch:
+  switch (nodeTag(curNode)) {
+  case T_RawStmt: {
+    RawStmt *stmt = castNode(RawStmt, curNode);
+    curNode = stmt->stmt;
+    goto dispatch;
+  }
+  case T_SelectStmt: {
+    SelectStmt *select = castNode(SelectStmt, curNode);
+    *with = &select->withClause;
+    break;
+  }
+  case T_InsertStmt: {
+    InsertStmt *insert = castNode(InsertStmt, curNode);
+    *with = &insert->withClause;
+    break;
+  }
+  case T_UpdateStmt: {
+    UpdateStmt *update = castNode(UpdateStmt, curNode);
+    *with = &update->withClause;
+    break;
+  }
+  case T_DeleteStmt: {
+    DeleteStmt *delete = castNode(DeleteStmt, curNode);
+    *with = &delete->withClause;
+    break;
+  }
+#if PG_VERSION_NUM >= 15
+  case T_MergeStmt: {
+    MergeStmt *delete = castNode(MergeStmt, curNode);
+    *with = &delete->withClause;
+    break;
+  }
+#endif
+  default:
+    return false;
+  }
+  return true;
+}
+
 List *omni_sql_add_cte(List *stmts, text *cte_name, List *cte_stmts, bool recursive, bool prepend) {
 
   if (list_length(stmts) != 1) {
@@ -37,54 +79,19 @@ List *omni_sql_add_cte(List *stmts, text *cte_name, List *cte_stmts, bool recurs
 
   void *node = linitial(stmts);
 
-  CommonTableExpr *cte_node = palloc0(sizeof(*cte_node));
+  CommonTableExpr *cte_node = makeNode(CommonTableExpr);
+  cte_node->ctename = text_to_cstring(cte_name);
+  cte_node->ctematerialized = CTEMaterializeDefault;
+  cte_node->ctequery = linitial_node(RawStmt, cte_stmts)->stmt;
+  cte_node->cterecursive = recursive;
 
-  *cte_node = (CommonTableExpr) {
-    .type = T_CommonTableExpr, .ctename = text_to_cstring(cte_name), .aliascolnames = NULL,
-    .ctematerialized = CTEMaterializeDefault, .ctequery = linitial_node(RawStmt, cte_stmts)->stmt,
-#if PG_VERSION_MAJORNUM >= 14
-    .search_clause = NULL, .cycle_clause = NULL,
-#endif
-    .location = -1, // unknown location
-        .cterecursive = recursive, .cterefcount = 0, .ctecolnames = NULL, .ctecoltypes = NULL,
-    .ctecoltypmods = NULL, .ctecolcollations = NULL
-  };
-
-  WithClause **with = NULL;
-dispatch:
-  switch (nodeTag(node)) {
-  case T_RawStmt: {
-    RawStmt *stmt = castNode(RawStmt, node);
-    node = stmt->stmt;
-    goto dispatch;
-  }
-  case T_SelectStmt: {
-    SelectStmt *select = castNode(SelectStmt, node);
-    with = &select->withClause;
-    break;
-  }
-  case T_InsertStmt: {
-    InsertStmt *insert = castNode(InsertStmt, node);
-    with = &insert->withClause;
-    break;
-  }
-  case T_UpdateStmt: {
-    UpdateStmt *update = castNode(UpdateStmt, node);
-    with = &update->withClause;
-    break;
-  }
-  case T_DeleteStmt: {
-    DeleteStmt *delete = castNode(DeleteStmt, node);
-    with = &delete->withClause;
-    break;
-  }
-  default:
+  WithClause **with;
+  if (!omni_sql_get_with_clause(node, &with)) {
     ereport(ERROR, errmsg("no supported statement found"));
   }
 
   if (*with == NULL) {
-    WithClause *new_with = palloc(sizeof(*new_with));
-    new_with->type = T_WithClause;
+    WithClause *new_with = makeNode(WithClause);
     new_with->location = -1;
     new_with->recursive = recursive;
     new_with->ctes = list_make1(cte_node);

--- a/extensions/omni_sql/omni_sql.h
+++ b/extensions/omni_sql/omni_sql.h
@@ -14,7 +14,11 @@
 #include "deparse.h"
 
 List *omni_sql_parse_statement(char *statement);
+
+bool omni_sql_get_with_clause(Node *node, WithClause ***with);
+
 List *omni_sql_add_cte(List *stmts, text *cte_name, List *cte_stmts, bool recursive, bool prepend);
+
 bool omni_sql_is_parameterized(List *stmts);
 
 #endif // OMNI_SQL_H

--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -22,8 +22,10 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - pymdownx.details
   - toc:
       permalink: true
+  - admonition
 
 plugins:
   - search


### PR DESCRIPTION
Writing something like this:

```sql
WITH test AS (SELECT omni_httpd.http_response(body := 'test') FROM request
              WHEREE request.path = '/test'),
     ping AS (SELECT omni_httpd.http_response(body := 'pong') FROM request WHERE request.path = '/ping')
SELECT * FROM test
UNION SELECT * FROM ping WHERE NOT EXISTS (SELECT FROM test)
```

is tedious and error-prone, especially when it comes to the union part.

Solution: make an aggregate function that simplifies this