### PR TITLE
Problem: omni_httpd.handlers queries can lead to runtime errors

### DIFF
--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -23,7 +23,7 @@ add_postgresql_extension(
         SCRIPTS omni_httpd--0.1.sql
         SOURCES omni_httpd.c master_worker.c http_worker.c fd.c cascading_query.c
         TESTS_REQUIRE omni_ext
-        REGRESS http role_name cascading_query)
+        REGRESS http role_name cascading_query handler_validity)
 
 target_link_libraries(omni_httpd libh2o-evloop libpgaug libomnisql libgluepg_stc dynpgext metalang99)
 

--- a/extensions/omni_httpd/cascading_query.c
+++ b/extensions/omni_httpd/cascading_query.c
@@ -156,7 +156,7 @@ Datum cascading_query_reduce(PG_FUNCTION_ARGS) {
     (*withClause)->ctes = NULL;
   }
 
-  omni_sql_add_cte(stmts, name, parsed_query, false, false);
+  omni_sql_add_cte(stmts, text_to_cstring(name), parsed_query, false, false);
 
   MemoryContextSwitchTo(old_context);
 

--- a/extensions/omni_httpd/docs/intro.md
+++ b/extensions/omni_httpd/docs/intro.md
@@ -22,6 +22,17 @@ UPDATE omni_httpd.handlers SET query =
      AS routes(name,query));
 ```
 
+??? tip "What if the query is invalid?"
+
+    omni_httpd enforces validity of the query using a constraint trigger at the transaction boundary when updating or
+    inserting a handler. This means that once the transaction is being committed, the query is validated and if it,
+    say, refers to an unknown relation, column or is invalid for other reasons, it will be rejected and the transaction
+    will not succeed.
+
+    Please note, however, that at this moment, this enforcement will not help avoiding runtime errors if you render
+    your query invalid *afterwards* (for example, by dropping relations it references), this will lead to runtime errors, ultimately
+    leading to HTTP 500 responses.
+
 The query called `headers` will dump request's headers, `not_found` will return HTTP 404. We can test it with `curl`:
 
 ```shell

--- a/extensions/omni_httpd/expected/handler_validity.out
+++ b/extensions/omni_httpd/expected/handler_validity.out
@@ -1,0 +1,11 @@
+-- Invalid queries
+INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT * FROM no_such_table$$);
+ERROR:  invalid query: relation "no_such_table" does not exist
+INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT request.pth FROM request$$);
+ERROR:  invalid query: column request.pth does not exist
+-- Valid query at the end of the transaction
+BEGIN;
+INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT * FROM no_such_table$$);
+CREATE TABLE no_such_table ();
+END;
+DROP TABLE no_such_table;

--- a/extensions/omni_httpd/expected/handler_validity.out
+++ b/extensions/omni_httpd/expected/handler_validity.out
@@ -1,8 +1,14 @@
 -- Invalid queries
 INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT * FROM no_such_table$$);
-ERROR:  invalid query: relation "no_such_table" does not exist
+ERROR:  invalid query
+DETAIL:  relation "no_such_table" does not exist
 INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT request.pth FROM request$$);
-ERROR:  invalid query: column request.pth does not exist
+ERROR:  invalid query
+DETAIL:  column request.pth does not exist
+INSERT INTO omni_httpd.handlers (query) VALUES($$$$);
+ERROR:  query can only contain one statement
+INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT; SELECT$$);
+ERROR:  query can only contain one statement
 -- Valid query at the end of the transaction
 BEGIN;
 INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT * FROM no_such_table$$);

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -247,8 +247,7 @@ void http_worker(Datum db_oid) {
                                       query_string));
             } else {
               List *request_cte_stmt = omni_sql_parse_statement(request_cte);
-              query_stmt = omni_sql_add_cte(query_stmt, cstring_to_text("request"),
-                                            request_cte_stmt, false, true);
+              query_stmt = omni_sql_add_cte(query_stmt, "request", request_cte_stmt, false, true);
 
               char *query = omni_sql_deparse_statement(query_stmt);
               list_free_deep(request_cte_stmt);

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -48,9 +48,18 @@ CREATE TABLE listeners (
 
 CREATE TABLE handlers (
     id integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    query text,
+    query text NOT NULL,
     role_name name NOT NULL DEFAULT current_user CHECK (current_user = role_name)
 );
+
+CREATE FUNCTION handlers_query_validity_trigger() RETURNS trigger
+AS 'MODULE_PATHNAME', 'handlers_query_validity_trigger' LANGUAGE C;
+
+CREATE CONSTRAINT TRIGGER handlers_query_validity_trigger AFTER INSERT OR UPDATE
+  ON handlers
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW
+  EXECUTE FUNCTION handlers_query_validity_trigger();
 
 CREATE TABLE listeners_handlers (
    listener_id integer NOT NULL REFERENCES listeners (id),

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -190,7 +190,7 @@ Datum handlers_query_validity_trigger(PG_FUNCTION_ARGS) {
     omni_sql_add_cte(stmts, "request", request_cte, false, true);
     char *err;
     if (!omni_sql_is_valid(stmts, &err)) {
-      ereport(ERROR, errmsg("invalid query: %s", err));
+      ereport(ERROR, errmsg("invalid query"), errdetail("%s", err));
     }
     return PointerGetDatum(trigger_data->tg_trigtuple);
   } else {

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -47,6 +47,8 @@
 
 #include <libgluepg_stc.h>
 
+#include <omni_sql.h>
+
 #include "fd.h"
 #include "omni_httpd.h"
 
@@ -164,4 +166,33 @@ Datum http_response(PG_FUNCTION_ARGS) {
   HeapTuple response = heap_form_tuple(response_tupledesc, values, (bool[3]){false, false, false});
 
   PG_RETURN_DATUM(HeapTupleGetDatum(response));
+}
+
+PG_FUNCTION_INFO_V1(handlers_query_validity_trigger);
+
+Datum handlers_query_validity_trigger(PG_FUNCTION_ARGS) {
+  if (CALLED_AS_TRIGGER(fcinfo)) {
+    TriggerData *trigger_data = (TriggerData *)(fcinfo->context);
+    TupleDesc tupdesc = trigger_data->tg_relation->rd_att;
+    bool isnull;
+    Datum query = SPI_getbinval(trigger_data->tg_trigtuple, tupdesc, 2, &isnull);
+    if (isnull) {
+      ereport(ERROR, errmsg("query can't be null"));
+    }
+    List *stmts = omni_sql_parse_statement(text_to_cstring(DatumGetTextPP(query)));
+    if (list_length(stmts) != 1) {
+      ereport(ERROR, errmsg("query can only contain one statement"));
+    }
+    List *request_cte = omni_sql_parse_statement(
+        "SELECT NULL::omni_httpd.http_method AS method, NULL::text AS path, NULL::text AS "
+        "query_string, NULL::bytea AS body, NULL::omni_httpd.http_header[] AS headers");
+    omni_sql_add_cte(stmts, "request", request_cte, false, true);
+    char *err;
+    if (!omni_sql_is_valid(stmts, &err)) {
+      ereport(ERROR, errmsg("invalid query: %s", err));
+    }
+    return PointerGetDatum(trigger_data->tg_trigtuple);
+  } else {
+    ereport(ERROR, errmsg("can only be called as a trigger"));
+  }
 }

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -22,6 +22,7 @@
 #include <miscadmin.h>
 #include <port.h>
 #include <postmaster/bgworker.h>
+#include <utils/rel.h>
 #if PG_MAJORVERSION_NUM >= 13
 #include <postmaster/interrupt.h>
 #endif

--- a/extensions/omni_httpd/sql/handler_validity.sql
+++ b/extensions/omni_httpd/sql/handler_validity.sql
@@ -1,0 +1,11 @@
+-- Invalid queries
+INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT * FROM no_such_table$$);
+INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT request.pth FROM request$$);
+
+-- Valid query at the end of the transaction
+BEGIN;
+INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT * FROM no_such_table$$);
+CREATE TABLE no_such_table ();
+END;
+
+DROP TABLE no_such_table;

--- a/extensions/omni_httpd/sql/handler_validity.sql
+++ b/extensions/omni_httpd/sql/handler_validity.sql
@@ -1,6 +1,8 @@
 -- Invalid queries
 INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT * FROM no_such_table$$);
 INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT request.pth FROM request$$);
+INSERT INTO omni_httpd.handlers (query) VALUES($$$$);
+INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT; SELECT$$);
 
 -- Valid query at the end of the transaction
 BEGIN;

--- a/extensions/omni_sql/CMakeLists.txt
+++ b/extensions/omni_sql/CMakeLists.txt
@@ -25,7 +25,7 @@ add_postgresql_extension(
         RELOCATABLE false
         SCRIPTS omni_sql--0.1.sql
         SOURCES omni_sql.c
-        REGRESS deparse cte parameterized
+        REGRESS deparse cte parameterized validity
 )
 
 target_link_libraries(omni_sql libpgaug libomnisql)

--- a/extensions/omni_sql/expected/validity.out
+++ b/extensions/omni_sql/expected/validity.out
@@ -1,0 +1,28 @@
+-- Valid
+SELECT omni_sql.is_valid('SELECT'::omni_sql.statement);
+ is_valid 
+----------
+ t
+(1 row)
+
+-- An invalid table
+SELECT omni_sql.is_valid('SELECT * FROM no_such_table_exists'::omni_sql.statement);
+ is_valid 
+----------
+ f
+(1 row)
+
+-- Parameters
+SELECT omni_sql.is_valid('SELECT $1'::omni_sql.statement);
+ is_valid 
+----------
+ f
+(1 row)
+
+-- Multiple statements (one is invalid)
+SELECT omni_sql.is_valid('SELECT; SELECT $1'::omni_sql.statement);
+ is_valid 
+----------
+ f
+(1 row)
+

--- a/extensions/omni_sql/lib.c
+++ b/extensions/omni_sql/lib.c
@@ -9,6 +9,7 @@
 // clang-format on
 
 #include <funcapi.h>
+#include <parser/analyze.h>
 #include <parser/parser.h>
 #include <utils/builtins.h>
 
@@ -67,7 +68,7 @@ dispatch:
   return true;
 }
 
-List *omni_sql_add_cte(List *stmts, text *cte_name, List *cte_stmts, bool recursive, bool prepend) {
+List *omni_sql_add_cte(List *stmts, char *cte_name, List *cte_stmts, bool recursive, bool prepend) {
 
   if (list_length(stmts) != 1) {
     ereport(ERROR, errmsg("Statement should contain one and only one statement"));
@@ -80,7 +81,7 @@ List *omni_sql_add_cte(List *stmts, text *cte_name, List *cte_stmts, bool recurs
   void *node = linitial(stmts);
 
   CommonTableExpr *cte_node = makeNode(CommonTableExpr);
-  cte_node->ctename = text_to_cstring(cte_name);
+  cte_node->ctename = cte_name;
   cte_node->ctematerialized = CTEMaterializeDefault;
   cte_node->ctequery = linitial_node(RawStmt, cte_stmts)->stmt;
   cte_node->cterecursive = recursive;
@@ -132,4 +133,35 @@ bool omni_sql_is_parameterized(List *stmts) {
     }
   }
   return false;
+}
+
+bool omni_sql_is_valid(List *stmts, char **error) {
+  if (omni_sql_is_parameterized(stmts)) {
+    return false;
+  }
+
+  ListCell *lc = NULL;
+  bool valid = true;
+  MemoryContext memory_context = CurrentMemoryContext;
+  foreach (lc, stmts) {
+    RawStmt *stmt = lfirst_node(RawStmt, lc);
+    PG_TRY();
+    {
+      parse_analyze_fixedparams(stmt, omni_sql_deparse_statement(list_make1(stmt)), NULL, 0, NULL);
+    }
+    PG_CATCH();
+    {
+      valid = false;
+      if (error != NULL) {
+        MemoryContextSwitchTo(memory_context);
+        ErrorData *err = CopyErrorData();
+        *error = err->message;
+      }
+      FlushErrorState();
+      goto done;
+    }
+    PG_END_TRY();
+  }
+done:
+  return valid;
 }

--- a/extensions/omni_sql/omni_sql--0.1.sql
+++ b/extensions/omni_sql/omni_sql--0.1.sql
@@ -22,3 +22,7 @@ CREATE FUNCTION add_cte(statement, name text, cte statement,
 CREATE FUNCTION is_parameterized(statement) RETURNS bool
   AS 'MODULE_PATHNAME', 'is_parameterized'
   LANGUAGE C STRICT IMMUTABLE;
+
+ CREATE FUNCTION is_valid(statement) RETURNS bool
+  AS 'MODULE_PATHNAME', 'is_valid'
+  LANGUAGE C STRICT IMMUTABLE;

--- a/extensions/omni_sql/omni_sql.c
+++ b/extensions/omni_sql/omni_sql.c
@@ -62,7 +62,7 @@ Datum add_cte(PG_FUNCTION_ARGS) {
   bool recursive = PG_GETARG_BOOL(3);
   bool prepend = PG_GETARG_BOOL(4);
 
-  stmts = omni_sql_add_cte(stmts, cte_name, cte_stmts, recursive, prepend);
+  stmts = omni_sql_add_cte(stmts, text_to_cstring(cte_name), cte_stmts, recursive, prepend);
 
   char *deparsed = omni_sql_deparse_statement(stmts);
   text *deparsed_statement = cstring_to_text(deparsed);
@@ -80,4 +80,17 @@ Datum is_parameterized(PG_FUNCTION_ARGS) {
   List *stmts = omni_sql_parse_statement(text_to_cstring(statement));
 
   PG_RETURN_BOOL(omni_sql_is_parameterized(stmts));
+}
+
+PG_FUNCTION_INFO_V1(is_valid);
+
+Datum is_valid(PG_FUNCTION_ARGS) {
+  if (PG_ARGISNULL(0)) {
+    ereport(ERROR, errmsg("statement can't be NULL"));
+  }
+  text *statement = PG_GETARG_TEXT_PP(0);
+  char *string = text_to_cstring(statement);
+  List *stmts = omni_sql_parse_statement(string);
+
+  PG_RETURN_BOOL(omni_sql_is_valid(stmts, NULL));
 }

--- a/extensions/omni_sql/omni_sql.h
+++ b/extensions/omni_sql/omni_sql.h
@@ -17,8 +17,10 @@ List *omni_sql_parse_statement(char *statement);
 
 bool omni_sql_get_with_clause(Node *node, WithClause ***with);
 
-List *omni_sql_add_cte(List *stmts, text *cte_name, List *cte_stmts, bool recursive, bool prepend);
+List *omni_sql_add_cte(List *stmts, char *cte_name, List *cte_stmts, bool recursive, bool prepend);
 
 bool omni_sql_is_parameterized(List *stmts);
+
+bool omni_sql_is_valid(List *stmts, char **error);
 
 #endif // OMNI_SQL_H

--- a/extensions/omni_sql/sql/validity.sql
+++ b/extensions/omni_sql/sql/validity.sql
@@ -1,0 +1,11 @@
+-- Valid
+SELECT omni_sql.is_valid('SELECT'::omni_sql.statement);
+
+-- An invalid table
+SELECT omni_sql.is_valid('SELECT * FROM no_such_table_exists'::omni_sql.statement);
+
+-- Parameters
+SELECT omni_sql.is_valid('SELECT $1'::omni_sql.statement);
+
+-- Multiple statements (one is invalid)
+SELECT omni_sql.is_valid('SELECT; SELECT $1'::omni_sql.statement);


### PR DESCRIPTION
If given queries can't be executed, they will lead to an error and effectively HTTP 500. This is not great because (for example), a simple typo won't be noticed until it results in a runtime error.

Solution: enforce query validity at the transaction boundary

We are using a deferred constraint trigger to verify that at the transaction boundary, the query has to be correct.

This is not bulletproof as the query may become invalid at a later time (say, when a relation used in it is removed), but at least it is better than not doing any checks.

This change also brings query validation primitve to omni_sql (to be improved at a later point)