### PR TITLE
Problem: spontaneously failing omni_httpd tests

### DIFF
--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -66,9 +66,15 @@ CACHED_OID(http_response);
 
 int num_http_workers;
 
+static void init_semaphore(void *ptr, void *data) { pg_atomic_init_u32(ptr, 0); }
+
 void _Dynpgext_init(const dynpgext_handle *handle) {
   DefineCustomIntVariable("omni_httpd.http_workers", "Number of HTTP workers", NULL,
                           &num_http_workers, 10, 1, INT_MAX, PGC_SIGHUP, 0, NULL, NULL, NULL);
+
+  handle->allocate_shmem(handle, OMNI_HTTPD_CONFIGURATION_RELOAD_SEMAPHORE,
+                         sizeof(pg_atomic_uint32), init_semaphore, NULL,
+                         DYNPGEXT_SCOPE_DATABASE_LOCAL);
 
   // Prepares and registers the main background worker
   BackgroundWorker bgw = {.bgw_name = "omni_httpd",

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -15,6 +15,7 @@
 Oid http_method_oid();
 Oid http_response_oid();
 Oid http_header_oid();
+
 Oid http_header_array_oid();
 
 int create_listening_socket(sa_family_t family, in_port_t port, char *address);
@@ -24,5 +25,8 @@ int create_listening_socket(sa_family_t family, in_port_t port, char *address);
 extern int num_http_workers;
 
 static const char *OMNI_HTTPD_CONFIGURATION_NOTIFY_CHANNEL = "omni_httpd_configuration";
+
+static const char *OMNI_HTTPD_CONFIGURATION_RELOAD_SEMAPHORE =
+    "omni_httpd:" EXT_VERSION ":_configuration_reload_semaphore";
 
 #endif //  OMNI_HTTPD_H


### PR DESCRIPTION
Solution: ensure master_worker wait for all http_workers before it commits the configuration reload record.

This is done with an atomic counting semaphore.