### PR TITLE
Problem: omni_httpd config reload race condition

### DIFF
--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -93,7 +93,9 @@ void http_worker(Datum db_oid) {
   Assert(semaphore != NULL);
 
   while (worker_running) {
-    uint32 v = pg_atomic_add_fetch_u32(semaphore, 1);
+    if (worker_reload) {
+      pg_atomic_add_fetch_u32(semaphore, 1);
+    }
     worker_reload = false;
     cvec_fd fds = accept_fds(MyBgworkerEntry->bgw_extra);
 


### PR DESCRIPTION
It's still possible to get a race condition. HTTP workers increment the semaphore upon initial statup. So when the master worker starts them, goes into the event loop and shortly after that reloads, it may see the correct (or even greater) number of HTTP workers on the semaphore.

Solution: HTTP workers should only increment semaphore on reload but not on the initial load.