### PR TITLE
Problem:  omni_httpd startup race condition

### DIFF
--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -93,7 +93,7 @@ void http_worker(Datum db_oid) {
   Assert(semaphore != NULL);
 
   while (worker_running) {
-    uint32 v = pg_atomic_add_fetch_u32(semaphore, 1);
+    pg_atomic_add_fetch_u32(semaphore, 1);
     worker_reload = false;
     cvec_fd fds = accept_fds(MyBgworkerEntry->bgw_extra);
 

--- a/extensions/omni_httpd/master_worker.c
+++ b/extensions/omni_httpd/master_worker.c
@@ -398,6 +398,12 @@ void master_worker(Datum db_oid) {
         }
         cvec_bgwhandle_push(&http_workers, handle);
       }
+      // Ensure all workers have indeed started their loops
+      uint32 expected = cvec_bgwhandle_size(&http_workers);
+      while (!pg_atomic_compare_exchange_u32(semaphore, &expected, 0)) {
+        expected = cvec_bgwhandle_size(&http_workers);
+        HandleMainLoopInterrupts();
+      }
       http_workers_started = true;
     }
 


### PR DESCRIPTION
During startup of the workers, we don't know how many of HTTP workers have started their loops by the time master worker's loop may be already ready for a configuration reload and signalling these workers to go into reload.

Solution: ensure we wait until HTTP workers enter their loops