### PR TITLE
Problem: BGW_MAXLEN is too short

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: env PATH=${{github.workspace}}:$PATH ctest -timeout 1000 --force-new-ctest-process --verbose --output-on-failure -j $(nproc) -C ${{matrix.build_type}}
+      run: env PATH=${{github.workspace}}:$PATH TMPDIR=$RUNNER_TEMP ctest -timeout 1000 --force-new-ctest-process --verbose --output-on-failure -j $(nproc) -C ${{matrix.build_type}}
 
     - uses: actions/upload-artifact@v3
       if: failure()

--- a/extensions/omni_ext/control_file.c
+++ b/extensions/omni_ext/control_file.c
@@ -192,6 +192,47 @@ void find_control_files(void (*callback)(const char *control_path, void *data), 
   closedir(dir);
 }
 
+/**
+ * Returns a name that fits into BGWLEN-1
+ *
+ * Many pathnames don't. So we try to do this by symlinking into $TMPDIR
+ * hoping it'll be shorter.
+ *
+ * (bgw_library_name should be MAXPGPATH-sized, really)
+ *
+ * @param library_name
+ * @return
+ */
+static char *get_fitting_library_name(char *library_name) {
+  if (sizeof(((BackgroundWorker){}).bgw_library_name) == BGW_MAXLEN &&
+      strlen(library_name) >= BGW_MAXLEN - 1) {
+    char *tmpdir = getenv("TMPDIR");
+    if (tmpdir == NULL) {
+      ereport(WARNING, errmsg("library path %s is too long to fit into BGW_MAXLEN-1 (%d chars) and "
+                              "there's no $TMPDIR",
+                              library_name, BGW_MAXLEN - 1));
+    } else {
+      char *tempfile = psprintf("%s/omni_ext_XXXXXX", tmpdir);
+      if (strlen(tempfile) >= BGW_MAXLEN - 1) {
+        ereport(WARNING,
+                errmsg("temp file name %s is still to large to fit into BGW_MAXLEN-1 (%d chars)",
+                       tempfile, BGW_MAXLEN));
+        return library_name;
+      }
+      int fd = mkstemp(tempfile);
+      unlink(tempfile);
+      close(fd);
+      if (symlink(library_name, tempfile) != 0) {
+        int e = errno;
+        ereport(WARNING, errmsg("can't symlink %s to %s: %s", library_name, tempfile, strerror(e)));
+        return library_name;
+      }
+      return tempfile;
+    }
+  }
+  return library_name;
+}
+
 void load_control_file(const char *control_path, void *data) {
   char *control_basename = basename((char *)control_path);
   struct load_control_file_config *config = (struct load_control_file_config *)data;
@@ -285,7 +326,8 @@ void load_control_file(const char *control_path, void *data) {
                     dynpgext_handle *handle = palloc(sizeof(dynpgext_handle));
                     handle->name = pstrdup(control_file.ext_name);
                     handle->version = pstrdup(control_file.ext_version);
-                    handle->library_name = pstrdup(control_file.module_pathname);
+                    handle->library_name =
+                        get_fitting_library_name(pstrdup(control_file.module_pathname));
                     if (config) {
                       handle->allocate_shmem = config->allocate_shmem;
                       handle->register_bgworker = config->register_bgworker_function;


### PR DESCRIPTION
Supplying an absolute pathname there is often impractical and leads to errors like this:

```
omni_ext_test[6239] ERROR:  could not access file "/Users/yrashk/Projects/omnigres/omnigres/build/extensions/omni_ext/test/omni_ext_test_no_preloa":
No such file or director
```

Solution: try to symlink long paths to $TMPDIR
and see if they fit.