### PR TITLE
Problem: ocassionally role_name test fails

### DIFF
--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -27,6 +27,7 @@
 
 #include <access/xact.h>
 #include <catalog/pg_authid.h>
+#include <catalog/pg_collation_d.h>
 #include <executor/spi.h>
 #include <funcapi.h>
 #include <miscadmin.h>
@@ -495,7 +496,7 @@ static int handler(h2o_handler_t *self, h2o_req_t *req) {
   // Stores a pointer to the last used role name (NULL initially) in this process
   // to enable on-demand role switching.
   static Name role_name;
-  if (role_name != lctx->role_name) {
+  if (role_name == NULL || namecmp(lctx->role_name, role_name, C_COLLATION_OID) != 0) {
     role_name = lctx->role_name;
     HeapTuple roleTup = SearchSysCache1(AUTHNAME, PointerGetDatum(role_name));
     if (!HeapTupleIsValid(roleTup)) {

--- a/libpgaug/libpgaug.c
+++ b/libpgaug/libpgaug.c
@@ -24,3 +24,22 @@ void __with_temp_memcxt_cleanup(struct __with_temp_memcxt *s) {
   }
   MemoryContextDelete(s->new);
 }
+
+#include <catalog/pg_collation_d.h>
+#include <utils/varlena.h>
+
+int namecmp(Name arg1, Name arg2, Oid collid) {
+  /*
+   * This code is licensed under the terms of PostgreSQL license
+   *
+   * Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
+   * Portions Copyright (c) 1994, Regents of the University of California
+   */
+  /* Fast path for common case used in system catalogs */
+  if (collid == C_COLLATION_OID)
+    return strncmp(NameStr(*arg1), NameStr(*arg2), NAMEDATALEN);
+
+  /* Else rely on the varstr infrastructure */
+  return varstr_cmp(NameStr(*arg1), strlen(NameStr(*arg1)), NameStr(*arg2), strlen(NameStr(*arg2)),
+                    collid);
+}

--- a/libpgaug/libpgaug.h
+++ b/libpgaug/libpgaug.h
@@ -86,4 +86,9 @@ void __with_temp_memcxt_cleanup(struct __with_temp_memcxt *s);
     return oid_array_##name;                                                                       \
   }
 
+/**
+ * Compares names (extracted from Postgres source code)
+ */
+int namecmp(Name arg1, Name arg2, Oid collid);
+
 #endif // LIBPGAUG_H


### PR DESCRIPTION
Instead of showing `test_user` it shows the name of the OS user (default username used for the database)

Solution: ensure we're not just checking pointers when comparing names

If the listener context is the same, then the check will never work correctly. For some reason, when I wrote this code, I thought that the pointers will never be the same.