### PR TITLE
Problem: ocassionally role_name test fails

### DIFF
--- a/extensions/omni_httpd/http_worker.h
+++ b/extensions/omni_httpd/http_worker.h
@@ -28,10 +28,14 @@ typedef struct {
    */
   MemoryContext memory_context;
   /**
-   * @brief Role name
+   * @brief Role ID
    *
    */
-  Name role_name;
+  Oid role_id;
+  /**
+   * @brief Is role a superuser?
+   */
+  bool role_supervisor;
   /**
    * @brief Associated socket
    *


### PR DESCRIPTION
Instead of showing test_user it shows the name of the OS user (default username used for the database)

Solution: use role ID instead of name

It's simpler (as long as user ID doesn't change)