### PR TITLE
Problem: having omni_httpd listeners port specified

### DIFF
--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -23,7 +23,7 @@ add_postgresql_extension(
         SCRIPTS omni_httpd--0.1.sql
         SOURCES omni_httpd.c master_worker.c http_worker.c fd.c cascading_query.c
         TESTS_REQUIRE omni_ext
-        REGRESS http role_name cascading_query handler_validity)
+        REGRESS http role_name cascading_query handler_validity port_selector)
 
 target_link_libraries(omni_httpd libh2o-evloop libpgaug libomnisql libgluepg_stc dynpgext metalang99)
 

--- a/extensions/omni_httpd/expected/port_selector.out
+++ b/extensions/omni_httpd/expected/port_selector.out
@@ -1,0 +1,22 @@
+--- Force omni_httpd to select a port
+BEGIN;
+WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 0) RETURNING id),
+     handler AS (INSERT INTO omni_httpd.handlers (query) VALUES ($$SELECT$$))
+INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
+SELECT listener.id, handler.id
+FROM listener, handler;
+ERROR:  WITH query "handler" does not have a RETURNING clause
+LINE 5: FROM listener, handler;
+                       ^
+DELETE FROM omni_httpd.configuration_reloads;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+END;
+CALL omni_httpd.wait_for_configuration_reloads(1);
+-- Ensure port was updated
+SELECT count(*) FROM omni_httpd.listeners WHERE port = 0;
+ count 
+-------
+     0
+(1 row)
+
+-- TODO: Test request on a given port. Needs non-shell http client

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -34,7 +34,7 @@ CREATE FUNCTION http_response(
     AS 'MODULE_PATHNAME', 'http_response'
     LANGUAGE C;
 
-CREATE DOMAIN port integer CHECK (VALUE > 0 AND VALUE <= 65535);
+CREATE DOMAIN port integer CHECK (VALUE >= 0 AND VALUE <= 65535);
 
 CREATE TYPE http_protocol AS ENUM ('http', 'https');
 

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -18,7 +18,7 @@ Oid http_header_oid();
 
 Oid http_header_array_oid();
 
-int create_listening_socket(sa_family_t family, in_port_t port, char *address);
+int create_listening_socket(sa_family_t family, in_port_t port, char *address, in_port_t *out_port);
 
 #define MAX_ADDRESS_SIZE sizeof("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:255.255.255.255/128")
 

--- a/extensions/omni_httpd/sql/port_selector.sql
+++ b/extensions/omni_httpd/sql/port_selector.sql
@@ -1,0 +1,16 @@
+--- Force omni_httpd to select a port
+BEGIN;
+WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 0) RETURNING id),
+     handler AS (INSERT INTO omni_httpd.handlers (query) VALUES ($$SELECT$$))
+INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
+SELECT listener.id, handler.id
+FROM listener, handler;
+DELETE FROM omni_httpd.configuration_reloads;
+END;
+
+CALL omni_httpd.wait_for_configuration_reloads(1);
+
+-- Ensure port was updated
+SELECT count(*) FROM omni_httpd.listeners WHERE port = 0;
+
+-- TODO: Test request on a given port. Needs non-shell http client


### PR DESCRIPTION
Port may be unavailable.

Solution: allow specifying 0 to force random port selection

This also fixes a nasty bug of http_worker assuming port is Int16 (it isn't because it is signed)

I've not updated the tests to use this as this will require an SQL-operated HTTP client as opposed to shelling out to `curl` as we do now. I could have used a third-party extension but didn't want to deal with their build process at the moment. We need to have our own HTTP client anyway.