### PR TITLE
Problem: having to update listener handle entry

### DIFF
--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -23,7 +23,7 @@ add_postgresql_extension(
         SCRIPTS omni_httpd--0.1.sql
         SOURCES omni_httpd.c master_worker.c http_worker.c fd.c cascading_query.c
         TESTS_REQUIRE omni_ext
-        REGRESS http role_name cascading_query handler_validity port_selector)
+        REGRESS http cascading_query handler_validity port_selector)
 
 target_link_libraries(omni_httpd libh2o-evloop libpgaug libomnisql libgluepg_stc dynpgext metalang99)
 

--- a/extensions/omni_httpd/expected/cascading_query.out
+++ b/extensions/omni_httpd/expected/cascading_query.out
@@ -8,8 +8,7 @@ INSERT INTO routes (name, query, priority) VALUES
   ('ping', $$SELECT omni_httpd.http_response(body => 'pong') FROM request WHERE request.path = '/ping'$$, 1);
 \pset format wrapped
 \pset columns 80
--- Preview the query
-SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORDER BY priority DESC;
+SELECT omni_httpd.cascading_query(name, query ORDER BY priority DESC NULLS LAST) FROM routes GROUP BY priority ORDER BY priority DESC;
                                 cascading_query                                 
 --------------------------------------------------------------------------------
  WITH test AS (SELECT omni_httpd.http_response(body := 'test') FROM request WHE.
@@ -19,26 +18,10 @@ SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORD
 (1 row)
 
 \pset format aligned
--- Try it
-BEGIN;
-WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9100) RETURNING id),
-     handler AS (INSERT INTO omni_httpd.handlers (query) SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORDER BY priority DESC RETURNING id)
-INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
-SELECT listener.id, handler.id
-FROM listener, handler;
-DELETE FROM omni_httpd.configuration_reloads;
-END;
-CALL omni_httpd.wait_for_configuration_reloads(1);
-\! curl --retry-connrefused --retry 10  --retry-max-time 10 -w '\n\n' --silent http://localhost:9100/test
-test
-
-\! curl --retry-connrefused --retry 10  --retry-max-time 10 -w '\n\n' --silent http://localhost:9100/ping
-pong
-
 -- CTE handling
 \pset format wrapped
 \pset columns 80
-SELECT omni_httpd.cascading_query(name, query) FROM (
+SELECT omni_httpd.cascading_query(name, query ORDER by priority DESC NULLS LAST) FROM (
   VALUES
   ('test', $$WITH test AS (SELECT 1 AS val) SELECT omni_httpd.http_response(body => 'test') FROM request, Test WHERE request.path = '/test' and test.val = 1$$, 1),
   ('ping', $$WITH test AS (SELECT 1 AS val) SELECT omni_httpd.http_response(body => 'pong') FROM request, Test WHERE request.path = '/ping' and test.val = 1$$, 1))

--- a/extensions/omni_httpd/expected/handler_validity.out
+++ b/extensions/omni_httpd/expected/handler_validity.out
@@ -1,17 +1,21 @@
 -- Invalid queries
-INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT * FROM no_such_table$$);
-ERROR:  invalid query
-DETAIL:  relation "no_such_table" does not exist
-INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT request.pth FROM request$$);
-ERROR:  invalid query
-DETAIL:  column request.pth does not exist
-INSERT INTO omni_httpd.handlers (query) VALUES($$$$);
-ERROR:  query can only contain one statement
-INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT; SELECT$$);
-ERROR:  query can only contain one statement
+BEGIN;
+INSERT INTO omni_httpd.handlers VALUES (DEFAULT) RETURNING id AS handler_id \gset
+INSERT INTO omni_httpd.handler_queries (handler_id, query) VALUES(:handler_id, $$SELECT * FROM no_such_table$$);
+ERROR:  relation "omni_httpd.handler_queries" does not exist
+LINE 1: INSERT INTO omni_httpd.handler_queries (handler_id, query) V...
+                    ^
+INSERT INTO omni_httpd.handler_queries (handler_id, query) VALUES(:handler_id, $$SELECT request.pth FROM request$$);
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+INSERT INTO omni_httpd.handler_queries (handler_id, query) VALUES(:handler_id, $$$$);
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+INSERT INTO omni_httpd.handler_queries (handler_id, query) VALUES(:handler_id, $$SELECT; SELECT$$);
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
 -- Valid query at the end of the transaction
 BEGIN;
-INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT * FROM no_such_table$$);
+INSERT INTO omni_httpd.handlers VALUES (DEFAULT) RETURNING id AS handler_id \gset
+INSERT INTO omni_httpd.handlers_queries (handler_id, query) VALUES(:handler_id, $$SELECT * FROM no_such_table$$);
 CREATE TABLE no_such_table ();
 END;
 DROP TABLE no_such_table;

--- a/extensions/omni_httpd/expected/http.out
+++ b/extensions/omni_httpd/expected/http.out
@@ -5,26 +5,26 @@ CREATE TABLE users (
 );
 INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
 BEGIN;
-WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9000) RETURNING id),
-     handler AS (INSERT INTO omni_httpd.handlers (query)
-     SELECT omni_httpd.cascading_query(name, query) FROM (VALUES
-      ('hello',
+WITH handler AS (INSERT INTO omni_httpd.handlers VALUES (DEFAULT) RETURNING id),
+     listener AS (INSERT INTO omni_httpd.listeners (address, port, handler_id) VALUES ('127.0.0.1', 9000, (SELECT id FROM handler)) RETURNING id),
+     queries AS (INSERT INTO omni_httpd.handlers_queries (priority, name, query, handler_id) VALUES
+      (1, 'hello',
       $$SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!')
        FROM request
        INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
-      $$),
-      ('headers',
-      $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$),
-      ('echo',
-      $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$),
-      ('not_found',
+      $$, (SELECT id FROM handler)),
+      (1, 'headers',
+      $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$, (SELECT id FROM handler)),
+      (1, 'echo',
+      $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$, (SELECT id FROM handler)),
+      (0, 'not_found',
       $$SELECT omni_httpd.http_response(status => 404, body => json_build_object('method', request.method, 'path', request.path, 'query_string', request.query_string))
-       FROM request$$)
-     ) AS routes(name,query)
-RETURNING id)
-INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
-SELECT listener.id, handler.id
-FROM listener, handler;
+       FROM request$$,  (SELECT id FROM handler)) RETURNING id)
+SELECT * FROM listener, queries LIMIT 0;
+ id | id 
+----+----
+(0 rows)
+
 DELETE FROM omni_httpd.configuration_reloads;
 END;
 CALL omni_httpd.wait_for_configuration_reloads(1);
@@ -49,10 +49,7 @@ Content-Type: text/html
 {"(user-agent,test-agent,t)","(accept,*/*,t)"}-- Try changing configuration
 BEGIN;
 UPDATE omni_httpd.listeners SET port = 9001 WHERE port = 9000;
-WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9002) RETURNING id),
-     handler AS (SELECT ls.handler_id AS id FROM omni_httpd.listeners INNER JOIN omni_httpd.listeners_handlers ls ON ls.listener_id = listeners.id WHERE port = 9001)
-INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
- SELECT listener.id, handler.id FROM listener, handler;
+INSERT INTO omni_httpd.listeners (address, port, handler_id) VALUES ('127.0.0.1', 9002, (SELECT handler_id AS id FROM omni_httpd.listeners WHERE port = 9001));
 DELETE FROM omni_httpd.configuration_reloads;
 END;
 CALL omni_httpd.wait_for_configuration_reloads(1);

--- a/extensions/omni_httpd/expected/port_selector.out
+++ b/extensions/omni_httpd/expected/port_selector.out
@@ -1,13 +1,13 @@
 --- Force omni_httpd to select a port
 BEGIN;
-WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 0) RETURNING id),
-     handler AS (INSERT INTO omni_httpd.handlers (query) VALUES ($$SELECT$$))
-INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
-SELECT listener.id, handler.id
-FROM listener, handler;
-ERROR:  WITH query "handler" does not have a RETURNING clause
-LINE 5: FROM listener, handler;
-                       ^
+WITH listener AS (INSERT INTO omni_httpd.listeners (address, port, handler_id) VALUES ('127.0.0.1', 0, (SELECT id FROM handler)) RETURNING id),
+     handler AS (INSERT INTO omni_httpd.handlers VALUES (DEFAULT) RETURNING id)
+     SELECT * FROM listener;
+ERROR:  relation "handler" does not exist
+LINE 1: ...ndler_id) VALUES ('127.0.0.1', 0, (SELECT id FROM handler)) ...
+                                                             ^
+DETAIL:  There is a WITH item named "handler", but it cannot be referenced from this part of the query.
+HINT:  Use WITH RECURSIVE, or re-order the WITH items to remove forward references.
 DELETE FROM omni_httpd.configuration_reloads;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 END;

--- a/extensions/omni_httpd/expected/role_name.out
+++ b/extensions/omni_httpd/expected/role_name.out
@@ -14,7 +14,7 @@ CALL omni_httpd.wait_for_configuration_reloads(1);
 BEGIN;
 UPDATE omni_httpd.handlers SET role_name = 'some_role' WHERE role_name = 'test_user';
 ERROR:  new row for relation "handlers" violates check constraint "handlers_role_name_check"
-DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., some_role).
+DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., some_role, null).
 DELETE FROM omni_httpd.configuration_reloads;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 END;
@@ -23,7 +23,7 @@ CALL omni_httpd.wait_for_configuration_reloads(1);
 BEGIN;
 UPDATE omni_httpd.handlers SET role_name = 'test_user1' WHERE role_name = 'test_user';
 ERROR:  new row for relation "handlers" violates check constraint "handlers_role_name_check"
-DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1).
+DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1, null).
 DELETE FROM omni_httpd.configuration_reloads;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 END;
@@ -40,7 +40,7 @@ SET ROLE test_user;
 UPDATE omni_httpd.handlers SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$
     WHERE role_name = 'test_user1' RETURNING role_name;
 ERROR:  new row for relation "handlers" violates check constraint "handlers_role_name_check"
-DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1).
+DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., test_user1, null).
 -- This will work
 BEGIN;
 UPDATE omni_httpd.handlers SET query = $$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$,

--- a/extensions/omni_httpd/master_worker.c
+++ b/extensions/omni_httpd/master_worker.c
@@ -248,11 +248,7 @@ void master_worker(Datum db_oid) {
     while (worker_reload) {
       worker_reload = false;
       if (SPI_execute(
-              "SELECT listeners.address, listeners.port, listeners.id FROM "
-              "omni_httpd.listeners_handlers  "
-              "INNER JOIN omni_httpd.listeners ON listeners.id = listeners_handlers.listener_id "
-              "INNER JOIN omni_httpd.handlers handlers ON handlers.id = "
-              "listeners_handlers.handler_id",
+              "SELECT listeners.address, listeners.port, listeners.id FROM omni_httpd.listeners",
               false, 0) == SPI_OK_SELECT) {
         TupleDesc tupdesc = SPI_tuptable->tupdesc;
         SPITupleTable *tuptable = SPI_tuptable;

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -175,14 +175,14 @@ Datum http_response(PG_FUNCTION_ARGS) {
   PG_RETURN_DATUM(HeapTupleGetDatum(response));
 }
 
-PG_FUNCTION_INFO_V1(handlers_query_validity_trigger);
+PG_FUNCTION_INFO_V1(handlers_queries_validity_trigger);
 
-Datum handlers_query_validity_trigger(PG_FUNCTION_ARGS) {
+Datum handlers_queries_validity_trigger(PG_FUNCTION_ARGS) {
   if (CALLED_AS_TRIGGER(fcinfo)) {
     TriggerData *trigger_data = (TriggerData *)(fcinfo->context);
     TupleDesc tupdesc = trigger_data->tg_relation->rd_att;
     bool isnull;
-    Datum query = SPI_getbinval(trigger_data->tg_trigtuple, tupdesc, 2, &isnull);
+    Datum query = SPI_getbinval(trigger_data->tg_trigtuple, tupdesc, 3, &isnull);
     if (isnull) {
       ereport(ERROR, errmsg("query can't be null"));
     }

--- a/extensions/omni_httpd/sql/cascading_query.sql
+++ b/extensions/omni_httpd/sql/cascading_query.sql
@@ -11,33 +11,16 @@ INSERT INTO routes (name, query, priority) VALUES
 \pset format wrapped
 \pset columns 80
 
--- Preview the query
-SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORDER BY priority DESC;
+SELECT omni_httpd.cascading_query(name, query ORDER BY priority DESC NULLS LAST) FROM routes GROUP BY priority ORDER BY priority DESC;
 
 \pset format aligned
-
--- Try it
-BEGIN;
-WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9100) RETURNING id),
-     handler AS (INSERT INTO omni_httpd.handlers (query) SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORDER BY priority DESC RETURNING id)
-INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
-SELECT listener.id, handler.id
-FROM listener, handler;
-DELETE FROM omni_httpd.configuration_reloads;
-END;
-
-CALL omni_httpd.wait_for_configuration_reloads(1);
-
-\! curl --retry-connrefused --retry 10  --retry-max-time 10 -w '\n\n' --silent http://localhost:9100/test
-
-\! curl --retry-connrefused --retry 10  --retry-max-time 10 -w '\n\n' --silent http://localhost:9100/ping
 
 -- CTE handling
 
 \pset format wrapped
 \pset columns 80
 
-SELECT omni_httpd.cascading_query(name, query) FROM (
+SELECT omni_httpd.cascading_query(name, query ORDER by priority DESC NULLS LAST) FROM (
   VALUES
   ('test', $$WITH test AS (SELECT 1 AS val) SELECT omni_httpd.http_response(body => 'test') FROM request, Test WHERE request.path = '/test' and test.val = 1$$, 1),
   ('ping', $$WITH test AS (SELECT 1 AS val) SELECT omni_httpd.http_response(body => 'pong') FROM request, Test WHERE request.path = '/ping' and test.val = 1$$, 1))

--- a/extensions/omni_httpd/sql/handler_validity.sql
+++ b/extensions/omni_httpd/sql/handler_validity.sql
@@ -1,12 +1,16 @@
 -- Invalid queries
-INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT * FROM no_such_table$$);
-INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT request.pth FROM request$$);
-INSERT INTO omni_httpd.handlers (query) VALUES($$$$);
-INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT; SELECT$$);
+BEGIN;
+INSERT INTO omni_httpd.handlers VALUES (DEFAULT) RETURNING id AS handler_id \gset
+INSERT INTO omni_httpd.handler_queries (handler_id, query) VALUES(:handler_id, $$SELECT * FROM no_such_table$$);
+INSERT INTO omni_httpd.handler_queries (handler_id, query) VALUES(:handler_id, $$SELECT request.pth FROM request$$);
+INSERT INTO omni_httpd.handler_queries (handler_id, query) VALUES(:handler_id, $$$$);
+INSERT INTO omni_httpd.handler_queries (handler_id, query) VALUES(:handler_id, $$SELECT; SELECT$$);
+ROLLBACK;
 
 -- Valid query at the end of the transaction
 BEGIN;
-INSERT INTO omni_httpd.handlers (query) VALUES($$SELECT * FROM no_such_table$$);
+INSERT INTO omni_httpd.handlers VALUES (DEFAULT) RETURNING id AS handler_id \gset
+INSERT INTO omni_httpd.handlers_queries (handler_id, query) VALUES(:handler_id, $$SELECT * FROM no_such_table$$);
 CREATE TABLE no_such_table ();
 END;
 

--- a/extensions/omni_httpd/sql/http.sql
+++ b/extensions/omni_httpd/sql/http.sql
@@ -7,26 +7,22 @@ CREATE TABLE users (
 INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
 
 BEGIN;
-WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9000) RETURNING id),
-     handler AS (INSERT INTO omni_httpd.handlers (query)
-     SELECT omni_httpd.cascading_query(name, query) FROM (VALUES
-      ('hello',
+WITH handler AS (INSERT INTO omni_httpd.handlers VALUES (DEFAULT) RETURNING id),
+     listener AS (INSERT INTO omni_httpd.listeners (address, port, handler_id) VALUES ('127.0.0.1', 9000, (SELECT id FROM handler)) RETURNING id),
+     queries AS (INSERT INTO omni_httpd.handlers_queries (priority, name, query, handler_id) VALUES
+      (1, 'hello',
       $$SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!')
        FROM request
        INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
-      $$),
-      ('headers',
-      $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$),
-      ('echo',
-      $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$),
-      ('not_found',
+      $$, (SELECT id FROM handler)),
+      (1, 'headers',
+      $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$, (SELECT id FROM handler)),
+      (1, 'echo',
+      $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$, (SELECT id FROM handler)),
+      (0, 'not_found',
       $$SELECT omni_httpd.http_response(status => 404, body => json_build_object('method', request.method, 'path', request.path, 'query_string', request.query_string))
-       FROM request$$)
-     ) AS routes(name,query)
-RETURNING id)
-INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
-SELECT listener.id, handler.id
-FROM listener, handler;
+       FROM request$$,  (SELECT id FROM handler)) RETURNING id)
+SELECT * FROM listener, queries LIMIT 0;
 DELETE FROM omni_httpd.configuration_reloads;
 END;
 
@@ -49,10 +45,7 @@ CALL omni_httpd.wait_for_configuration_reloads(1);
 BEGIN;
 
 UPDATE omni_httpd.listeners SET port = 9001 WHERE port = 9000;
-WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9002) RETURNING id),
-     handler AS (SELECT ls.handler_id AS id FROM omni_httpd.listeners INNER JOIN omni_httpd.listeners_handlers ls ON ls.listener_id = listeners.id WHERE port = 9001)
-INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
- SELECT listener.id, handler.id FROM listener, handler;
+INSERT INTO omni_httpd.listeners (address, port, handler_id) VALUES ('127.0.0.1', 9002, (SELECT handler_id AS id FROM omni_httpd.listeners WHERE port = 9001));
 
 DELETE FROM omni_httpd.configuration_reloads;
 END;

--- a/extensions/omni_httpd/sql/port_selector.sql
+++ b/extensions/omni_httpd/sql/port_selector.sql
@@ -1,10 +1,8 @@
 --- Force omni_httpd to select a port
 BEGIN;
-WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 0) RETURNING id),
-     handler AS (INSERT INTO omni_httpd.handlers (query) VALUES ($$SELECT$$))
-INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
-SELECT listener.id, handler.id
-FROM listener, handler;
+WITH listener AS (INSERT INTO omni_httpd.listeners (address, port, handler_id) VALUES ('127.0.0.1', 0, (SELECT id FROM handler)) RETURNING id),
+     handler AS (INSERT INTO omni_httpd.handlers VALUES (DEFAULT) RETURNING id)
+     SELECT * FROM listener;
 DELETE FROM omni_httpd.configuration_reloads;
 END;
 


### PR DESCRIPTION
Any time one wants to modify request handling, they need to locate the correct handler for the listener and update the query in full.

However, this means that

* the discoverability of handlers is obtuse (one needs to locate the listener and join with handlers over listeners_handlers to find the handler)
* the composability of such handlers is somewhat limited

Solution #1: introduce unique names to handlers so that they can be easily located

Solution #2: combine multiple listeners_handlers sorted by priority

Closes #102

---

TODO:

- [ ] Rewrite documentation to use this approach
- [ ] Figure out if `role_name` per handler and having handlers grouped by it is sensible