### PR TITLE
Problem: omni_httpd's `request` CTE may not be `http_request`

### DIFF
--- a/extensions/omni_httpd/expected/http.out
+++ b/extensions/omni_httpd/expected/http.out
@@ -17,6 +17,9 @@ WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.
       $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$),
       ('echo',
       $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$),
+      -- This validates that `request CTE` can be casted to http_request
+      ('http_request',
+      $$SELECT omni_httpd.http_response(body => request.*::omni_httpd.http_request::text) FROM request WHERE request.path = '/http_request'$$),
       ('not_found',
       $$SELECT omni_httpd.http_response(status => 404, body => json_build_object('method', request.method, 'path', request.path, 'query_string', request.query_string))
        FROM request$$)

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -253,11 +253,11 @@ void http_worker(Datum db_oid) {
             MemoryContext memory_context = CurrentMemoryContext;
             char *request_cte = psprintf(
                 // clang-format off
-                      "SELECT $" REQUEST_PLAN_PARAM(REQUEST_PLAN_PATH) " AS path, "
-                       "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_METHOD) "::text::omni_httpd.http_method AS method, "
-                       "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_QUERY_STRING) " AS query_string, "
-                       "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_BODY) " AS body, "
-                       "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_HEADERS) " AS headers "
+                    "SELECT " "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_METHOD) "::text::omni_httpd.http_method AS method, "
+                    "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_PATH) " AS path, "
+                    "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_QUERY_STRING) " AS query_string, "
+                    "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_BODY) " AS body, "
+                    "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_HEADERS) " AS headers "
                 // clang-format on
             );
 

--- a/extensions/omni_httpd/http_worker.h
+++ b/extensions/omni_httpd/http_worker.h
@@ -114,15 +114,15 @@ static cvec_fd accept_fds(char *socket_name);
 #define REQUEST_PLAN_PARAM(x) ML99_STRINGIFY(ML99_INC(x))
 
 /**
- * @brief Path parameter index
- *
- */
-#define REQUEST_PLAN_PATH 0
-/**
  * @brief Method parameter index
  *
  */
-#define REQUEST_PLAN_METHOD 1
+#define REQUEST_PLAN_METHOD 0
+/**
+ * @brief Path parameter index
+ *
+ */
+#define REQUEST_PLAN_PATH 1
 /**
  * @brief Query string parameter index
  *

--- a/extensions/omni_httpd/sql/http.sql
+++ b/extensions/omni_httpd/sql/http.sql
@@ -19,6 +19,9 @@ WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.
       $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$),
       ('echo',
       $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$),
+      -- This validates that `request CTE` can be casted to http_request
+      ('http_request',
+      $$SELECT omni_httpd.http_response(body => request.*::omni_httpd.http_request::text) FROM request WHERE request.path = '/http_request'$$),
       ('not_found',
       $$SELECT omni_httpd.http_response(status => 404, body => json_build_object('method', request.method, 'path', request.path, 'query_string', request.query_string))
        FROM request$$)


### PR DESCRIPTION
How do we know what's supplied can be converted to `omni_httpd.http_request` type?

Solution: write a test that tries to do this

The tests showed that `request` CTE was not in fact compatible with the type. This change fixes this.