### PR TITLE
Problem: cascading_query() aggregate use and ordering

### DIFF
--- a/extensions/omni_httpd/docs/intro.md
+++ b/extensions/omni_httpd/docs/intro.md
@@ -75,6 +75,11 @@ or can be retrieved during deployment (say, from a Git repository or any other s
     Not found
     ```
 
+    !!! tip
+
+        An interesting corollary to this approach is that if all of the handling sub-queries are of the same priority,
+        then priority-ordering is not required and one can simply use `cascading_query` without `ORDER BY`.
+
 ??? question "What does `cascading_query` do?"
 
     The idea behind `cascading_query` is that it aggregates named queries in a `UNION` query where all given queries

--- a/extensions/omni_httpd/docs/intro.md
+++ b/extensions/omni_httpd/docs/intro.md
@@ -14,17 +14,14 @@ own SQL completely by hand). This function simplifies building priority-sorted r
 
 ```sql
 UPDATE omni_httpd.handlers SET query = 
-(SELECT omni_httpd.cascading_query(name, query) FROM (VALUES
+(SELECT omni_httpd.cascading_query(name, query ORDER BY priority DESC NULLS LAST) FROM (VALUES
      ('headers',
      $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$, 1),
      ('not_found',
      $$SELECT omni_httpd.http_response(status => 404, body => 'Not found') FROM request$$, 0)
-     ORDER BY column3 DESC -- (1)
      ) 
      AS routes(name,query,priority) );
 ```
-
-1. `column3` refers to the third (last) column with the integer
 
 ??? tip "What if the query is invalid?"
 
@@ -58,12 +55,11 @@ or can be retrieved during deployment (say, from a Git repository or any other s
 
     ```sql
     UPDATE omni_httpd.handlers SET query =
-    (SELECT omni_httpd.cascading_query(name, query) FROM (VALUES
+    (SELECT omni_httpd.cascading_query(name, query ORDER BY priority ASC NULLS LAST) FROM (VALUES -- (1)
     ('headers',
     $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$, 1),
     ('not_found',
     $$SELECT omni_httpd.http_response(status => 404, body => 'Not found') FROM request$$, 0)
-    ORDER BY column3 ASC -- (1)
     )
     AS routes(name,query,priority) );
     ```

--- a/extensions/omni_httpd/expected/cascading_query.out
+++ b/extensions/omni_httpd/expected/cascading_query.out
@@ -9,7 +9,7 @@ INSERT INTO routes (name, query, priority) VALUES
 \pset format wrapped
 \pset columns 80
 -- Preview the query
-SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORDER BY priority DESC;
+SELECT omni_httpd.cascading_query(name, query ORDER BY priority DESC NULLS LAST) FROM routes;
                                 cascading_query                                 
 --------------------------------------------------------------------------------
  WITH test AS (SELECT omni_httpd.http_response(body := 'test') FROM request WHE.
@@ -22,7 +22,7 @@ SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORD
 -- Try it
 BEGIN;
 WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9100) RETURNING id),
-     handler AS (INSERT INTO omni_httpd.handlers (query) SELECT omni_httpd.cascading_query(name, query) FROM routes GROUP BY priority ORDER BY priority DESC RETURNING id)
+     handler AS (INSERT INTO omni_httpd.handlers (query) SELECT omni_httpd.cascading_query(name, query ORDER BY priority DESC NULLS LAST) FROM routes RETURNING id)
 INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
 SELECT listener.id, handler.id
 FROM listener, handler;
@@ -38,11 +38,11 @@ pong
 -- CTE handling
 \pset format wrapped
 \pset columns 80
-SELECT omni_httpd.cascading_query(name, query) FROM (
+SELECT omni_httpd.cascading_query(name, query ORDER BY priority DESC NULLS LAST ) FROM (
   VALUES
   ('test', $$WITH test AS (SELECT 1 AS val) SELECT omni_httpd.http_response(body => 'test') FROM request, Test WHERE request.path = '/test' and test.val = 1$$, 1),
   ('ping', $$WITH test AS (SELECT 1 AS val) SELECT omni_httpd.http_response(body => 'pong') FROM request, Test WHERE request.path = '/ping' and test.val = 1$$, 1))
-  AS routes(name, query, priority) GROUP BY priority ORDER BY priority DESC;
+  AS routes(name, query, priority);
                                 cascading_query                                 
 --------------------------------------------------------------------------------
  WITH __omni_httpd_test_test AS (SELECT 1 AS val), test AS (SELECT omni_httpd.h.

--- a/extensions/omni_httpd/expected/http.out
+++ b/extensions/omni_httpd/expected/http.out
@@ -7,23 +7,23 @@ INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
 BEGIN;
 WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9000) RETURNING id),
      handler AS (INSERT INTO omni_httpd.handlers (query)
-     SELECT omni_httpd.cascading_query(name, query) FROM (VALUES
+     SELECT omni_httpd.cascading_query(name, query ORDER BY priority DESC NULLS LAST) FROM (VALUES
       ('hello',
       $$SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!')
        FROM request
        INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
-      $$),
+      $$, 1),
       ('headers',
-      $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$),
+      $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$, 1),
       ('echo',
-      $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$),
+      $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$, 1),
       -- This validates that `request CTE` can be casted to http_request
       ('http_request',
-      $$SELECT omni_httpd.http_response(body => request.*::omni_httpd.http_request::text) FROM request WHERE request.path = '/http_request'$$),
+      $$SELECT omni_httpd.http_response(body => request.*::omni_httpd.http_request::text) FROM request WHERE request.path = '/http_request'$$, 1),
       ('not_found',
       $$SELECT omni_httpd.http_response(status => 404, body => json_build_object('method', request.method, 'path', request.path, 'query_string', request.query_string))
-       FROM request$$)
-     ) AS routes(name,query)
+       FROM request$$, 0)
+     ) AS routes(name,query, priority)
 RETURNING id)
 INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
 SELECT listener.id, handler.id

--- a/extensions/omni_httpd/sql/http.sql
+++ b/extensions/omni_httpd/sql/http.sql
@@ -9,23 +9,23 @@ INSERT INTO users (handle, name) VALUES ('johndoe', 'John');
 BEGIN;
 WITH listener AS (INSERT INTO omni_httpd.listeners (address, port) VALUES ('127.0.0.1', 9000) RETURNING id),
      handler AS (INSERT INTO omni_httpd.handlers (query)
-     SELECT omni_httpd.cascading_query(name, query) FROM (VALUES
+     SELECT omni_httpd.cascading_query(name, query ORDER BY priority DESC NULLS LAST) FROM (VALUES
       ('hello',
       $$SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!')
        FROM request
        INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
-      $$),
+      $$, 1),
       ('headers',
-      $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$),
+      $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$, 1),
       ('echo',
-      $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$),
+      $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$, 1),
       -- This validates that `request CTE` can be casted to http_request
       ('http_request',
-      $$SELECT omni_httpd.http_response(body => request.*::omni_httpd.http_request::text) FROM request WHERE request.path = '/http_request'$$),
+      $$SELECT omni_httpd.http_response(body => request.*::omni_httpd.http_request::text) FROM request WHERE request.path = '/http_request'$$, 1),
       ('not_found',
       $$SELECT omni_httpd.http_response(status => 404, body => json_build_object('method', request.method, 'path', request.path, 'query_string', request.query_string))
-       FROM request$$)
-     ) AS routes(name,query)
+       FROM request$$, 0)
+     ) AS routes(name,query, priority)
 RETURNING id)
 INSERT INTO omni_httpd.listeners_handlers (listener_id, handler_id)
 SELECT listener.id, handler.id


### PR DESCRIPTION
As used right now, the aggregate is not guaranteed to produce the query in the intended order.

From Postgres documentation:

```
Ordinarily, the input rows are fed to the aggregate function in an
unspecified order. In many cases this does not matter; for example, min
produces the same result no matter what order it receives the inputs in.
However, some aggregate functions (such as array_agg and string_agg)
produce results that depend on the ordering of the input rows. When
using such an aggregate, the optional order_by_clause can be used to
specify the desired ordering.
```

Solution: use `ORDER BY` clause inside the aggregator.