### PR TITLE
Problem: http_response is volatile

### DIFF
--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -32,7 +32,7 @@ CREATE FUNCTION http_response(
 )
     RETURNS http_response
     AS 'MODULE_PATHNAME', 'http_response'
-    LANGUAGE C;
+    LANGUAGE C IMMUTABLE;
 
 CREATE DOMAIN port integer CHECK (VALUE >= 0 AND VALUE <= 65535);
 


### PR DESCRIPTION
This may prevent some optimizations.

Solution: make it immutable

In my naive benchmarking, the performance gain was minimal (if any). Yet, perhaps, it's best to keep it immutable as it may still be better.