### PR TITLE
Problem: http_response function may crash

### DIFF
--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -23,7 +23,7 @@ add_postgresql_extension(
         SCRIPTS omni_httpd--0.1.sql
         SOURCES omni_httpd.c master_worker.c http_worker.c fd.c cascading_query.c
         TESTS_REQUIRE omni_ext
-        REGRESS http role_name cascading_query handler_validity port_selector)
+        REGRESS http role_name cascading_query handler_validity port_selector http_response)
 
 target_link_libraries(omni_httpd libh2o-evloop libpgaug libomnisql libgluepg_stc dynpgext metalang99)
 

--- a/extensions/omni_httpd/expected/http_response.out
+++ b/extensions/omni_httpd/expected/http_response.out
@@ -1,0 +1,84 @@
+-- NULL status
+SELECT omni_httpd.http_response(status => null, body => 'test');
+                                 http_response                                  
+--------------------------------------------------------------------------------
+ (200,"{""(content-type,\\""text/plain; charset=utf-8\\"",f)""}","\\x74657374")
+(1 row)
+
+-- NULL headers
+SELECT omni_httpd.http_response(headers => null, body => 'test');
+                                 http_response                                  
+--------------------------------------------------------------------------------
+ (200,"{""(content-type,\\""text/plain; charset=utf-8\\"",f)""}","\\x74657374")
+(1 row)
+
+-- NULL body
+SELECT omni_httpd.http_response(body => null);
+ http_response 
+---------------
+ (200,,)
+(1 row)
+
+-- Text body
+SELECT omni_httpd.http_response(body => 'text');
+                                 http_response                                  
+--------------------------------------------------------------------------------
+ (200,"{""(content-type,\\""text/plain; charset=utf-8\\"",f)""}","\\x74657874")
+(1 row)
+
+-- JSON body
+SELECT omni_httpd.http_response(body => '{}'::json);
+                   http_response                    
+----------------------------------------------------
+ (200,"{""(content-type,text/json,f)""}","\\x7b7d")
+(1 row)
+
+-- JSONB body
+SELECT omni_httpd.http_response(body => '{}'::jsonb);
+                   http_response                    
+----------------------------------------------------
+ (200,"{""(content-type,text/json,f)""}","\\x7b7d")
+(1 row)
+
+-- Binary body
+SELECT omni_httpd.http_response(body => convert_to('binary', 'UTF8'));
+                               http_response                               
+---------------------------------------------------------------------------
+ (200,"{""(content-type,application/octet-stream,f)""}","\\x62696e617279")
+(1 row)
+
+-- Specifying status
+SELECT omni_httpd.http_response(status => 404);
+ http_response 
+---------------
+ (404,,)
+(1 row)
+
+-- Specifying headers
+SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('test', 'value')]::omni_httpd.http_header[], body => null);
+         http_response         
+-------------------------------
+ (200,"{""(test,value,f)""}",)
+(1 row)
+
+-- Merging headers with inferred ones
+SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('test', 'value')]::omni_httpd.http_header[], body => 'test');
+                                           http_response                                           
+---------------------------------------------------------------------------------------------------
+ (200,"{""(test,value,f)"",""(content-type,\\""text/plain; charset=utf-8\\"",f)""}","\\x74657374")
+(1 row)
+
+-- Overriding content type
+SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'test');
+                     http_response                      
+--------------------------------------------------------
+ (200,"{""(content-type,text/html,f)""}","\\x74657374")
+(1 row)
+
+-- Overriding content type, with a different case
+SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('Content-Type', 'text/html')], body => 'test');
+                     http_response                      
+--------------------------------------------------------
+ (200,"{""(Content-Type,text/html,f)""}","\\x74657374")
+(1 row)
+

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -27,8 +27,8 @@ CREATE TYPE http_response AS (
 
 CREATE FUNCTION http_response(
     status int DEFAULT 200,
-    headers http_header[] DEFAULT array[]::http_header[],
-    body anycompatible DEFAULT ''::bytea
+    headers http_header[] DEFAULT NULL,
+    body anycompatible DEFAULT NULL
 )
     RETURNS http_response
     AS 'MODULE_PATHNAME', 'http_response'

--- a/extensions/omni_httpd/sql/http_response.sql
+++ b/extensions/omni_httpd/sql/http_response.sql
@@ -1,0 +1,34 @@
+-- NULL status
+SELECT omni_httpd.http_response(status => null, body => 'test');
+
+-- NULL headers
+SELECT omni_httpd.http_response(headers => null, body => 'test');
+
+-- NULL body
+SELECT omni_httpd.http_response(body => null);
+
+-- Text body
+SELECT omni_httpd.http_response(body => 'text');
+
+-- JSON body
+SELECT omni_httpd.http_response(body => '{}'::json);
+
+-- JSONB body
+SELECT omni_httpd.http_response(body => '{}'::jsonb);
+
+-- Binary body
+SELECT omni_httpd.http_response(body => convert_to('binary', 'UTF8'));
+
+-- Specifying status
+SELECT omni_httpd.http_response(status => 404);
+
+-- Specifying headers
+SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('test', 'value')]::omni_httpd.http_header[], body => null);
+
+-- Merging headers with inferred ones
+SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('test', 'value')]::omni_httpd.http_header[], body => 'test');
+
+-- Overriding content type
+SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('content-type', 'text/html')], body => 'test');
+-- Overriding content type, with a different case
+SELECT omni_httpd.http_response(headers => array[omni_httpd.http_header('Content-Type', 'text/html')], body => 'test');


### PR DESCRIPTION
When given NULL parameters, it will.

Solution: check for NULL and provide defaults where appropriate

While at it, fixed a bunch of issues pertaining to http headers array manipulation.