### PR TITLE
Problem: parse_query_string takes text only

### DIFF
--- a/extensions/omni_web/expected/smoketest.out
+++ b/extensions/omni_web/expected/smoketest.out
@@ -46,3 +46,14 @@ select omni_web.parse_query_string('a=%20&b=1+3');
  {a," ",b,"1 3"}
 (1 row)
 
+-- Ensure it works with binaries that can be converted
+-- to strings
+select omni_web.parse_query_string(convert_to('a=x&b=1', 'UTF8'));
+ parse_query_string 
+--------------------
+ {a,x,b,1}
+(1 row)
+
+-- Ensure it fails with an arbitrary binary
+select omni_web.parse_query_string(E'\x0000'::bytea);
+ERROR:  invalid byte sequence for encoding "UTF8": 0x00

--- a/extensions/omni_web/omni_web--0.1.sql
+++ b/extensions/omni_web/omni_web--0.1.sql
@@ -3,3 +3,10 @@ create function parse_query_string(query_string text) returns text[]
 as
 'MODULE_PATHNAME',
 'parse_query_string' language c;
+
+create function parse_query_string(query_string bytea) returns text[]
+    strict immutable
+as
+$$
+select omni_web.parse_query_string(convert_from(query_string, 'UTF8'));
+$$ language sql;

--- a/extensions/omni_web/sql/smoketest.sql
+++ b/extensions/omni_web/sql/smoketest.sql
@@ -6,3 +6,10 @@ select omni_web.parse_query_string('a=x&b=1');
 select omni_web.parse_query_string('a&b=1');
 select omni_web.parse_query_string('a=%20&b=1');
 select omni_web.parse_query_string('a=%20&b=1+3');
+
+-- Ensure it works with binaries that can be converted
+-- to strings
+select omni_web.parse_query_string(convert_to('a=x&b=1', 'UTF8'));
+
+-- Ensure it fails with an arbitrary binary
+select omni_web.parse_query_string(E'\x0000'::bytea);


### PR DESCRIPTION
However, omni_httpd.http_request.body is a bytea

Solution: make it take bytea, too