### PR TITLE
Problem: updating test results of multiple components

### DIFF
--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -306,11 +306,15 @@ ${_loadextensions} \
         endif()
 
         add_custom_target(
-            ${NAME}_update_results
-            COMMAND
-            ${CMAKE_COMMAND} -E copy_if_different
-            ${CMAKE_CURRENT_BINARY_DIR}/${NAME}/results/*.out
-            ${CMAKE_CURRENT_SOURCE_DIR}/expected)
+                ${NAME}_update_results
+                COMMAND
+                ${CMAKE_COMMAND} -E copy_if_different
+                ${CMAKE_CURRENT_BINARY_DIR}/${NAME}/results/*.out
+                ${CMAKE_CURRENT_SOURCE_DIR}/expected)
+        if(NOT TARGET update_test_results)
+            add_custom_target(update_test_results)
+        endif()
+        add_dependencies(update_test_results ${NAME}_update_results)
     endif()
 
     if(INITDB AND CREATEDB AND (PSQL OR PGCLI) AND PG_CTL)


### PR DESCRIPTION
Sometimes, a lot of tests change at once (code reformatting is one example) and updating expected results one component at a time (with `make <COMPONENT>_update_results`) can be a frustrating experience.

Solution: add `update_test_results` target to update them all