### PR TITLE
Problem: container image contains omni_httpd only

### DIFF
--- a/docker/initdb/001-settings.sql
+++ b/docker/initdb/001-settings.sql
@@ -1,2 +1,2 @@
-ALTER SYSTEM SET max_worker_processes = 64;
-ALTER SYSTEM SET shared_preload_libraries = 'omni_ext--0.1';
+alter system set max_worker_processes = 64;
+alter system set shared_preload_libraries = 'omni_ext--0.1';

--- a/docker/initdb/003-default-extensions.sql
+++ b/docker/initdb/003-default-extensions.sql
@@ -1,0 +1,2 @@
+create extension omni_httpd;
+create extension omni_web;

--- a/docker/initdb/003-httpd.sql
+++ b/docker/initdb/003-httpd.sql
@@ -1,2 +1,0 @@
--- Install omni_httpd by default (at least for the time being)
-CREATE EXTENSION omni_httpd;


### PR DESCRIPTION
However, there's also useful functionality in omni_web, and without it, examples from the documentation may not work.

Solution: include omni_web by default as well.