### PR TITLE
Problem: accessing HTTP headers

### DIFF
--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -23,7 +23,7 @@ add_postgresql_extension(
         SCRIPTS omni_httpd--0.1.sql
         SOURCES omni_httpd.c master_worker.c http_worker.c fd.c cascading_query.c
         TESTS_REQUIRE omni_ext
-        REGRESS http role_name cascading_query handler_validity port_selector http_response)
+        REGRESS http role_name cascading_query handler_validity port_selector http_response headers)
 
 target_link_libraries(omni_httpd libh2o-evloop libpgaug libomnisql libgluepg_stc dynpgext metalang99)
 

--- a/extensions/omni_httpd/docs/headers.md
+++ b/extensions/omni_httpd/docs/headers.md
@@ -1,0 +1,11 @@
+# Headers
+
+HTTP requests come with headers, which can be retrieved using `omni_httpd.header_get` and `omni_httpd.header_get_all`
+functions:
+
+```sql
+select omni_httpd.header_get(request.headers, 'host') as host;
+select omni_httpd.header_get_all(request.headers, 'accept') as accept;
+```
+
+The header name these functions take is case insensitive.

--- a/extensions/omni_httpd/expected/headers.out
+++ b/extensions/omni_httpd/expected/headers.out
@@ -1,0 +1,22 @@
+select omni_httpd.http_header_get(array [omni_httpd.http_header('Host', 'omnihost')], 'Host');
+ http_header_get 
+-----------------
+ omnihost
+(1 row)
+
+select omni_httpd.http_header_get(array [omni_httpd.http_header('Host', 'omnihost')], 'host');
+ http_header_get 
+-----------------
+ omnihost
+(1 row)
+
+select
+    omni_httpd.http_header_get_all(
+            array [omni_httpd.http_header('Accept', 'application/xml'), omni_httpd.http_header('Accept', 'application/json')],
+            'accept');
+ http_header_get_all 
+---------------------
+ application/xml
+ application/json
+(2 rows)
+

--- a/extensions/omni_httpd/mkdocs.yml
+++ b/extensions/omni_httpd/mkdocs.yml
@@ -1,2 +1,5 @@
 INHERIT: ../../mkdocs.base.yml
 site_name: omni_httpd
+nav:
+  - Intro: 'intro.md'
+  - Headers: 'headers.md'

--- a/extensions/omni_httpd/sql/headers.sql
+++ b/extensions/omni_httpd/sql/headers.sql
@@ -1,0 +1,6 @@
+select omni_httpd.http_header_get(array [omni_httpd.http_header('Host', 'omnihost')], 'Host');
+select omni_httpd.http_header_get(array [omni_httpd.http_header('Host', 'omnihost')], 'host');
+select
+    omni_httpd.http_header_get_all(
+            array [omni_httpd.http_header('Accept', 'application/xml'), omni_httpd.http_header('Accept', 'application/json')],
+            'accept');


### PR DESCRIPTION
This requires processing an array and ensuring case is correct. However, this is such a common piece of functionality that it should be simpler.

Solution: add `http_header_get` and `http_header_get_all` functions