### PR TITLE
Problem: using omni_web.param_get family

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ update omni_httpd.handlers
 set
     query =
         $$select omni_httpd.http_response('Hello, ' || 
-                   coalesce(omni_web.param_get(omni_web.parse_query_string(request.query_string), 'name'), 'world') || '!')
+                   coalesce(omni_web.param_get(request.query_string, 'name'), 'world') || '!')
           from request;$$;
 ```
 

--- a/extensions/omni_web/expected/params.out
+++ b/extensions/omni_web/expected/params.out
@@ -1,12 +1,12 @@
 -- params type
-select array['key', 'value']::omni_web.params;
+select array ['key', 'value']::omni_web.params;
     array    
 -------------
  {key,value}
 (1 row)
 
 -- Invalid params should fail:
-select array['key']::omni_web.params;
+select array ['key']::omni_web.params;
 ERROR:  value for domain omni_web.params violates check constraint "params_check"
 \pset null '<null>'
 select omni_web.param_get(omni_web.parse_query_string('a=1&a=2'), 'a');
@@ -25,6 +25,33 @@ select omni_web.param_get_all(omni_web.parse_query_string('a&a=2'), 'a');
  param_get_all 
 ---------------
  <null>
+ 2
+(2 rows)
+
+-- Shortcuts
+select omni_web.param_get('a=1', 'a');
+ param_get 
+-----------
+ 1
+(1 row)
+
+select omni_web.param_get(convert_to('a=1', 'utf8'), 'a');
+ param_get 
+-----------
+ 1
+(1 row)
+
+select omni_web.param_get_all('a=1&a=2', 'a');
+ param_get_all 
+---------------
+ 1
+ 2
+(2 rows)
+
+select omni_web.param_get_all(convert_to('a=1&a=2', 'utf8'), 'a');
+ param_get_all 
+---------------
+ 1
  2
 (2 rows)
 

--- a/extensions/omni_web/omni_web--0.1.sql
+++ b/extensions/omni_web/omni_web--0.1.sql
@@ -29,6 +29,22 @@ order by
 $$
     language sql;
 
+create function param_get_all(params text, param text) returns setof text
+    strict immutable
+as
+$$
+select omni_web.param_get_all(omni_web.parse_query_string(params), param);
+$$
+    language sql;
+
+create function param_get_all(params bytea, param text) returns setof text
+    strict immutable
+as
+$$
+select omni_web.param_get_all(omni_web.parse_query_string(convert_from(params, 'UTF8')), param);
+$$
+    language sql;
+
 create function param_get(params params, param text) returns text
     strict immutable
 as
@@ -38,5 +54,21 @@ select
 from
     omni_web.param_get_all(params, param)
 limit 1
+$$
+    language sql;
+
+create function param_get(params text, param text) returns text
+    strict immutable
+as
+$$
+select omni_web.param_get(omni_web.parse_query_string(params), param);
+$$
+    language sql;
+
+create function param_get(params bytea, param text) returns text
+    strict immutable
+as
+$$
+select omni_web.param_get(omni_web.parse_query_string(convert_from(params, 'UTF8')), param);
 $$
     language sql;

--- a/extensions/omni_web/sql/params.sql
+++ b/extensions/omni_web/sql/params.sql
@@ -1,9 +1,15 @@
 -- params type
-select array['key', 'value']::omni_web.params;
+select array ['key', 'value']::omni_web.params;
 -- Invalid params should fail:
-select array['key']::omni_web.params;
+select array ['key']::omni_web.params;
 
 \pset null '<null>'
 select omni_web.param_get(omni_web.parse_query_string('a=1&a=2'), 'a');
 select omni_web.param_get(omni_web.parse_query_string('a&a=2'), 'a');
 select omni_web.param_get_all(omni_web.parse_query_string('a&a=2'), 'a');
+
+-- Shortcuts
+select omni_web.param_get('a=1', 'a');
+select omni_web.param_get(convert_to('a=1', 'utf8'), 'a');
+select omni_web.param_get_all('a=1&a=2', 'a');
+select omni_web.param_get_all(convert_to('a=1&a=2', 'utf8'), 'a');


### PR DESCRIPTION
It requires a lot of typing:

```
omni_web.param_get(omni_web.parse_query_string(...), param)
```

Solution: accept text & bytea as params and parse them on the fly