### PR TITLE
Problem: updating omni_httpd.listeners port

### DIFF
--- a/extensions/omni_httpd/expected/port_selector.out
+++ b/extensions/omni_httpd/expected/port_selector.out
@@ -1,8 +1,9 @@
 --- Force omni_httpd to select a port
 begin;
 with
-    listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 0) returning id),
-    handler as (insert into omni_httpd.handlers (query) values ($$SELECT$$))
+    listener
+        as (insert into omni_httpd.listeners (address, port, effective_port) values ('127.0.0.1', 0, 0) returning id),
+    handler as (insert into omni_httpd.handlers (query) values ($$SELECT$$) returning id)
 insert
 into
     omni_httpd.listeners_handlers (listener_id, handler_id)
@@ -12,13 +13,9 @@ select
 from
     listener,
     handler;
-ERROR:  WITH query "handler" does not have a RETURNING clause
-LINE 12:     handler;
-             ^
 delete
 from
     omni_httpd.configuration_reloads;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
 end;
 call omni_httpd.wait_for_configuration_reloads(1);
 -- Ensure port was updated
@@ -27,7 +24,7 @@ select
 from
     omni_httpd.listeners
 where
-    port = 0;
+    effective_port = 0;
  count 
 -------
      0

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -163,10 +163,11 @@ void http_worker(Datum db_oid) {
       SPI_connect();
 
       int ret = SPI_execute(
-          "SELECT listeners.address, listeners.port, handlers.query, handlers.role_name FROM "
+          "select listeners.address, listeners.effective_port, handlers.query, handlers.role_name "
+          "from "
           "omni_httpd.listeners_handlers "
-          "INNER JOIN omni_httpd.listeners ON listeners.id = listeners_handlers.listener_id "
-          "INNER JOIN omni_httpd.handlers handlers ON handlers.id = listeners_handlers.handler_id",
+          "inner join omni_httpd.listeners on listeners.id = listeners_handlers.listener_id "
+          "inner join omni_httpd.handlers handlers on handlers.id = listeners_handlers.handler_id",
           false, 0);
       if (ret == SPI_OK_SELECT) {
         TupleDesc tupdesc = SPI_tuptable->tupdesc;
@@ -256,12 +257,12 @@ void http_worker(Datum db_oid) {
               MemoryContext memory_context = CurrentMemoryContext;
               char *request_cte = psprintf(
                   // clang-format off
-                                  "SELECT " "$" REQUEST_PLAN_PARAM(
+                                  "select " "$" REQUEST_PLAN_PARAM(
                                           REQUEST_PLAN_METHOD) "::text::omni_httpd.http_method AS method, "
-                                  "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_PATH) " AS path, "
-                                  "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_QUERY_STRING) " AS query_string, "
-                                  "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_BODY) " AS body, "
-                                  "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_HEADERS) " AS headers "
+                                  "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_PATH) " as path, "
+                                  "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_QUERY_STRING) " as query_string, "
+                                  "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_BODY) " as body, "
+                                  "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_HEADERS) " as headers "
                   // clang-format on
               );
 

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -73,11 +73,11 @@ create type http_protocol as enum ('http', 'https');
 
 create table listeners
 (
-    id       integer primary key generated always as identity,
-    address  inet          not null default '127.0.0.1',
-    port     port          not null default 80,
-    protocol http_protocol not null default 'http'
-    -- TODO: key/cert
+    id             integer primary key generated always as identity,
+    address        inet          not null default '127.0.0.1',
+    port           port          not null default 80,
+    effective_port port          not null default 0,
+    protocol       http_protocol not null default 'http'
 );
 
 create function check_if_role_accessible_to_current_user(role name) returns boolean

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -33,4 +33,9 @@ static const char *OMNI_HTTPD_CONFIGURATION_RELOAD_SEMAPHORE =
 #define HTTP_RESPONSE_TUPLE_STATUS 1
 #define HTTP_RESPONSE_TUPLE_HEADERS 2
 
+/**
+ * Indicates whether this process is `master_worker`
+ */
+extern bool IsOmniHttpdWorker;
+
 #endif //  OMNI_HTTPD_H

--- a/extensions/omni_httpd/sql/port_selector.sql
+++ b/extensions/omni_httpd/sql/port_selector.sql
@@ -1,8 +1,9 @@
 --- Force omni_httpd to select a port
 begin;
 with
-    listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 0) returning id),
-    handler as (insert into omni_httpd.handlers (query) values ($$SELECT$$))
+    listener
+        as (insert into omni_httpd.listeners (address, port, effective_port) values ('127.0.0.1', 0, 0) returning id),
+    handler as (insert into omni_httpd.handlers (query) values ($$SELECT$$) returning id)
 insert
 into
     omni_httpd.listeners_handlers (listener_id, handler_id)
@@ -25,6 +26,6 @@ select
 from
     omni_httpd.listeners
 where
-    port = 0;
+    effective_port = 0;
 
 -- TODO: Test request on a given port. Needs non-shell http client


### PR DESCRIPTION
When a port is specified as 0, omni_httpd will update it with the actual port. However, this means that on the restart, it'll keep using that port that was selected once.

The intention of using zero is to say, "pick one." And restarts should honour this.

Proposed solution: add effective_port column

This way omni_httpd can use it always update to set the selected port.

While at it, changed relevant SQL code in C files to be lowercase to match the style elsewhere.

Closes #111