### PR TITLE
Problem: omni_httpd workers are blocking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install OpenSSL
+    - name: Install necessary dependencies
+      # OpenSSL and `timeout` (from coreutils)
       if: matrix.os == 'macos-12'
       env:
         HOMEBREW_NO_AUTO_UPDATE: "1"
@@ -41,7 +42,7 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: "1"
       run: |
         brew update
-        brew install openssl@3
+        brew install openssl@3 coreutils
 
     - name: Install recent curl on Linux
       if: matrix.os == 'ubuntu-latest'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,9 +19,8 @@ mergedeep==1.3.4
 mkdocs==1.4.2
 mkdocs-awesome-pages-plugin==2.8.0
 mkdocs-include-markdown-plugin==4.0.4
-mkdocs-material==9.1.3
+mkdocs-material==9.1.5
 mkdocs-material-extensions==1.1.1
-mkdocs-mermaid2-plugin==0.6.0
 mkdocs-monorepo-plugin==1.0.4
 natsort==8.2.0
 packaging==23.0

--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -3,6 +3,7 @@ project(omni_httpd)
 
 include(CTest)
 include(FindPkgConfig)
+include(FindThreads)
 
 list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
 
@@ -11,6 +12,9 @@ enable_testing()
 find_package(PostgreSQL REQUIRED)
 find_package(H2O REQUIRED)
 find_package(Metalang REQUIRED)
+if(NOT Threads_FOUND)
+        message(FATAL_ERROR "Threading library required (such as pthreads)")
+endif()
 
 pkg_check_modules(BROTLI_DEC libbrotlidec)
 pkg_check_modules(BROTLI_ENC libbrotlienc)
@@ -21,11 +25,14 @@ add_postgresql_extension(
         SCHEMA omni_httpd
         RELOCATABLE false
         SCRIPTS omni_httpd--0.1.sql
-        SOURCES omni_httpd.c master_worker.c http_worker.c fd.c cascading_query.c
+        SOURCES omni_httpd.c master_worker.c http_worker.c event_loop.c fd.c cascading_query.c
         TESTS_REQUIRE omni_ext
         REGRESS http role_name cascading_query handler_validity port_selector http_response headers)
 
-target_link_libraries(omni_httpd libh2o-evloop libpgaug libomnisql libgluepg_stc dynpgext metalang99)
+set_property(TARGET omni_httpd PROPERTY C_STANDARD 11)
+
+target_link_libraries(omni_httpd libh2o-evloop libpgaug libomnisql libgluepg_stc dynpgext metalang99
+        Threads::Threads)
 
 # Disable full macro expansion backtraces for Metalang99.
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")

--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -27,7 +27,8 @@ add_postgresql_extension(
         SCRIPTS omni_httpd--0.1.sql
         SOURCES omni_httpd.c master_worker.c http_worker.c event_loop.c fd.c cascading_query.c
         TESTS_REQUIRE omni_ext
-        REGRESS http role_name cascading_query handler_validity port_selector http_response headers)
+        REGRESS http role_name cascading_query handler_validity port_selector http_response headers
+        http2_reproxy)
 
 set_property(TARGET omni_httpd PROPERTY C_STANDARD 11)
 

--- a/extensions/omni_httpd/docs/architecture.md
+++ b/extensions/omni_httpd/docs/architecture.md
@@ -1,0 +1,34 @@
+# Architecture
+
+```mermaid
+sequenceDiagram
+    actor B as Browser
+    box lightyellow Multiple instances
+      participant H as HTTP server thread
+      participant HW as HTTP worker
+    end
+    participant MW as Master worker
+    participant P as Postgres
+    actor O as Operator
+   
+    P -->> MW: Start background worker
+    loop omni_httpd.http_workers GUC times
+      MW -->> HW: Start background worker
+    end
+    HW -->> H: Start
+    loop for every request
+      B ->> H: HTTP request
+      critical Dispatch
+       H ->> HW: Request
+       HW ->> HW: Run handler query
+      option HTTP worker busy (HTTP/2+)
+       H ->> H: proxy to another worker
+      option HTTP worker busy (HTTP/1)
+       H ->> H: Wait until not busy
+      end
+      HW ->> H: Response
+      H ->> B: Response
+    end
+
+    O ->> P: Update listeners and/or handlers
+```

--- a/extensions/omni_httpd/docs/architecture.md
+++ b/extensions/omni_httpd/docs/architecture.md
@@ -1,7 +1,35 @@
 # Architecture
 
+omni_httpd serves HTTP connections
+by employing a fleet of background workers.
+
+There's a master worker that handles starting HTTP workers
+and handling configuration change requests [^1]
+
+[^1]:
+Triggered by changes to `omni_httpd.listeners` or `omni_httpd.handlers` or manually
+using `omni_httpd.reload_configuration()`)
+
+There are multiple HTTP workers [^2]. Each HTTP worker is an instance of Postgres and
+can therefore handle incoming requests. This is done by running handlers defined in
+the `omni_httpd.handlers` table on the main thread, and handling network I/O of
+HTTP requests and responses on a secondary thread [^3].
+
+[^2]:
+Can be configured using `omni_httpd.http_workers` configuration variable. Defaults to number of CPU cores online.
+
+[^3]:
+This thread is strictly prohibited from calling into Postgres.
+
+To enable scenarios where multiplexing is possible (such as HTTP/2), omni_httpd
+will attempt to re-send incoming HTTP/2 (or higher) requests to other workers
+if the current worker is busy handling a request.
+
+Below is a diagram outlining general workflow.
+
 ```mermaid
 sequenceDiagram
+    autonumber
     actor B as Browser
     box lightyellow Multiple instances
       participant H as HTTP server thread
@@ -32,3 +60,11 @@ sequenceDiagram
 
     O ->> P: Update listeners and/or handlers
 ```
+
+??? tip "What to know more?"
+
+    * :two: Master worker opens the listening socket and shares it with HTTP
+       workers over a UNIX socket (using `SCM_RIGHTS`). More work needs to
+       be done to improve this. Please consider [contributing](https://github.com/omnigres/omnigres/issues/41)!
+    * :three: Actual HTTP functionality is enabled by awesome [h2o](https://h2o.examp1e.net/) web server. Particularly,
+      its libh2o component.

--- a/extensions/omni_httpd/event_loop.c
+++ b/extensions/omni_httpd/event_loop.c
@@ -1,0 +1,232 @@
+#include <signal.h>
+#include <stdatomic.h>
+
+#include <h2o.h>
+
+#include "event_loop.h"
+
+#ifdef POSTGRES_H
+#error "event_loop.c can't use any Postgres API"
+#endif
+
+h2o_evloop_t *worker_event_loop;
+
+atomic_bool worker_running;
+atomic_bool worker_reload;
+bool event_loop_suspended;
+bool event_loop_resumed;
+pthread_mutex_t event_loop_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t event_loop_resume_cond = PTHREAD_COND_INITIALIZER;
+pthread_cond_t event_loop_resume_cond_ack = PTHREAD_COND_INITIALIZER;
+
+h2o_multithread_receiver_t event_loop_receiver;
+h2o_multithread_queue_t *event_loop_queue;
+
+static size_t requests_in_flight = 0;
+
+typedef struct {
+  h2o_multithread_message_t super;
+  request_message_t *reqmsg;
+  size_t bufcnt;
+  h2o_send_state_t state;
+  h2o_sendvec_t vecs;
+} send_message_t;
+
+static void h2o_queue_send(request_message_t *msg, h2o_iovec_t *bufs, size_t bufcnt,
+                           h2o_send_state_t state) {
+  if (state == H2O_SEND_STATE_FINAL) {
+    requests_in_flight--;
+  }
+  h2o_req_t *req = msg->req;
+  if (req == NULL) {
+    // The connection is gone, bail
+    return;
+  }
+
+  send_message_t *message = malloc(sizeof(*message) - (sizeof(h2o_sendvec_t) * (bufcnt - 1)));
+  size_t i;
+  message->reqmsg = msg;
+  message->bufcnt = bufcnt;
+  message->state = state;
+
+  for (i = 0; i != bufcnt; ++i)
+    h2o_sendvec_init_raw(&message->vecs + i, bufs[i].base, bufs[i].len);
+
+  message->super = (h2o_multithread_message_t){{NULL}};
+
+  h2o_multithread_send_message(&event_loop_receiver, &message->super);
+}
+
+void h2o_queue_send_inline(request_message_t *msg, const char *body, size_t len) {
+  h2o_req_t *req = msg->req;
+  if (req == NULL) {
+    // The connection is gone, bail
+    return;
+  }
+  static h2o_generator_t generator = {NULL, NULL};
+
+  h2o_iovec_t buf = h2o_strdup(&req->pool, body, len);
+
+  /* the function intentionally does not set the content length, since it may be used for generating
+   * 304 response, etc. */
+  /* req->res.content_length = buf.len; */
+
+  h2o_start_response(req, &generator);
+
+  if (h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")))
+    h2o_queue_send(msg, NULL, 0, H2O_SEND_STATE_FINAL);
+  else
+    h2o_queue_send(msg, &buf, 1, H2O_SEND_STATE_FINAL);
+}
+
+static void on_message(h2o_multithread_receiver_t *receiver, h2o_linklist_t *messages) {
+  while (!h2o_linklist_is_empty(messages)) {
+    h2o_multithread_message_t *message =
+        H2O_STRUCT_FROM_MEMBER(h2o_multithread_message_t, link, messages->next);
+    send_message_t *send_msg = (send_message_t *)messages->next;
+    request_message_t *reqmsg = send_msg->reqmsg;
+    pthread_mutex_lock(&reqmsg->mutex);
+    if (reqmsg->req == NULL) {
+      // Connection is gone, bail
+      // Can release request message
+      free(reqmsg);
+      goto done;
+    }
+    h2o_sendvec(reqmsg->req, &send_msg->vecs, send_msg->bufcnt, send_msg->state);
+  done:
+    pthread_mutex_unlock(&reqmsg->mutex);
+    h2o_linklist_unlink(&message->link);
+    free(send_msg);
+  }
+}
+
+static void sighandler(int sig) {
+  switch (sig) {
+  case SIGUSR2:
+    atomic_store(&worker_reload, true);
+    h2o_multithread_send_message(&event_loop_receiver, NULL);
+    h2o_multithread_send_message(&handler_receiver, NULL);
+    break;
+  case SIGTERM:
+    atomic_store(&worker_running, false);
+    h2o_multithread_send_message(&event_loop_receiver, NULL);
+    h2o_multithread_send_message(&handler_receiver, NULL);
+    break;
+  default:
+    break;
+  }
+}
+
+void *event_loop(void *arg) {
+  assert(worker_event_loop != NULL);
+  assert(handler_queue != NULL);
+  assert(event_loop_queue != NULL);
+
+  h2o_multithread_register_receiver(event_loop_queue, &event_loop_receiver, on_message);
+
+  // Block signals except for SIGUSR2 and SIGTERM
+
+  struct sigaction handler;
+  handler.sa_handler = sighandler;
+  handler.sa_flags = 0;
+
+  sigemptyset(&handler.sa_mask);
+  sigaddset(&handler.sa_mask, SIGUSR2);
+  sigaddset(&handler.sa_mask, SIGTERM);
+  assert(sigprocmask(SIG_SETMASK, &handler.sa_mask, NULL) == 0);
+
+  assert(sigaction(SIGUSR2, &handler, NULL) == 0);
+  assert(sigaction(SIGTERM, &handler, NULL) == 0);
+
+  bool running = atomic_load(&worker_running);
+  bool reload = atomic_load(&worker_reload);
+
+  while (running) {
+    if (event_loop_suspended) {
+      pthread_mutex_lock(&event_loop_mutex);
+      while (event_loop_suspended) {
+        pthread_cond_wait(&event_loop_resume_cond, &event_loop_mutex);
+      }
+      event_loop_resumed = true;
+      pthread_cond_signal(&event_loop_resume_cond_ack);
+      pthread_mutex_unlock(&event_loop_mutex);
+    }
+
+    running = true;
+    reload = false;
+
+    while (running && !reload) {
+      while ((running = atomic_load(&worker_running)) && !(reload = atomic_load(&worker_reload)) &&
+             h2o_evloop_run(worker_event_loop, INT32_MAX) == 0)
+        ;
+    }
+
+    // Make sure request handler no longer waits
+    pthread_mutex_lock(&event_loop_mutex);
+    event_loop_resumed = false;
+    event_loop_suspended = true;
+    pthread_cond_signal(&event_loop_resume_cond_ack);
+    pthread_mutex_unlock(&event_loop_mutex);
+  }
+  return NULL;
+}
+
+void on_accept(h2o_socket_t *listener, const char *err) {
+  if (false /* TODO */) {
+    // Don't accept new connections if this instance is busy as we'd likely
+    // have to proxy it
+    return;
+  }
+  h2o_socket_t *sock;
+
+  if (err != NULL) {
+    return;
+  }
+
+  if ((sock = h2o_evloop_socket_accept(listener)) == NULL) {
+    return;
+  }
+  h2o_accept(listener_accept_ctx(listener), sock);
+}
+
+void req_dispose(void *ptr) {
+  request_message_t **message_ptr = (request_message_t **)ptr;
+  request_message_t *message = *message_ptr;
+  pthread_mutex_lock(&message->mutex);
+  message->req = NULL;
+  pthread_mutex_unlock(&message->mutex);
+}
+
+int event_loop_req_handler(h2o_handler_t *self, h2o_req_t *req) {
+  if (requests_in_flight > 0 && req->version >= 0x0200) {
+    // If HTTP/2 or above is used, they can return results of requests
+    // before the previous result is retrieved, so we'll try to proxy it
+    // to another worker.
+    h2o_req_overrides_t *overrides = h2o_mem_alloc_pool(&req->pool, h2o_req_overrides_t, 1);
+
+    *overrides = (h2o_req_overrides_t){NULL};
+    overrides->use_proxy_protocol = false;
+    overrides->proxy_preserve_host = true;
+    overrides->forward_close_connection = true;
+
+    // request reprocess (note: path may become an empty string, to which one of the target URL
+    // within the socketpool will be right-padded when lib/core/proxy connects to upstream; see
+    // #1563)
+    h2o_iovec_t path = h2o_build_destination(req, NULL, 0, 0);
+    h2o_reprocess_request(req, req->method, req->scheme, req->authority, path, overrides, 0);
+    return 0;
+  }
+  requests_in_flight++;
+  request_message_t *msg = malloc(sizeof(*msg));
+  msg->super = (h2o_multithread_message_t){{NULL}};
+  msg->req = req;
+  pthread_mutex_init(&msg->mutex, NULL);
+
+  // Track request deallocation
+  request_message_t **msgref =
+      (request_message_t **)h2o_mem_alloc_shared(&req->pool, sizeof(msg), req_dispose);
+  *msgref = msg;
+
+  h2o_multithread_send_message(&handler_receiver, &msg->super);
+  return 0;
+}

--- a/extensions/omni_httpd/event_loop.c
+++ b/extensions/omni_httpd/event_loop.c
@@ -159,6 +159,8 @@ void on_accept(h2o_socket_t *listener, const char *err) {
 }
 
 void req_dispose(void *ptr) {
+  // If HTTP request is disposed (can happen if the connection goes away, too)
+  // ensure we signal that by nulling `req` safely.
   request_message_t **message_ptr = (request_message_t **)ptr;
   request_message_t *message = *message_ptr;
   pthread_mutex_lock(&message->mutex);

--- a/extensions/omni_httpd/event_loop.c
+++ b/extensions/omni_httpd/event_loop.c
@@ -141,9 +141,9 @@ void *event_loop(void *arg) {
 }
 
 void on_accept(h2o_socket_t *listener, const char *err) {
-  if (false /* TODO */) {
+  if (requests_in_flight > 0) {
     // Don't accept new connections if this instance is busy as we'd likely
-    // have to proxy it
+    // have to proxy it (or put in the queue if it is not HTTP/2+)
     return;
   }
   h2o_socket_t *sock;

--- a/extensions/omni_httpd/event_loop.h
+++ b/extensions/omni_httpd/event_loop.h
@@ -1,0 +1,49 @@
+#ifndef OMNI_HTTPD_EVENT_LOOP_H
+#define OMNI_HTTPD_EVENT_LOOP_H
+
+#include <pthread.h>
+#include <stdbool.h>
+
+extern h2o_evloop_t *worker_event_loop;
+
+extern atomic_bool worker_running;
+extern atomic_bool worker_reload;
+extern bool event_loop_suspended;
+extern bool event_loop_resumed;
+extern pthread_mutex_t event_loop_mutex;
+extern pthread_cond_t event_loop_resume_cond;
+extern pthread_cond_t event_loop_resume_cond_ack;
+extern pthread_cond_t event_loop_request_cond;
+extern h2o_multithread_receiver_t event_loop_receiver;
+extern h2o_multithread_queue_t *event_loop_queue;
+
+typedef struct {
+  h2o_multithread_message_t super;
+  h2o_req_t *req;
+  pthread_mutex_t mutex;
+} request_message_t;
+
+extern h2o_multithread_receiver_t handler_receiver;
+extern h2o_multithread_queue_t *handler_queue;
+void *event_loop(void *arg);
+
+/**
+ * Returns socket's accept context
+ * @param listener
+ * @return
+ */
+h2o_accept_ctx_t *listener_accept_ctx(h2o_socket_t *listener);
+
+/**
+ * @brief Accept socket
+ *
+ * @param listener
+ * @param err
+ */
+void on_accept(h2o_socket_t *listener, const char *err);
+
+int event_loop_req_handler(h2o_handler_t *self, h2o_req_t *req);
+
+void h2o_queue_send_inline(request_message_t *msg, const char *body, size_t len);
+
+#endif // OMNI_HTTPD_EVENT_LOOP_H

--- a/extensions/omni_httpd/event_loop.h
+++ b/extensions/omni_httpd/event_loop.h
@@ -4,26 +4,74 @@
 #include <pthread.h>
 #include <stdbool.h>
 
+/**
+ * This event loop handles incoming connections
+ */
 extern h2o_evloop_t *worker_event_loop;
 
+/**
+ * Indicates whether the worker should be running.
+ */
 extern atomic_bool worker_running;
+
+/**
+ * Indicates whether the worker should be reloaded
+ */
 extern atomic_bool worker_reload;
+
+/**
+ * Indicates if `worker_event_loop` should be suspended
+ */
 extern bool event_loop_suspended;
+
+/**
+ * Indicates if `worker_event_loop` has been resumed
+ */
 extern bool event_loop_resumed;
+
+/**
+ * Mutex to access condvars like `event_loop_resume_cond` and
+ * `event_loop_resume_cond_ack`
+ */
 extern pthread_mutex_t event_loop_mutex;
+
+/**
+ * Signals that `worker_event_loop` should be resumed
+ */
 extern pthread_cond_t event_loop_resume_cond;
+
+/**
+ * Signals that `worker_event_loop` has been resumed
+ */
 extern pthread_cond_t event_loop_resume_cond_ack;
-extern pthread_cond_t event_loop_request_cond;
+
+/**
+ * `worker_event_loop` receives HTTP responses through this receiver
+ */
 extern h2o_multithread_receiver_t event_loop_receiver;
+
+/**
+ * `worker_event_loop` receives HTTP responses in this queue
+ */
 extern h2o_multithread_queue_t *event_loop_queue;
 
+/**
+ * `worker_event_loop` envelopes incoming HTTP requests into this data type
+ */
 typedef struct {
   h2o_multithread_message_t super;
   h2o_req_t *req;
   pthread_mutex_t mutex;
 } request_message_t;
 
+/**
+ * Main thread's event loop receives `request_message_t` messages using this receiver
+ */
 extern h2o_multithread_receiver_t handler_receiver;
+
+/**
+ * Main thread's event loop receives `request_message_t` messages in this queue
+ */
 extern h2o_multithread_queue_t *handler_queue;
 void *event_loop(void *arg);
 
@@ -42,8 +90,20 @@ h2o_accept_ctx_t *listener_accept_ctx(h2o_socket_t *listener);
  */
 void on_accept(h2o_socket_t *listener, const char *err);
 
+/**
+ * `worker_event_loop` should be setup to use this handler
+ * @param self
+ * @param req
+ * @return
+ */
 int event_loop_req_handler(h2o_handler_t *self, h2o_req_t *req);
 
+/**
+ * Send inline HTTP response to `worker_event_loop`
+ * @param msg request message
+ * @param body body
+ * @param len length
+ */
 void h2o_queue_send_inline(request_message_t *msg, const char *body, size_t len);
 
 #endif // OMNI_HTTPD_EVENT_LOOP_H

--- a/extensions/omni_httpd/expected/http2_reproxy.out
+++ b/extensions/omni_httpd/expected/http2_reproxy.out
@@ -1,0 +1,34 @@
+begin;
+with
+    listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 9101) returning id),
+    handler as (insert into omni_httpd.handlers (query)
+        select
+            omni_httpd.cascading_query(name, query order by priority desc nulls last)
+        from
+            (values
+                 ('sleep',
+                  $$select omni_httpd.http_response(pg_sleep(5)::text) from request where request.path = '/sleep'$$, 1),
+                 ('other',
+                  $$select omni_httpd.http_response('test')$$,
+                  1)) as routes(name, query, priority)
+        returning id)
+insert
+into
+    omni_httpd.listeners_handlers (listener_id, handler_id)
+select
+    listener.id,
+    handler.id
+from
+    listener,
+    handler;
+delete
+from
+    omni_httpd.configuration_reloads;
+end;
+call omni_httpd.wait_for_configuration_reloads(1);
+-- Should complete it faster than 5*2 seconds. 7s is generously accounting for the overhead.
+-- As per `timeout`'s man page:
+--        124    if COMMAND times out, and --preserve-status is not specified
+-- Using 127.0.0.1 instead of localhost as using the latter seems to occassionaly produce
+-- `connection refused`
+\! timeout 7s curl --retry-connrefused --silent --no-progress-meter --parallel --http2 http://127.0.0.1:9101/sleep http://127.0.0.1:9101/sleep ; [ $? -eq 124 ] && echo "timeout"

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -10,7 +10,9 @@
 #include <errno.h>
 #include <limits.h>
 #include <netinet/in.h>
+#include <pthread.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/socket.h>
@@ -49,6 +51,7 @@
 
 #include <dynpgext.h>
 
+#include "event_loop.h"
 #include "fd.h"
 #include "http_worker.h"
 #include "omni_httpd.h"
@@ -57,12 +60,23 @@
 #error "only evloop is supported, ensure H2O_USE_LIBUV is not set to 1"
 #endif
 
-static bool worker_running = true;
-static bool worker_reload = true;
-static void reload_worker() { worker_reload = true; }
-static void stop_worker() { worker_running = false; }
+h2o_multithread_receiver_t handler_receiver;
+h2o_multithread_queue_t *handler_queue;
 
 static clist_listener_contexts listener_contexts;
+
+static void on_message(h2o_multithread_receiver_t *receiver, h2o_linklist_t *messages) {
+  while (!h2o_linklist_is_empty(messages)) {
+    h2o_multithread_message_t *message =
+        H2O_STRUCT_FROM_MEMBER(h2o_multithread_message_t, link, messages->next);
+
+    request_message_t *request_msg = (request_message_t *)messages->next;
+
+    handler(request_msg);
+
+    h2o_linklist_unlink(&message->link);
+  }
+}
 
 /**
  * HTTP worker entry point
@@ -72,19 +86,16 @@ static clist_listener_contexts listener_contexts;
  * @param db_oid Database OID
  */
 void http_worker(Datum db_oid) {
-#if PG_MAJORVERSION_NUM >= 13
-  pqsignal(SIGHUP, SignalHandlerForConfigReload);
-#else
-#warning "TODO: SignalHandlerForConfigReload for Postgres 12"
-#endif
-  pqsignal(SIGTERM, die);
-
-  BackgroundWorkerUnblockSignals();
-  BackgroundWorkerInitializeConnectionByOid(db_oid, InvalidOid, 0);
+  atomic_store(&worker_running, true);
+  atomic_store(&worker_reload, true);
 
   setup_server();
-  pqsignal(SIGTERM, stop_worker);
-  pqsignal(SIGUSR2, reload_worker);
+
+  pthread_t event_loop_thread;
+  event_loop_suspended = true;
+  pthread_create(&event_loop_thread, NULL, event_loop, NULL);
+
+  BackgroundWorkerInitializeConnectionByOid(db_oid, InvalidOid, 0);
 
   listener_contexts = clist_listener_contexts_init();
 
@@ -92,10 +103,11 @@ void http_worker(Datum db_oid) {
       dynpgext_lookup_shmem(OMNI_HTTPD_CONFIGURATION_RELOAD_SEMAPHORE);
   Assert(semaphore != NULL);
 
-  while (worker_running) {
-    if (worker_reload) {
+  while (atomic_load(&worker_running)) {
+    bool worker_reload_test = true;
+    if (atomic_compare_exchange_strong(&worker_reload, &worker_reload_test, false)) {
       pg_atomic_add_fetch_u32(semaphore, 1);
-      worker_reload = false;
+
       cvec_fd fds = accept_fds(MyBgworkerEntry->bgw_extra);
 
       // Disposing allocated listener/query pairs and their associated data
@@ -329,8 +341,25 @@ void http_worker(Datum db_oid) {
       AbortCurrentTransaction();
     }
 
-    while (worker_running && !worker_reload && h2o_evloop_run(worker_event_loop, INT32_MAX) == 0)
+    event_loop_suspended = false;
+    pthread_mutex_lock(&event_loop_mutex);
+    pthread_cond_signal(&event_loop_resume_cond);
+    pthread_mutex_unlock(&event_loop_mutex);
+
+    bool running = atomic_load(&worker_running);
+    bool reload = atomic_load(&worker_reload);
+    while ((running = atomic_load(&worker_running)) && !(reload = atomic_load(&worker_reload)) &&
+           h2o_evloop_run(handler_event_loop, INT32_MAX))
       ;
+
+    // Ensure the event loop is suspended while we're reloading
+    if (reload || !running) {
+      pthread_mutex_lock(&event_loop_mutex);
+      while (event_loop_resumed) {
+        pthread_cond_wait(&event_loop_resume_cond_ack, &event_loop_mutex);
+      }
+      pthread_mutex_unlock(&event_loop_mutex);
+    }
   }
 
   clist_listener_contexts_drop(&listener_contexts);
@@ -340,23 +369,8 @@ static inline int listener_ctx_cmp(const listener_ctx *l, const listener_ctx *r)
   return (l->plan == r->plan && l->socket == r->socket && l->fd == r->fd) ? 0 : -1;
 }
 
-/**
- * @brief Accept socket
- *
- * @param listener
- * @param err
- */
-static void on_accept(h2o_socket_t *listener, const char *err) {
-  h2o_socket_t *sock;
-
-  if (err != NULL) {
-    return;
-  }
-
-  if ((sock = h2o_evloop_socket_accept(listener)) == NULL) {
-    return;
-  }
-  h2o_accept(&((listener_ctx *)listener->data)->accept_ctx, sock);
+h2o_accept_ctx_t *listener_accept_ctx(h2o_socket_t *listener) {
+  return &((listener_ctx *)listener->data)->accept_ctx;
 }
 
 /**
@@ -448,9 +462,16 @@ static void setup_server() {
   config.server_name = h2o_iovec_init(H2O_STRLIT("omni_httpd-" EXT_VERSION));
   hostconf = h2o_config_register_host(&config, h2o_iovec_init(H2O_STRLIT("default")), 65535);
 
+  // Set up event loop for HTTP event loop
   worker_event_loop = h2o_evloop_create();
+  event_loop_queue = h2o_multithread_create_queue(worker_event_loop);
 
-  h2o_pathconf_t *pathconf = register_handler(hostconf, "/", handler);
+  // Set up event loop for request handler loop
+  handler_event_loop = h2o_evloop_create();
+  handler_queue = h2o_multithread_create_queue(handler_event_loop);
+  h2o_multithread_register_receiver(handler_queue, &handler_receiver, on_message);
+
+  h2o_pathconf_t *pathconf = register_handler(hostconf, "/", event_loop_req_handler);
 }
 static cvec_fd accept_fds(char *socket_name) {
   struct sockaddr_un address;
@@ -474,7 +495,7 @@ try_connect:
   if (connect(socket_fd, (struct sockaddr *)&address, sizeof(struct sockaddr_un)) != 0) {
     int e = errno;
     if (e == EAGAIN || e == EWOULDBLOCK) {
-      if (worker_reload) {
+      if (atomic_load(&worker_reload)) {
         // Don't try to get fds, roll with the reload
         return cvec_fd_init();
       } else {
@@ -491,7 +512,7 @@ try_connect:
 
   do {
     errno = 0;
-    if (worker_reload) {
+    if (atomic_load(&worker_reload)) {
       break;
     }
     result = recv_fds(socket_fd);
@@ -502,22 +523,23 @@ try_connect:
   return result;
 }
 
-/**
- * @brief Request handler
- *
- * @param self
- * @param req
- * @return int
- */
-static int handler(h2o_handler_t *self, h2o_req_t *req) {
+static int handler(request_message_t *msg) {
+  pthread_mutex_lock(&msg->mutex);
+  h2o_req_t *req = msg->req;
+  if (req == NULL) {
+    // The connection is gone
+    // We can release the message
+    free(msg);
+    goto release;
+  }
   listener_ctx *lctx = H2O_STRUCT_FROM_MEMBER(listener_ctx, context, req->conn->ctx);
 
   SPIPlanPtr plan = lctx->plan;
 
   if (plan == NULL) {
     req->res.status = 500;
-    h2o_send_inline(req, H2O_STRLIT("Internal server error"));
-    return 0;
+    h2o_queue_send_inline(msg, H2O_STRLIT("Internal server error"));
+    goto release;
   }
 
   SetCurrentStatementStartTimestamp();
@@ -608,7 +630,7 @@ static int handler(h2o_handler_t *self, h2o_req_t *req) {
     FlushErrorState();
 
     req->res.status = 500;
-    h2o_send_inline(req, H2O_STRLIT("Internal server error"));
+    h2o_queue_send_inline(msg, H2O_STRLIT("Internal server error"));
     goto cleanup;
   }
   PG_END_TRY();
@@ -675,25 +697,25 @@ static int handler(h2o_handler_t *self, h2o_req_t *req) {
 
       if (!isnull) {
         bytea *body_content = DatumGetByteaPP(body);
-        h2o_send_inline(req, VARDATA_ANY(body_content), VARSIZE_ANY_EXHDR(body_content));
+        h2o_queue_send_inline(msg, VARDATA_ANY(body_content), VARSIZE_ANY_EXHDR(body_content));
       } else {
-        h2o_send_inline(req, "", 0);
+        h2o_queue_send_inline(msg, "", 0);
       }
 
     } else {
-      h2o_send_inline(req, "", 0);
+      h2o_queue_send_inline(msg, "", 0);
     }
     succeeded = true;
   } else {
     if (ret == SPI_OK_SELECT) {
       // No result
       req->res.status = 204;
-      h2o_send_inline(req, H2O_STRLIT(""));
+      h2o_queue_send_inline(msg, H2O_STRLIT(""));
       succeeded = true;
     } else {
       req->res.status = 500;
       ereport(WARNING, errmsg("Error executing query: %s", SPI_result_code_string(ret)));
-      h2o_send_inline(req, H2O_STRLIT("Internal server error"));
+      h2o_queue_send_inline(msg, H2O_STRLIT("Internal server error"));
     }
   }
 
@@ -705,6 +727,9 @@ cleanup:
   } else {
     AbortCurrentTransaction();
   }
+
+release:
+  pthread_mutex_unlock(&msg->mutex);
 
   return 0;
 }

--- a/extensions/omni_httpd/http_worker.h
+++ b/extensions/omni_httpd/http_worker.h
@@ -16,7 +16,7 @@
  * @brief Each listener has a context
  *
  */
-typedef struct {
+typedef struct st_listener_ctx {
   /**
    * @brief Query plan
    *
@@ -74,7 +74,6 @@ static inline int listener_ctx_cmp(const listener_ctx *l, const listener_ctx *r)
 #include <stc/clist.h>
 
 static h2o_globalconf_t config;
-static h2o_evloop_t *worker_event_loop;
 
 /**
  * Sets up H2O server
@@ -139,6 +138,8 @@ static cvec_fd accept_fds(char *socket_name);
  */
 #define REQUEST_PLAN_HEADERS 4
 
-static int handler(h2o_handler_t *self, h2o_req_t *req);
+static int handler(request_message_t *msg);
+
+static h2o_evloop_t *handler_event_loop;
 
 #endif // OMNIGRES_HTTP_WORKER_H

--- a/extensions/omni_httpd/mkdocs.yml
+++ b/extensions/omni_httpd/mkdocs.yml
@@ -3,3 +3,4 @@ site_name: omni_httpd
 nav:
   - Intro: 'intro.md'
   - Headers: 'headers.md'
+  - Architecture: 'architecture.md'

--- a/extensions/omni_httpd/sql/http2_reproxy.sql
+++ b/extensions/omni_httpd/sql/http2_reproxy.sql
@@ -1,0 +1,36 @@
+begin;
+with
+    listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 9101) returning id),
+    handler as (insert into omni_httpd.handlers (query)
+        select
+            omni_httpd.cascading_query(name, query order by priority desc nulls last)
+        from
+            (values
+                 ('sleep',
+                  $$select omni_httpd.http_response(pg_sleep(5)::text) from request where request.path = '/sleep'$$, 1),
+                 ('other',
+                  $$select omni_httpd.http_response('test')$$,
+                  1)) as routes(name, query, priority)
+        returning id)
+insert
+into
+    omni_httpd.listeners_handlers (listener_id, handler_id)
+select
+    listener.id,
+    handler.id
+from
+    listener,
+    handler;
+delete
+from
+    omni_httpd.configuration_reloads;
+end;
+
+call omni_httpd.wait_for_configuration_reloads(1);
+
+-- Should complete it faster than 5*2 seconds. 7s is generously accounting for the overhead.
+-- As per `timeout`'s man page:
+--        124    if COMMAND times out, and --preserve-status is not specified
+-- Using 127.0.0.1 instead of localhost as using the latter seems to occassionaly produce
+-- `connection refused`
+\! timeout 7s curl --retry-connrefused --silent --no-progress-meter --parallel --http2 http://127.0.0.1:9101/sleep http://127.0.0.1:9101/sleep ; [ $? -eq 124 ] && echo "timeout"

--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -32,6 +32,11 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - footnotes
+  - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
 
 plugins:
   - search

--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -27,9 +27,13 @@ markdown_extensions:
   - toc:
       permalink: true
   - admonition
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
 plugins:
   - search
   - monorepo
-  - mermaid2
   - include-markdown


### PR DESCRIPTION
Every HTTP worker is currently going busy when getting a new connection and a request.

This works (and having more than one worker ensures there are more workers to accept new connections), however, it negatively impacts HTTP/2 multiplexing. Once the worker is processing the request, it will not be processing other requests.

Solution: run HTTP processing event loop in a separate thread and use the primary thread for maintenance operations and executing Postgres handlers.

In addition, if there are requests in flight (defined as Postgres executing something), and the protocol is 2 or above, proxy the request back. It's not perfect as at times it is faster to wait than reprocess the query elsewhere, but we'd need a more sophisticated mechanism to handle this. Or maybe more tuning knobs.

Resolves #40