### PR TITLE
Problem: hard-coded default of 10 http workers

### DIFF
--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -71,8 +71,13 @@ int num_http_workers;
 static void init_semaphore(void *ptr, void *data) { pg_atomic_init_u32(ptr, 0); }
 
 void _Dynpgext_init(const dynpgext_handle *handle) {
+  int default_num_http_workers = 10;
+#ifdef _SC_NPROCESSORS_ONLN
+  default_num_http_workers = sysconf(_SC_NPROCESSORS_ONLN);
+#endif
   DefineCustomIntVariable("omni_httpd.http_workers", "Number of HTTP workers", NULL,
-                          &num_http_workers, 10, 1, INT_MAX, PGC_SIGHUP, 0, NULL, NULL, NULL);
+                          &num_http_workers, default_num_http_workers, 1, INT_MAX, PGC_SIGHUP, 0,
+                          NULL, NULL, NULL);
 
   handle->allocate_shmem(handle, OMNI_HTTPD_CONFIGURATION_RELOAD_SEMAPHORE,
                          sizeof(pg_atomic_uint32), init_semaphore, NULL,


### PR DESCRIPTION
While it can be changed, it is not clear why this would be the best default for any system. Frankly, I think this was set this way because my current computer has 10 cores.

Solution: use _SC_NPROCESSORS_ONLN where available

According to manpages, Linux, macOS and FreeBSD have it.