### PR TITLE
Problem: naming omni_ext extension omni_ext--0.1

### DIFF
--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -91,7 +91,7 @@
 find_program(PGCLI pgcli)
 
 function(add_postgresql_extension NAME)
-    set(_optional SHARED_PRELOAD PRIVATE)
+    set(_optional SHARED_PRELOAD PRIVATE UNVERSIONED_SO)
     set(_single VERSION ENCODING SCHEMA RELOCATABLE)
     set(_multi SOURCES SCRIPTS SCRIPT_TEMPLATES REQUIRES TESTS_REQUIRE REGRESS)
     cmake_parse_arguments(_ext "${_optional}" "${_single}" "${_multi}" ${ARGN})
@@ -156,11 +156,16 @@ function(add_postgresql_extension NAME)
         set(_link_flags "${_link_flags} -bundle -bundle_loader ${PG_BINARY}")
     endif()
 
+    set(_suffix "--${_ext_VERSION}.so")
+    if(_ext_UNVERSIONED_SO)
+        set(_suffix ".so")
+    endif()
+
     set_target_properties(
         ${NAME}
         PROPERTIES
         PREFIX ""
-        SUFFIX "--${_ext_VERSION}.so"
+        SUFFIX "${_suffix}"
         LINK_FLAGS "${_link_flags}"
         POSITION_INDEPENDENT_CODE ON)
 

--- a/docker/initdb-slim/001-settings.sql
+++ b/docker/initdb-slim/001-settings.sql
@@ -1,2 +1,2 @@
 alter system set max_worker_processes = 64;
-alter system set shared_preload_libraries = 'omni_ext--0.1';
+alter system set shared_preload_libraries = 'omni_ext';

--- a/docker/initdb/001-settings.sql
+++ b/docker/initdb/001-settings.sql
@@ -1,2 +1,2 @@
 alter system set max_worker_processes = 64;
-alter system set shared_preload_libraries = 'omni_ext--0.1', 'plrust';
+alter system set shared_preload_libraries = 'omni_ext', 'plrust';

--- a/extensions/omni_ext/CMakeLists.txt
+++ b/extensions/omni_ext/CMakeLists.txt
@@ -27,6 +27,7 @@ add_postgresql_extension(
         RELOCATABLE false
         SCRIPTS omni_ext--0.1.sql
         SOURCES omni_ext.c control_file.c init.c workers.c strverscmp.c
+        UNVERSIONED_SO ON
         SHARED_PRELOAD ON)
 
 set_property(TARGET omni_ext PROPERTY C_STANDARD 11)


### PR DESCRIPTION
Looks a bit awkward. The thing is, omni_ext is not upgradable in runtime and therefore having a versioned name will likely not be beneficial in any way.

Solution: introduce UNVERSIONED_SO property
that makes extension shared object unversioned.