### PR TITLE
Problem: returning distinctly different values of a type

### DIFF
--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -6,6 +6,7 @@ list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../cmake)
 enable_testing()
 
 add_subdirectory(omni_ext)
+add_subdirectory(omni_types)
 add_subdirectory(omni_containers)
 add_subdirectory(omni_httpd)
 add_subdirectory(omni_sql)

--- a/extensions/omni_types/CMakeLists.txt
+++ b/extensions/omni_types/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(omni_types)
+
+include(CPM)
+include(CTest)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+
+enable_testing()
+
+find_package(PostgreSQL REQUIRED)
+
+add_postgresql_extension(
+        omni_types
+        VERSION 0.1
+        SCHEMA omni_types
+        RELOCATABLE false
+        SCRIPTS omni_types--0.1.sql
+        SOURCES sum_type.c
+        REGRESS sum_type
+)

--- a/extensions/omni_types/docs/sum_types.md
+++ b/extensions/omni_types/docs/sum_types.md
@@ -1,0 +1,153 @@
+<!-- @formatter:off -->
+# Sum Types
+
+[Sum types](https://en.wikipedia.org/wiki/Tagged_union) (also known as tagged unions, or enums) is a type that allows to hold a value that could take on several different types that are known ahead of time.
+
+In Postgres context, this allows one to return values of different types in a single query column, or store different values in a column where maintaining separate columns or tables is excessive.
+
+## Defining a sum type
+
+One can define it using `omni_types.sum_type` function, passing the intended type name and the list of variant types.
+
+Below, let's create a unified [geometric type](https://www.postgresql.org/docs/current/datatype-geometric.html)[^geom_type]:
+
+[^geom_type]: PostGIS defines it is own [`geometry` type](https://postgis.net/docs/manual-3.3/using_postgis_dbmanagement.html#PostGIS_Geometry). Our definition is used to showcase a generalized approach.
+
+```postgresql
+omni_types=#
+select omni_types.sum_type('geom', 'point', 'line', 'lseg', 'box', 'path', 'polygon', 'circle');
+sum_type
+----------
+ geom
+(1 row)
+```
+
+We can now see it's been created:
+
+```postgresql
+omni_types=#
+\dT geom
+list of data types
+ schema | name | Description
+--------+------+-------------
+ public | geom |
+(1 row)
+         
+omni_types=#
+table omni_types.sum_types;
+oid  |                 variants
+-------+-------------------------------------------
+ 16397 | {point,line,lseg,box,path,polygon,circle}
+(1 row) 
+```
+
+## Textual representation
+
+Sum type can be initialized using textual representatin, with the variant name used to
+indicate the type:
+
+```postgresql
+omni_types=#
+select 'point(10,10)'::geom;
+geom
+----------------
+ point((10,10))
+(1 row)
+```
+
+By the virtue of seeing the above output, we know that it also converts back to a textual representation
+using the underlying variant's representation.
+
+## Conversion and casting
+
+Sum types can be casted from and to their variants.
+
+```postgresql
+omni_types=# select '<(10,10),10>'::circle::geom;
+geom
+----------------------
+ circle(<(10,10),10>)
+(1 row)
+             
+omni_types=#
+select '<(10,10),10>'::circle::geom::circle;
+circle
+--------------
+ <(10,10),10>
+(1 row)
+```
+
+They can also be converted using functions following the pattern of
+`<type>_from_<type>`:
+
+```postgresql
+omni_types=# select geom_from_point('10,10');
+geom_from_point
+-----------------
+ point((10,10))
+(1 row)
+     
+omni_types=# select point_from_geom(geom_from_point('10,10'));
+point_from_geom
+-----------------
+ (10,10)
+(1 row)
+```
+
+If one attempts to cast or convert to a wrong variant, `null` will be returned:
+
+```postgresql
+omni_types=# select '<(10,10),10>'::circle::geom::point;
+point
+-------
+ null
+(1 row)
+omni_types=# select point_from_geom('<(10,10),10>'::circle::geom);
+point_from_geom
+-----------------
+ null
+(1 row)
+```
+
+??? warning "Caveat: casting domains"
+
+    Due to the way [domains](https://www.postgresql.org/docs/current/sql-createdomain.html) work, casting
+    is impossible as they are rather thin layers over their base types.
+
+    That being said, the functions described above can be used to accomplish the same:
+
+    ```postgresql
+    omni_types=# create domain my_point as point;
+    CREATE DOMAIN
+
+    omni_types=# select omni_types.sum_type('my_geom','my_point');
+    sum_type
+    ----------
+     my_geom
+    (1 row)
+
+    omni_types=# select my_geom_from_my_point('1,1');
+     my_geom_from_my_point
+    -----------------------
+     my_point((1,1))
+    (1 row)
+    
+    omni_types=# select my_point_from_my_geom(my_geom_from_my_point('1,1'));
+     my_point_from_my_geom
+    -----------------------
+     (1,1)
+    (1 row)
+    ```
+
+## Retrieving the variant type
+
+One can determine the type of the variant to advise further processing:
+
+```postgresql
+omni_types=#
+select omni_types.variant('point(10,10)'::geom);
+variant
+---------
+ point
+(1 row)
+```

--- a/extensions/omni_types/expected/sum_type.out
+++ b/extensions/omni_types/expected/sum_type.out
@@ -1,0 +1,589 @@
+\pset null 'NULL'
+\set dump_types 'select typname,variants from omni_types.sum_types st inner join pg_type t on t.oid = st.oid'
+create or replace function get_type_size(data_type regtype)
+    returns integer as
+$$
+select
+    typlen
+from
+    pg_type
+where
+    oid = data_type
+$$
+    language sql;
+-- Empty
+begin;
+select omni_types.sum_type('empty', variadic array []::regtype[]);
+ sum_type 
+----------
+ empty
+(1 row)
+
+\dT
+      List of data types
+ Schema | Name  | Description 
+--------+-------+-------------
+ public | empty | 
+(1 row)
+
+:dump_types;
+ typname | variants 
+---------+----------
+ empty   | {}
+(1 row)
+
+select null::empty is null as is_null;
+ is_null 
+---------
+ t
+(1 row)
+
+rollback;
+-- Single fixed size by val
+begin;
+select omni_types.sum_type('sum_type', 'integer');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT;
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | sum_type | 
+(1 row)
+
+:dump_types;
+ typname  | variants  
+----------+-----------
+ sum_type | {integer}
+(1 row)
+
+select get_type_size('sum_type');
+ get_type_size 
+---------------
+             8
+(1 row)
+
+select 'integer(100)'::sum_type;
+   sum_type   
+--------------
+ integer(100)
+(1 row)
+
+select 'integer(100)'::sum_type::integer;
+ int4 
+------
+  100
+(1 row)
+
+select 100::sum_type;
+   sum_type   
+--------------
+ integer(100)
+(1 row)
+
+rollback;
+-- Multiple fixed size by val
+begin;
+select omni_types.sum_type('sum_type', 'integer', 'bigint');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT;
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | sum_type | 
+(1 row)
+
+:dump_types;
+ typname  |     variants     
+----------+------------------
+ sum_type | {integer,bigint}
+(1 row)
+
+select get_type_size('sum_type');
+ get_type_size 
+---------------
+            12
+(1 row)
+
+select 'integer(1000)'::sum_type;
+   sum_type    
+---------------
+ integer(1000)
+(1 row)
+
+select 'integer(1000)'::sum_type::integer;
+ int4 
+------
+ 1000
+(1 row)
+
+select 1000::sum_type;
+   sum_type    
+---------------
+ integer(1000)
+(1 row)
+
+select 'bigint(10000000000)'::sum_type;
+      sum_type       
+---------------------
+ bigint(10000000000)
+(1 row)
+
+select 'bigint(10000000000)'::sum_type::bigint;
+    int8     
+-------------
+ 10000000000
+(1 row)
+
+select 10000000000::bigint::sum_type;
+      sum_type       
+---------------------
+ bigint(10000000000)
+(1 row)
+
+rollback;
+-- Single fixed size
+begin;
+select omni_types.sum_type('sum_type', 'name');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT;
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | sum_type | 
+(1 row)
+
+:dump_types;
+ typname  | variants 
+----------+----------
+ sum_type | {name}
+(1 row)
+
+select get_type_size('sum_type');
+ get_type_size 
+---------------
+            68
+(1 row)
+
+select 'name(test)'::sum_type;
+  sum_type  
+------------
+ name(test)
+(1 row)
+
+select 'name(test)'::sum_type::name;
+ name 
+------
+ test
+(1 row)
+
+select 'test'::name::sum_type;
+  sum_type  
+------------
+ name(test)
+(1 row)
+
+rollback;
+-- Multiple fixed size, by val is mixed
+begin;
+select omni_types.sum_type('sum_type', 'name', 'integer');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT;
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | sum_type | 
+(1 row)
+
+:dump_types;
+ typname  |    variants    
+----------+----------------
+ sum_type | {name,integer}
+(1 row)
+
+select get_type_size('sum_type');
+ get_type_size 
+---------------
+            68
+(1 row)
+
+select 'name(test)'::sum_type;
+  sum_type  
+------------
+ name(test)
+(1 row)
+
+select 'name(test)'::sum_type::name;
+ name 
+------
+ test
+(1 row)
+
+select 'test'::name::sum_type;
+  sum_type  
+------------
+ name(test)
+(1 row)
+
+select 'integer(1000)'::sum_type;
+   sum_type    
+---------------
+ integer(1000)
+(1 row)
+
+select 'integer(1000)'::sum_type::integer;
+ int4 
+------
+ 1000
+(1 row)
+
+select 1000::sum_type;
+   sum_type    
+---------------
+ integer(1000)
+(1 row)
+
+rollback;
+-- Single variable size
+begin;
+select omni_types.sum_type('sum_type', 'text');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT;
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | sum_type | 
+(1 row)
+
+:dump_types;
+ typname  | variants 
+----------+----------
+ sum_type | {text}
+(1 row)
+
+select get_type_size('sum_type');
+ get_type_size 
+---------------
+            -1
+(1 row)
+
+select 'text(Hello)'::sum_type;
+  sum_type   
+-------------
+ text(Hello)
+(1 row)
+
+select 'text(Hello)'::sum_type::text;
+ text  
+-------
+ Hello
+(1 row)
+
+select 'Hello'::text::sum_type;
+  sum_type   
+-------------
+ text(Hello)
+(1 row)
+
+rollback;
+-- Multiple mixed variable and fixed size
+begin;
+select omni_types.sum_type('sum_type', 'text', 'integer', 'name');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT;
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | sum_type | 
+(1 row)
+
+:dump_types;
+ typname  |      variants       
+----------+---------------------
+ sum_type | {text,integer,name}
+(1 row)
+
+select get_type_size('sum_type');
+ get_type_size 
+---------------
+            -1
+(1 row)
+
+select 'text(Hello)'::sum_type;
+  sum_type   
+-------------
+ text(Hello)
+(1 row)
+
+select 'text(Hello)'::sum_type::text;
+ text  
+-------
+ Hello
+(1 row)
+
+select 'Hello'::text::sum_type;
+  sum_type   
+-------------
+ text(Hello)
+(1 row)
+
+select 'integer(1000)'::sum_type;
+   sum_type    
+---------------
+ integer(1000)
+(1 row)
+
+select 'integer(1000)'::sum_type::integer;
+ int4 
+------
+ 1000
+(1 row)
+
+select 1000::sum_type;
+   sum_type    
+---------------
+ integer(1000)
+(1 row)
+
+select 'name(test)'::sum_type;
+  sum_type  
+------------
+ name(test)
+(1 row)
+
+select 'name(test)'::sum_type::name;
+ name 
+------
+ test
+(1 row)
+
+select 'test'::name::sum_type;
+  sum_type  
+------------
+ name(test)
+(1 row)
+
+rollback;
+-- Domains
+begin;
+create domain height as integer check (value > 0);
+create domain age as integer check (value > 0 and value < 200);
+select omni_types.sum_type('sum_type', 'height', 'age');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT;
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | age      | 
+ public | height   | 
+ public | sum_type | 
+(3 rows)
+
+:dump_types;
+ typname  |   variants   
+----------+--------------
+ sum_type | {height,age}
+(1 row)
+
+select get_type_size('sum_type');
+ get_type_size 
+---------------
+             8
+(1 row)
+
+select 'height(100)'::sum_type;
+  sum_type   
+-------------
+ height(100)
+(1 row)
+
+select 'age(100)'::sum_type;
+ sum_type 
+----------
+ age(100)
+(1 row)
+
+-- Can't cast domain types, use functions
+select sum_type_from_height(100);
+ sum_type_from_height 
+----------------------
+ height(100)
+(1 row)
+
+select sum_type_from_age(100);
+ sum_type_from_age 
+-------------------
+ age(100)
+(1 row)
+
+rollback;
+--- Composite types
+begin;
+create type person as
+(
+    name text,
+    dob  date
+);
+create type animal as enum ('dog', 'cat', 'fish', 'other');
+create type pet as
+(
+    name   text,
+    animal animal
+);
+select omni_types.sum_type('sum_type', 'person', 'pet');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT;
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | animal   | 
+ public | person   | 
+ public | pet      | 
+ public | sum_type | 
+(4 rows)
+
+:dump_types;
+ typname  |   variants   
+----------+--------------
+ sum_type | {person,pet}
+(1 row)
+
+select get_type_size('sum_type');
+ get_type_size 
+---------------
+            -1
+(1 row)
+
+select $$person((John,01/01/1980))$$::sum_type;
+         sum_type          
+---------------------------
+ person((John,01-01-1980))
+(1 row)
+
+select $$pet((Charlie,dog))$$::sum_type;
+      sum_type      
+--------------------
+ pet((Charlie,dog))
+(1 row)
+
+select row ('John', '01/01/1980')::person::sum_type;
+            row            
+---------------------------
+ person((John,01-01-1980))
+(1 row)
+
+select row ('Charlie','dog')::pet::sum_type;
+        row         
+--------------------
+ pet((Charlie,dog))
+(1 row)
+
+select row ('John', '01/01/1980')::person::sum_type::person;
+        row        
+-------------------
+ (John,01-01-1980)
+(1 row)
+
+select row ('John', '01/01/1980')::person::sum_type::pet;
+ row  
+------
+ NULL
+(1 row)
+
+select row ('Charlie','dog')::pet::sum_type::pet;
+      row      
+---------------
+ (Charlie,dog)
+(1 row)
+
+select row ('Charlie','dog')::pet::sum_type::person;
+ row  
+------
+ NULL
+(1 row)
+
+rollback;
+-- Casting variants to different types
+begin;
+select omni_types.sum_type('sum_type', 'integer', 'boolean');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT;
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | sum_type | 
+(1 row)
+
+:dump_types;
+ typname  |     variants      
+----------+-------------------
+ sum_type | {integer,boolean}
+(1 row)
+
+select 100::sum_type::boolean;
+ bool 
+------
+ NULL
+(1 row)
+
+select true::sum_type::integer;
+ int4 
+------
+ NULL
+(1 row)
+
+rollback;
+-- Duplicates
+begin;
+select omni_types.sum_type('sum_type', 'integer', 'integer');
+ERROR:  Sum types can not contain duplicate variants
+CONTEXT:  PL/pgSQL function omni_types.sum_type_unique_variants_trigger_func() line 12 at RAISE
+SQL statement "insert into omni_types.sum_types (oid, variants) values ($1, $2)"
+rollback;
+-- Ensure no types are leaked
+\dT;
+     List of data types
+ Schema | Name | Description 
+--------+------+-------------
+(0 rows)
+
+:dump_types;
+ typname | variants 
+---------+----------
+(0 rows)
+

--- a/extensions/omni_types/expected/sum_type.out
+++ b/extensions/omni_types/expected/sum_type.out
@@ -575,6 +575,47 @@ ERROR:  Sum types can not contain duplicate variants
 CONTEXT:  PL/pgSQL function omni_types.sum_type_unique_variants_trigger_func() line 12 at RAISE
 SQL statement "insert into omni_types.sum_types (oid, variants) values ($1, $2)"
 rollback;
+-- Determining variant
+begin;
+select omni_types.sum_type('sum_type', 'integer', 'boolean');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT;
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | sum_type | 
+(1 row)
+
+:dump_types;
+ typname  |     variants      
+----------+-------------------
+ sum_type | {integer,boolean}
+(1 row)
+
+select omni_types.variant(100::sum_type);
+ variant 
+---------
+ integer
+(1 row)
+
+select omni_types.variant(true::sum_type);
+ variant 
+---------
+ boolean
+(1 row)
+
+-- Invalid type
+select omni_types.variant(10);
+ variant 
+---------
+ NULL
+(1 row)
+
+rollback;
 -- Ensure no types are leaked
 \dT;
      List of data types

--- a/extensions/omni_types/mkdocs.yml
+++ b/extensions/omni_types/mkdocs.yml
@@ -1,0 +1,2 @@
+INHERIT: ../../mkdocs.base.yml
+site_name: omni_types

--- a/extensions/omni_types/omni_types--0.1.sql
+++ b/extensions/omni_types/omni_types--0.1.sql
@@ -36,3 +36,7 @@ as
 'MODULE_PATHNAME',
 'sum_type'
     language c;
+
+create function variant(v anycompatible) returns regtype as
+'MODULE_PATHNAME',
+'sum_variant' language c;

--- a/extensions/omni_types/omni_types--0.1.sql
+++ b/extensions/omni_types/omni_types--0.1.sql
@@ -1,0 +1,38 @@
+create table sum_types
+(
+    oid      oid primary key unique,
+    variants regtype[] not null
+);
+
+create or replace function sum_type_unique_variants_trigger_func()
+    returns trigger as
+$$
+declare
+    duplicate_count integer;
+begin
+    select
+        count(*) - count(distinct element)
+    into duplicate_count
+    from
+        unnest(new.variants) as element;
+
+    if duplicate_count > 0 then
+        raise exception 'Sum types can not contain duplicate variants';
+    end if;
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger sum_type_unique_variants_trigger
+    before insert or update
+    on sum_types
+    for each row
+execute function sum_type_unique_variants_trigger_func();
+
+create function sum_type(name name,
+                         variadic variants regtype[]
+) returns regtype
+as
+'MODULE_PATHNAME',
+'sum_type'
+    language c;

--- a/extensions/omni_types/sql/sum_type.sql
+++ b/extensions/omni_types/sql/sum_type.sql
@@ -1,0 +1,197 @@
+\pset null 'NULL'
+\set dump_types 'select typname,variants from omni_types.sum_types st inner join pg_type t on t.oid = st.oid'
+
+create or replace function get_type_size(data_type regtype)
+    returns integer as
+$$
+select
+    typlen
+from
+    pg_type
+where
+    oid = data_type
+$$
+    language sql;
+
+
+-- Empty
+begin;
+
+select omni_types.sum_type('empty', variadic array []::regtype[]);
+\dT
+:dump_types;
+
+select null::empty is null as is_null;
+
+rollback;
+
+-- Single fixed size by val
+begin;
+select omni_types.sum_type('sum_type', 'integer');
+\dT;
+:dump_types;
+
+select get_type_size('sum_type');
+
+select 'integer(100)'::sum_type;
+select 'integer(100)'::sum_type::integer;
+select 100::sum_type;
+
+rollback;
+
+-- Multiple fixed size by val
+begin;
+select omni_types.sum_type('sum_type', 'integer', 'bigint');
+\dT;
+:dump_types;
+
+select get_type_size('sum_type');
+
+select 'integer(1000)'::sum_type;
+select 'integer(1000)'::sum_type::integer;
+select 1000::sum_type;
+select 'bigint(10000000000)'::sum_type;
+select 'bigint(10000000000)'::sum_type::bigint;
+select 10000000000::bigint::sum_type;
+
+rollback;
+
+-- Single fixed size
+begin;
+select omni_types.sum_type('sum_type', 'name');
+\dT;
+:dump_types;
+
+select get_type_size('sum_type');
+
+select 'name(test)'::sum_type;
+select 'name(test)'::sum_type::name;
+select 'test'::name::sum_type;
+
+rollback;
+
+-- Multiple fixed size, by val is mixed
+begin;
+select omni_types.sum_type('sum_type', 'name', 'integer');
+\dT;
+:dump_types;
+
+select get_type_size('sum_type');
+
+select 'name(test)'::sum_type;
+select 'name(test)'::sum_type::name;
+select 'test'::name::sum_type;
+select 'integer(1000)'::sum_type;
+select 'integer(1000)'::sum_type::integer;
+select 1000::sum_type;
+
+rollback;
+
+-- Single variable size
+begin;
+select omni_types.sum_type('sum_type', 'text');
+\dT;
+:dump_types;
+
+select get_type_size('sum_type');
+
+select 'text(Hello)'::sum_type;
+select 'text(Hello)'::sum_type::text;
+select 'Hello'::text::sum_type;
+
+rollback;
+
+-- Multiple mixed variable and fixed size
+begin;
+select omni_types.sum_type('sum_type', 'text', 'integer', 'name');
+\dT;
+:dump_types;
+
+select get_type_size('sum_type');
+
+select 'text(Hello)'::sum_type;
+select 'text(Hello)'::sum_type::text;
+select 'Hello'::text::sum_type;
+select 'integer(1000)'::sum_type;
+select 'integer(1000)'::sum_type::integer;
+select 1000::sum_type;
+select 'name(test)'::sum_type;
+select 'name(test)'::sum_type::name;
+select 'test'::name::sum_type;
+
+rollback;
+
+-- Domains
+begin;
+create domain height as integer check (value > 0);
+create domain age as integer check (value > 0 and value < 200);
+
+select omni_types.sum_type('sum_type', 'height', 'age');
+\dT;
+:dump_types;
+
+select get_type_size('sum_type');
+
+select 'height(100)'::sum_type;
+select 'age(100)'::sum_type;
+
+-- Can't cast domain types, use functions
+select sum_type_from_height(100);
+select sum_type_from_age(100);
+
+rollback;
+
+--- Composite types
+begin;
+create type person as
+(
+    name text,
+    dob  date
+);
+
+create type animal as enum ('dog', 'cat', 'fish', 'other');
+
+create type pet as
+(
+    name   text,
+    animal animal
+);
+
+select omni_types.sum_type('sum_type', 'person', 'pet');
+\dT;
+:dump_types;
+
+select get_type_size('sum_type');
+
+select $$person((John,01/01/1980))$$::sum_type;
+select $$pet((Charlie,dog))$$::sum_type;
+select row ('John', '01/01/1980')::person::sum_type;
+select row ('Charlie','dog')::pet::sum_type;
+select row ('John', '01/01/1980')::person::sum_type::person;
+select row ('John', '01/01/1980')::person::sum_type::pet;
+select row ('Charlie','dog')::pet::sum_type::pet;
+select row ('Charlie','dog')::pet::sum_type::person;
+
+
+rollback;
+
+-- Casting variants to different types
+begin;
+select omni_types.sum_type('sum_type', 'integer', 'boolean');
+\dT;
+:dump_types;
+
+select 100::sum_type::boolean;
+select true::sum_type::integer;
+
+rollback;
+
+-- Duplicates
+begin;
+select omni_types.sum_type('sum_type', 'integer', 'integer');
+
+rollback;
+
+-- Ensure no types are leaked
+\dT;
+:dump_types;

--- a/extensions/omni_types/sql/sum_type.sql
+++ b/extensions/omni_types/sql/sum_type.sql
@@ -192,6 +192,20 @@ select omni_types.sum_type('sum_type', 'integer', 'integer');
 
 rollback;
 
+-- Determining variant
+begin;
+select omni_types.sum_type('sum_type', 'integer', 'boolean');
+\dT;
+:dump_types;
+
+select omni_types.variant(100::sum_type);
+select omni_types.variant(true::sum_type);
+
+-- Invalid type
+select omni_types.variant(10);
+
+rollback;
+
 -- Ensure no types are leaked
 \dT;
 :dump_types;

--- a/extensions/omni_types/sum_type.c
+++ b/extensions/omni_types/sum_type.c
@@ -273,7 +273,6 @@ Datum sum_in(PG_FUNCTION_ARGS) {
   return make_variant(sum_type_len, discriminant, variant_type_len, variant_byval, result);
 }
 
-
 Datum sum_out(PG_FUNCTION_ARGS) {
   HeapTuple proc_tuple = SearchSysCache1(PROCOID, fcinfo->flinfo->fn_oid);
   Assert(HeapTupleIsValid(proc_tuple));

--- a/extensions/omni_types/sum_type.c
+++ b/extensions/omni_types/sum_type.c
@@ -1,0 +1,629 @@
+/**
+ * @file omni_types.c
+ *
+ */
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+#include "access/heapam.h"
+#include "access/table.h"
+#include "catalog/pg_cast.h"
+#include "executor/spi.h"
+#include "utils/builtins.h"
+#include "utils/fmgroids.h"
+#include "utils/lsyscache.h"
+#include <access/htup_details.h>
+#include <catalog/namespace.h>
+#include <catalog/pg_collation.h>
+#include <catalog/pg_language.h>
+#include <catalog/pg_proc.h>
+#include <catalog/pg_type.h>
+#include <commands/typecmds.h>
+#include <miscadmin.h>
+#include <utils/array.h>
+#include <utils/syscache.h>
+
+PG_MODULE_MAGIC;
+
+/**
+ * Defines a sum type
+ * @param fcinfo
+ * @return
+ */
+PG_FUNCTION_INFO_V1(sum_type);
+
+/**
+ * Converts cstring into a sum type
+ * @param fcinfo
+ * @return
+ */
+PG_FUNCTION_INFO_V1(sum_in);
+/**
+ * Converts sum type to a cstring
+ * @param fcinfo
+ * @return
+ */
+PG_FUNCTION_INFO_V1(sum_out);
+/**
+ * Casts sum type to a variant
+ * @param fcinfo
+ * @return
+ */
+PG_FUNCTION_INFO_V1(sum_cast_to);
+/**
+ * Casts variant to sum type
+ * @param fcinfo
+ * @return
+ */
+PG_FUNCTION_INFO_V1(sum_cast_from);
+
+typedef int32 Discriminant;
+// This is to basically ensure a theoretical limit of types can be covered by the discriminant
+// (although it is generally excessive)
+StaticAssertDecl(sizeof(uint32_t) <= sizeof(Oid),
+                 "discriminant size should not be able to cover more than there can be types");
+StaticAssertDecl(sizeof(uint32_t) == sizeof(Oid), "discriminant size should match that of Oid");
+
+/**
+ * Fixed-size type layout
+ */
+typedef struct {
+  Discriminant discriminant;
+  char data[FLEXIBLE_ARRAY_MEMBER];
+} FixedSizeVariant;
+
+/**
+ * Variable-size type layout
+ */
+typedef struct {
+  Discriminant discriminant;
+  /**
+   * @note If the variant iself is a `varlena`, `data` will embed that `varlena` in its entirety
+   * to make it easier to work with (no need to create a new varlena with the reduced size).
+   * It increases the size of the overall structure by the size of  the `varlena` header.
+   */
+  struct varlena data;
+} VarSizeVariant;
+
+StaticAssertDecl(offsetof(VarSizeVariant, discriminant) == offsetof(FixedSizeVariant, discriminant),
+                 "discriminant offset should be equal");
+
+/**
+ * Makes a sum type from a given variant
+ * @param sum_type_len length of the sum type
+ * @param discriminant discriminant
+ * @param variant_type_len length of the variant type
+ * @param variant_byval is variant passed by value?
+ * @param variant_value the actual variant
+ * @return sum type
+ */
+static Datum make_variant(int16 sum_type_len, Discriminant discriminant, int16 variant_type_len,
+                          bool variant_byval, Datum variant_value) {
+  // If sum type is fixed size
+  if (sum_type_len != -1) {
+    FixedSizeVariant *fixed_size = palloc(sum_type_len);
+    fixed_size->discriminant = discriminant;
+
+    // If the variant is passed by val
+    if (variant_byval) {
+      // Copy the variant itself
+      memcpy(&fixed_size->data, &variant_value, variant_type_len);
+    } else {
+      // Copy the variant from behind the pointer
+      memcpy(&fixed_size->data, DatumGetPointer(variant_value), variant_type_len);
+    }
+    PG_RETURN_POINTER(fixed_size);
+  } else {
+    // If sum type is variable size,
+    size_t sz = variant_type_len == -1 ? VARSIZE(variant_value) : variant_type_len;
+    struct varlena *varsize = palloc(VARHDRSZ + sizeof(VarSizeVariant) + sz);
+    SET_VARSIZE(varsize, sizeof(VarSizeVariant) + sz);
+    VarSizeVariant *var_size_variant = (VarSizeVariant *)VARDATA_ANY(varsize);
+    var_size_variant->discriminant = discriminant;
+    // If the variant is passed by val
+    if (variant_byval) {
+      // Copy the variant itself
+      memcpy(VARDATA_ANY(&var_size_variant->data), &variant_value, sz);
+    } else {
+      // Copy the variant from behind the pointer
+      // If the variant itself is a variable size, it'll copy the `varlena`
+      // which is intentional
+      memcpy(&var_size_variant->data, DatumGetPointer(variant_value), sz);
+    }
+    PG_RETURN_POINTER(varsize);
+  }
+}
+
+Datum sum_in(PG_FUNCTION_ARGS) {
+
+  char *input = PG_GETARG_CSTRING(0);
+  if (input[strlen(input) - 1] != ')') {
+    // No closing paren
+    ereport(ERROR, errmsg("Invalid syntax"), errdetail("missing trailing parenthesis"));
+  }
+
+  HeapTuple proc_tuple = SearchSysCache1(PROCOID, fcinfo->flinfo->fn_oid);
+  Assert(HeapTupleIsValid(proc_tuple));
+  Form_pg_proc proc_struct = (Form_pg_proc)GETSTRUCT(proc_tuple);
+  Oid sum_type_oid = proc_struct->prorettype;
+  ReleaseSysCache(proc_tuple);
+
+  HeapTuple sum_type_tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(sum_type_oid));
+  Assert(HeapTupleIsValid(sum_type_tup));
+  Form_pg_type sum_typtup = (Form_pg_type)GETSTRUCT(sum_type_tup);
+  int16 sum_type_len = sum_typtup->typlen;
+  ReleaseSysCache(sum_type_tup);
+
+  // Find matching variant
+  Oid types = get_relname_relid("sum_types", get_namespace_oid("omni_types", false));
+
+  Relation rel = table_open(types, AccessShareLock);
+  TupleDesc tupdesc = RelationGetDescr(rel);
+  TableScanDesc scan = table_beginscan_catalog(rel, 0, NULL);
+  Oid variant = InvalidOid;
+  Discriminant discriminant = 0;
+  for (;;) {
+    HeapTuple tup = heap_getnext(scan, ForwardScanDirection);
+    // The end
+    if (tup == NULL)
+      break;
+
+    bool isnull;
+    // Matching type
+    if (sum_type_oid == DatumGetObjectId(heap_getattr(tup, 1, tupdesc, &isnull))) {
+      ArrayIterator it = array_create_iterator(
+          DatumGetArrayTypeP(heap_getattr(tup, 2, tupdesc, &isnull)), 0, NULL);
+
+      Datum elem;
+      // Iterate through variants
+      uint32_t i = 0;
+      while (array_iterate(it, &elem, &isnull)) {
+        if (isnull) {
+          continue;
+        }
+        char *type = format_type_be(DatumGetObjectId(elem));
+        if (strncmp(input, type, strlen(type)) == 0 && input[strlen(type)] == '(') {
+          variant = DatumGetObjectId(elem);
+          discriminant = i;
+          break;
+        }
+        i++;
+      }
+      array_free_iterator(it);
+      if (elem != InvalidOid) {
+        break;
+      }
+    }
+  }
+  if (scan->rs_rd->rd_tableam->scan_end) {
+    scan->rs_rd->rd_tableam->scan_end(scan);
+  }
+  table_close(rel, AccessShareLock);
+
+  if (variant == InvalidOid) {
+    ereport(ERROR, errmsg("No valid variant found"));
+  }
+
+  HeapTuple type_tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(variant));
+  Assert(HeapTupleIsValid(type_tup));
+  Form_pg_type typtup = (Form_pg_type)GETSTRUCT(type_tup);
+  int16 variant_type_len = typtup->typlen;
+  bool variant_byval = typtup->typbyval;
+  regproc variant_input_function_oid = typtup->typinput;
+  int32 variant_typmod = typtup->typmodin;
+  Oid variant_ioparam = OidIsValid(typtup->typelem) ? typtup->typelem : typtup->oid;
+  ReleaseSysCache(type_tup);
+
+  char *left_paren = strchr(input, '(');
+  unsigned long effective_input_size = strlen(input) - (left_paren - input) - 1;
+  char *modified_input = (char *)palloc(effective_input_size);
+  strncpy(modified_input, left_paren + 1, effective_input_size - 1);
+  modified_input[effective_input_size - 1] = 0;
+
+  Datum result = OidInputFunctionCall(variant_input_function_oid, modified_input, variant_ioparam,
+                                      variant_typmod);
+
+  return make_variant(sum_type_len, discriminant, variant_type_len, variant_byval, result);
+}
+
+/**
+ * Extract variant value from a sum type.
+ *
+ * If invalid, `variant` will contain `InvalidOid`.
+ *
+ * @param arg sum type value
+ * @param sum_type_oid sum type
+ * @param variant returns the variant Oid
+ * @param val returns the extracted variant
+ */
+static void get_variant_val(Datum *arg, Oid sum_type_oid, Oid *variant, Datum *val);
+
+Datum sum_out(PG_FUNCTION_ARGS) {
+  HeapTuple proc_tuple = SearchSysCache1(PROCOID, fcinfo->flinfo->fn_oid);
+  Assert(HeapTupleIsValid(proc_tuple));
+  Form_pg_proc proc_struct = (Form_pg_proc)GETSTRUCT(proc_tuple);
+  Oid sum_type_oid = proc_struct->proargtypes.values[0];
+  ReleaseSysCache(proc_tuple);
+
+  Datum *arg = (Datum *)PG_GETARG_POINTER(0);
+
+  Oid variant;
+  Datum val;
+  get_variant_val(arg, sum_type_oid, &variant, &val);
+
+  HeapTuple type_tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(variant));
+  Assert(HeapTupleIsValid(type_tup));
+  Form_pg_type typtup = (Form_pg_type)GETSTRUCT(type_tup);
+  regproc variant_output_function_oid = typtup->typoutput;
+  char *variant_name = format_type_be(variant);
+
+  char *out = OidOutputFunctionCall(variant_output_function_oid, val);
+
+  StringInfoData string;
+  initStringInfo(&string);
+  appendStringInfo(&string, "%s(%s)", variant_name, out);
+
+  ReleaseSysCache(type_tup);
+
+  PG_RETURN_CSTRING(string.data);
+}
+
+Datum sum_cast_to(PG_FUNCTION_ARGS) {
+  HeapTuple proc_tuple = SearchSysCache1(PROCOID, fcinfo->flinfo->fn_oid);
+  Assert(HeapTupleIsValid(proc_tuple));
+  Form_pg_proc proc_struct = (Form_pg_proc)GETSTRUCT(proc_tuple);
+  Oid sum_type_oid = proc_struct->proargtypes.values[0];
+  Oid variant_type_oid = proc_struct->prorettype;
+  ReleaseSysCache(proc_tuple);
+
+  Datum *arg = (Datum *)PG_GETARG_POINTER(0);
+
+  Oid variant;
+  Datum val;
+  get_variant_val(arg, sum_type_oid, &variant, &val);
+
+  if (variant != variant_type_oid) {
+    PG_RETURN_NULL();
+  }
+
+  return val;
+}
+
+Datum sum_cast_from(PG_FUNCTION_ARGS) {
+  HeapTuple proc_tuple = SearchSysCache1(PROCOID, fcinfo->flinfo->fn_oid);
+  Assert(HeapTupleIsValid(proc_tuple));
+  Form_pg_proc proc_struct = (Form_pg_proc)GETSTRUCT(proc_tuple);
+  Oid sum_type_oid = proc_struct->prorettype;
+  Oid variant_type_oid = proc_struct->proargtypes.values[0];
+  ReleaseSysCache(proc_tuple);
+
+  // Find matching variant
+  Oid types = get_relname_relid("sum_types", get_namespace_oid("omni_types", false));
+
+  Relation rel = table_open(types, AccessShareLock);
+  TupleDesc tupdesc = RelationGetDescr(rel);
+  TableScanDesc scan = table_beginscan_catalog(rel, 0, NULL);
+  bool discriminant_found = false;
+  Discriminant discriminant = 0;
+  for (;;) {
+    HeapTuple tup = heap_getnext(scan, ForwardScanDirection);
+    // The end
+    if (tup == NULL)
+      break;
+
+    bool isnull;
+    // Matching type
+    if (sum_type_oid == DatumGetObjectId(heap_getattr(tup, 1, tupdesc, &isnull))) {
+      ArrayIterator it = array_create_iterator(
+          DatumGetArrayTypeP(heap_getattr(tup, 2, tupdesc, &isnull)), 0, NULL);
+
+      Datum elem;
+      // Iterate through variants
+      uint32_t i = 0;
+      while (array_iterate(it, &elem, &isnull)) {
+        if (isnull) {
+          continue;
+        }
+        Oid oid = DatumGetObjectId(elem);
+        if (oid == variant_type_oid) {
+          discriminant = i;
+          discriminant_found = true;
+          break;
+        }
+        i++;
+      }
+      array_free_iterator(it);
+    }
+  }
+  if (scan->rs_rd->rd_tableam->scan_end) {
+    scan->rs_rd->rd_tableam->scan_end(scan);
+  }
+  table_close(rel, AccessShareLock);
+
+  if (!discriminant_found) {
+    ereport(ERROR, errmsg("No valid variant found"));
+  }
+
+  HeapTuple sum_type_tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(sum_type_oid));
+  Assert(HeapTupleIsValid(sum_type_tup));
+  Form_pg_type sum_typtup = (Form_pg_type)GETSTRUCT(sum_type_tup);
+  int16 sum_type_len = sum_typtup->typlen;
+  ReleaseSysCache(sum_type_tup);
+
+  HeapTuple type_tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(variant_type_oid));
+  Assert(HeapTupleIsValid(type_tup));
+  Form_pg_type typtup = (Form_pg_type)GETSTRUCT(type_tup);
+  int16 variant_type_len = typtup->typlen;
+  bool variant_byval = typtup->typbyval;
+  ReleaseSysCache(type_tup);
+
+  return make_variant(sum_type_len, discriminant, variant_type_len, variant_byval,
+                      PG_GETARG_DATUM(0));
+}
+
+static void get_variant_val(Datum *arg, Oid sum_type_oid, Oid *variant, Datum *val) {
+  HeapTuple sum_type_tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(sum_type_oid));
+  Assert(HeapTupleIsValid(sum_type_tup));
+  Form_pg_type sum_typtup = (Form_pg_type)GETSTRUCT(sum_type_tup);
+  int16 sum_type_len = sum_typtup->typlen;
+  ReleaseSysCache(sum_type_tup);
+
+  struct varlena *varsize = (struct varlena *)arg;
+  FixedSizeVariant *value =
+      sum_type_len == -1 ? (FixedSizeVariant *)VARDATA_ANY(varsize) : (FixedSizeVariant *)arg;
+
+  // Find the variant
+  Oid types = get_relname_relid("sum_types", get_namespace_oid("omni_types", false));
+
+  Relation rel = table_open(types, AccessShareLock);
+  TupleDesc tupdesc = RelationGetDescr(rel);
+  TableScanDesc scan = table_beginscan_catalog(rel, 0, NULL);
+  *variant = InvalidOid;
+  for (;;) {
+    HeapTuple tup = heap_getnext(scan, ForwardScanDirection);
+    // The end
+    if (tup == NULL)
+      break;
+
+    bool isnull;
+    // Matching type
+    if (sum_type_oid == DatumGetObjectId(heap_getattr(tup, 1, tupdesc, &isnull))) {
+      ArrayType *arr = DatumGetArrayTypeP(heap_getattr(tup, 2, tupdesc, &isnull));
+      Assert(ARR_NDIM(arr) == 1);
+      Assert(ARR_DIMS(arr)[0] >= value->discriminant + 1);
+
+      Datum element = array_get_element(PointerGetDatum(arr), 1, (int[1]){value->discriminant + 1},
+                                        -1, 4, true, TYPALIGN_INT, &isnull);
+      *variant = DatumGetObjectId(element);
+      break;
+    }
+  }
+  if (scan->rs_rd->rd_tableam->scan_end) {
+    scan->rs_rd->rd_tableam->scan_end(scan);
+  }
+  table_close(rel, AccessShareLock);
+
+  Assert(*variant != InvalidOid);
+
+  HeapTuple type_tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(*variant));
+  Assert(HeapTupleIsValid(type_tup));
+  Form_pg_type typtup = (Form_pg_type)GETSTRUCT(type_tup);
+  bool variant_byval = typtup->typbyval;
+
+  *val =
+      // if sum type is variable size
+      (Datum)(sum_type_len == -1
+                  // if variable is variable size
+                  ? (variant_byval
+                         // if variant is passed by value, get it from behind the pointer
+                         ? *((Datum *)VARDATA_ANY(&((VarSizeVariant *)VARDATA_ANY(varsize))->data))
+                         // otherwise, pass the pointer
+                         : (Datum) & ((VarSizeVariant *)VARDATA_ANY(varsize))->data)
+                  // if variant is passed by value, get it from behind the pointer
+                  : (variant_byval ? *((Datum *)value->data)
+                                   // otherwise, pass the pointer
+                                   : (Datum)value->data));
+  ReleaseSysCache(type_tup);
+}
+
+Datum sum_type(PG_FUNCTION_ARGS) {
+
+  if (PG_ARGISNULL(0)) {
+    ereport(ERROR, errmsg("sum type must have a non-NULL name"));
+  }
+
+  Name name = PG_GETARG_NAME(0);
+
+  if (PG_ARGISNULL(1)) {
+    ereport(ERROR, errmsg("sum type must have a non-NULL array of variants"));
+  }
+
+  // Get current schema
+  List *search_path = fetch_search_path(false);
+  Assert(search_path != NIL);
+  Oid namespace = linitial_oid(search_path);
+
+  // Obtain `probin` (current extension's binary)
+  HeapTuple proc_tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(fcinfo->flinfo->fn_oid));
+  Assert(HeapTupleIsValid(proc_tuple));
+  bool isnull;
+  char *probin = text_to_cstring(
+      DatumGetTextPP(SysCacheGetAttr(PROCOID, proc_tuple, Anum_pg_proc_probin, &isnull)));
+  ReleaseSysCache(proc_tuple);
+
+  ArrayType *arr = PG_GETARG_ARRAYTYPE_P(1);
+
+  int16 variant_size = 0;
+  bool varlen = false;
+
+  // Figure out sum type size
+  {
+    ArrayIterator it = array_create_iterator(arr, 0, NULL);
+
+    Datum elem;
+    bool is_null = false;
+
+    while (array_iterate(it, &elem, &is_null)) {
+      if (is_null) {
+        // Handle null element
+        continue;
+      }
+      HeapTuple type_tuple;
+      Form_pg_type typ;
+
+      // Get the type tuple corresponding to the OID
+      type_tuple = SearchSysCache1(TYPEOID, elem);
+      if (!HeapTupleIsValid(type_tuple)) {
+        // Handle error
+        ereport(ERROR, errmsg("Type OID %lu is invalid", elem));
+      }
+
+      /* Get the Form_pg_type struct from the type tuple */
+      typ = (Form_pg_type)GETSTRUCT(type_tuple);
+
+      if (typ->typlen == -1) {
+        varlen = true;
+      } else {
+        variant_size = Max(variant_size, typ->typlen);
+      }
+
+      ReleaseSysCache(type_tuple);
+    }
+
+    array_free_iterator(it);
+  }
+
+  int16 type_size = varlen ? -1 : sizeof(Discriminant) + variant_size;
+
+  // Create shell type first
+  ObjectAddress shell = TypeShellMake(NameStr(*name), namespace, GetUserId());
+
+  // Register the type and ensure constraints are checked
+  SPI_connect();
+  SPI_execute_with_args("insert into omni_types.sum_types (oid, variants) values ($1, $2)", 2,
+                        (Oid[2]){OIDOID, REGTYPEARRAYOID},
+                        (Datum[2]){
+                            shell.objectId,
+                            PointerGetDatum(arr),
+                        },
+                        (char[2]){' ', ' '}, false, 0);
+  SPI_finish();
+
+  Oid array_oid = AssignTypeArrayOid();
+
+  // Prepare cstring -> sum type function
+  char *f_in = psprintf("%s_in", NameStr(*name));
+  ObjectAddress in =
+      ProcedureCreate(f_in, namespace, false, false, shell.objectId, GetUserId(), ClanguageId,
+                      F_FMGR_C_VALIDATOR, "sum_in", probin,
+#if PG_MAJORVERSION_NUM > 13
+                      NULL,
+#endif
+                      PROKIND_FUNCTION, false, true, true, PROVOLATILE_STABLE, PROPARALLEL_SAFE,
+                      buildoidvector((Oid[1]){CSTRINGOID}, 1), PointerGetDatum(NULL),
+                      PointerGetDatum(NULL), PointerGetDatum(NULL), NIL, PointerGetDatum(NULL),
+                      PointerGetDatum(NULL), InvalidOid, 1.0, 0.0);
+
+  // Prepare sum type -> cstring function
+  char *f_out = psprintf("%s_out", NameStr(*name));
+  ObjectAddress out =
+      ProcedureCreate(f_out, namespace, false, false, CSTRINGOID, GetUserId(), ClanguageId,
+                      F_FMGR_C_VALIDATOR, "sum_out", probin,
+#if PG_MAJORVERSION_NUM > 13
+                      NULL,
+#endif
+                      PROKIND_FUNCTION, false, true, true, PROVOLATILE_STABLE, PROPARALLEL_SAFE,
+                      buildoidvector((Oid[1]){shell.objectId}, 1), PointerGetDatum(NULL),
+                      PointerGetDatum(NULL), PointerGetDatum(NULL), NIL, PointerGetDatum(NULL),
+                      PointerGetDatum(NULL), InvalidOid, 1.0, 0.0);
+
+  // Prepare the type itself
+  ObjectAddress type =
+      TypeCreate(InvalidOid, NameStr(*name), namespace, InvalidOid, 0, GetUserId(), type_size,
+                 TYPTYPE_BASE, TYPCATEGORY_USER, true, DEFAULT_TYPDELIM, in.objectId, out.objectId,
+                 InvalidOid, InvalidOid, InvalidOid, InvalidOid, InvalidOid,
+#if PG_MAJORVERSION_NUM > 13
+                 InvalidOid,
+#endif
+                 InvalidOid, false, array_oid, InvalidOid, NULL, NULL, false, TYPALIGN_INT,
+                 TYPSTORAGE_PLAIN, -1, 0, false, DEFAULT_COLLATION_OID);
+
+  Assert(shell.objectId == type.objectId);
+
+  char *array_type_name = makeArrayTypeName(NameStr(*name), namespace);
+
+  ObjectAddress array_type =
+      TypeCreate(array_oid, array_type_name, namespace, InvalidOid, 0, GetUserId(), -1,
+                 TYPTYPE_BASE, TYPCATEGORY_ARRAY, false, DEFAULT_TYPDELIM, F_ARRAY_IN, F_ARRAY_OUT,
+                 F_ARRAY_RECV, F_ARRAY_SEND, InvalidOid, InvalidOid, F_ARRAY_TYPANALYZE,
+#if PG_MAJORVERSION_NUM > 13
+                 F_ARRAY_SUBSCRIPT_HANDLER,
+#endif
+                 type.objectId, true, InvalidOid, InvalidOid, NULL, NULL, false, TYPALIGN_INT,
+                 TYPSTORAGE_EXTENDED, -1, 0, false, DEFAULT_COLLATION_OID);
+
+  // Create casts
+  {
+    Datum elem;
+    bool is_null;
+    ArrayIterator it = array_create_iterator(arr, 0, NULL);
+    while (array_iterate(it, &elem, &is_null)) {
+      if (is_null) {
+        // Handle null element
+        continue;
+      }
+      Oid target = DatumGetObjectId(elem);
+
+      HeapTuple type_tuple = SearchSysCache1(TYPEOID, elem);
+      Assert(HeapTupleIsValid(type_tuple));
+
+      Form_pg_type typ = (Form_pg_type)GETSTRUCT(type_tuple);
+      bool is_domain = typ->typtype == TYPTYPE_DOMAIN;
+
+      char *f_cast_to = psprintf("%s_from_%s", NameStr(typ->typname), NameStr(*name));
+      char *f_cast_from = psprintf("%s_from_%s", NameStr(*name), NameStr(typ->typname));
+
+      ReleaseSysCache(type_tuple);
+
+      ObjectAddress cast_to =
+          ProcedureCreate(f_cast_to, namespace, false, false, target, GetUserId(), ClanguageId,
+                          F_FMGR_C_VALIDATOR, "sum_cast_to", probin,
+#if PG_MAJORVERSION_NUM > 13
+                          NULL,
+#endif
+                          PROKIND_FUNCTION,
+
+                          false, true, true, PROVOLATILE_STABLE, PROPARALLEL_SAFE,
+                          buildoidvector((Oid[1]){type.objectId}, 1), PointerGetDatum(NULL),
+                          PointerGetDatum(NULL), PointerGetDatum(NULL), NIL, PointerGetDatum(NULL),
+                          PointerGetDatum(NULL), InvalidOid, 1.0, 0.0);
+
+      ObjectAddress cast_from =
+          ProcedureCreate(f_cast_from, namespace, false, false, type.objectId, GetUserId(),
+                          ClanguageId, F_FMGR_C_VALIDATOR, "sum_cast_from", probin,
+#if PG_MAJORVERSION_NUM > 13
+                          NULL,
+#endif
+                          PROKIND_FUNCTION,
+
+                          false, true, true, PROVOLATILE_STABLE, PROPARALLEL_SAFE,
+                          buildoidvector((Oid[1]){target}, 1), PointerGetDatum(NULL),
+                          PointerGetDatum(NULL), PointerGetDatum(NULL), NIL, PointerGetDatum(NULL),
+                          PointerGetDatum(NULL), InvalidOid, 1.0, 0.0);
+
+      if (!is_domain) {
+        // It's pointless to create domain casts
+        CastCreate(type.objectId, target, cast_to.objectId, COERCION_CODE_ASSIGNMENT,
+                   COERCION_METHOD_FUNCTION, DEPENDENCY_NORMAL);
+        CastCreate(target, type.objectId, cast_from.objectId, COERCION_CODE_ASSIGNMENT,
+                   COERCION_METHOD_FUNCTION, DEPENDENCY_NORMAL);
+      }
+    }
+
+    array_free_iterator(it);
+  }
+
+  PG_RETURN_OID(type.objectId);
+}


### PR DESCRIPTION
Sometimes under the wraps of one type we need to return distinctly different values. For example, if omni_httpd wants to handle different type "reactions" to an HTTP request (respond, upgrade, etc.).

Solution: implement sum types in omni_types extension

This is also known as enum or union.