### PR TITLE
Problem: omnigres slim image contains no additional PLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,7 @@ COPY --from=build /build/packaged /omni
 COPY docker/initdb-slim/* /docker-entrypoint-initdb.d/
 RUN cp -R /omni/extension $(pg_config --sharedir)/ && cp -R /omni/*.so $(pg_config --pkglibdir)/ && rm -rf /omni
 RUN apt update && apt -y install libtclcl1 libpython3.9 libperl5.32
+RUN PG_VER=${PG%.*} && apt update && apt -y install postgresql-pltcl-${PG_VER} postgresql-plperl-${PG_VER} postgresql-plpython3-${PG_VER} postgresql-${PG_VER}-pljava
 EXPOSE 8080
 EXPOSE 5432
 


### PR DESCRIPTION
This limits its usability when it comes to writing some logic.

Solution: include all standard PLs and pljava

The non-slim image gets all of this, too, of course.