### PR TITLE
Problem: error clarity when defining sum type with a pseudotype

### DIFF
--- a/extensions/omni_types/expected/sum_type.out
+++ b/extensions/omni_types/expected/sum_type.out
@@ -657,6 +657,12 @@ select (case when omni_types.variant(val) = 'text'::regtype then length(val::tex
 (2 rows)
 
 rollback;
+-- Pseudo-types can't be used
+begin;
+select omni_types.sum_type('sum_type', 'text', 'anyarray');
+ERROR:  Pseudo-types can't be variants
+DETAIL:  anyarray
+rollback;
 -- Ensure no types are leaked
 \dT;
      List of data types

--- a/extensions/omni_types/sql/sum_type.sql
+++ b/extensions/omni_types/sql/sum_type.sql
@@ -224,6 +224,11 @@ select (case when omni_types.variant(val) = 'text'::regtype then length(val::tex
 
 rollback;
 
+-- Pseudo-types can't be used
+begin;
+select omni_types.sum_type('sum_type', 'text', 'anyarray');
+rollback;
+
 -- Ensure no types are leaked
 \dT;
 :dump_types;

--- a/extensions/omni_types/sum_type.c
+++ b/extensions/omni_types/sum_type.c
@@ -520,6 +520,11 @@ Datum sum_type(PG_FUNCTION_ARGS) {
       /* Get the Form_pg_type struct from the type tuple */
       typ = (Form_pg_type)GETSTRUCT(type_tuple);
 
+      if (typ->typcategory == TYPCATEGORY_PSEUDOTYPE) {
+        ereport(ERROR, errmsg("Pseudo-types can't be variants"),
+                errdetail("%s", NameStr(typ->typname)));
+      }
+
       if (typ->typlen == -1) {
         varlen = true;
       } else {


### PR DESCRIPTION
It may look like this:

```
A result of type anyarray requires at least one input of type
anyelement, anyarray, anynonarray, anyenum, anyrange, or anymultirange.
```

Solution: handle it explictly with a clear error