### PR TITLE
Problem: pg_dump won't export omni_types.sum_types correctly

### DIFF
--- a/extensions/omni_types/expected/sum_type.out
+++ b/extensions/omni_types/expected/sum_type.out
@@ -1,5 +1,5 @@
 \pset null 'NULL'
-\set dump_types 'select typname,variants from omni_types.sum_types st inner join pg_type t on t.oid = st.oid'
+\set dump_types 'select typ as typname,variants from omni_types.sum_types'
 create or replace function get_type_size(data_type regtype)
     returns integer as
 $$
@@ -573,7 +573,7 @@ begin;
 select omni_types.sum_type('sum_type', 'integer', 'integer');
 ERROR:  Sum types can not contain duplicate variants
 CONTEXT:  PL/pgSQL function omni_types.sum_type_unique_variants_trigger_func() line 12 at RAISE
-SQL statement "insert into omni_types.sum_types (oid, variants) values ($1, $2)"
+SQL statement "insert into omni_types.sum_types (typ, variants) values ($1, $2)"
 rollback;
 -- Determining variant
 begin;

--- a/extensions/omni_types/omni_types--0.1.sql
+++ b/extensions/omni_types/omni_types--0.1.sql
@@ -1,6 +1,6 @@
 create table sum_types
 (
-    oid      oid primary key unique,
+    typ      regtype primary key unique,
     variants regtype[] not null
 );
 

--- a/extensions/omni_types/sql/sum_type.sql
+++ b/extensions/omni_types/sql/sum_type.sql
@@ -1,5 +1,5 @@
 \pset null 'NULL'
-\set dump_types 'select typname,variants from omni_types.sum_types st inner join pg_type t on t.oid = st.oid'
+\set dump_types 'select typ as typname,variants from omni_types.sum_types'
 
 create or replace function get_type_size(data_type regtype)
     returns integer as

--- a/extensions/omni_types/sum_type.c
+++ b/extensions/omni_types/sum_type.c
@@ -544,8 +544,8 @@ Datum sum_type(PG_FUNCTION_ARGS) {
 
   // Register the type and ensure constraints are checked
   SPI_connect();
-  SPI_execute_with_args("insert into omni_types.sum_types (oid, variants) values ($1, $2)", 2,
-                        (Oid[2]){OIDOID, REGTYPEARRAYOID},
+  SPI_execute_with_args("insert into omni_types.sum_types (typ, variants) values ($1, $2)", 2,
+                        (Oid[2]){REGTYPEOID, REGTYPEARRAYOID},
                         (Datum[2]){
                             shell.objectId,
                             PointerGetDatum(arr),


### PR DESCRIPTION
It'll dump OIDs for sum types

Solution: make it dump type names instead by using `regtype`