### PR TITLE
Problem: no binary I/O for sum types

### DIFF
--- a/extensions/omni_types/expected/sum_type.out
+++ b/extensions/omni_types/expected/sum_type.out
@@ -663,6 +663,47 @@ select omni_types.sum_type('sum_type', 'text', 'anyarray');
 ERROR:  Pseudo-types can't be variants
 DETAIL:  anyarray
 rollback;
+-- Binary I/O
+begin;
+select omni_types.sum_type('sum_type', 'text', 'integer');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+select typsend = 'sum_type_send'::regproc as valid_send,
+       typreceive = 'sum_type_recv'::regproc as valid_recv
+from pg_type
+where oid = 'sum_type'::regtype;
+ valid_send | valid_recv 
+------------+------------
+ t          | t
+(1 row)
+
+select sum_type_recv(sum_type_send('text(Hello)'));
+ sum_type_recv 
+---------------
+ text(Hello)
+(1 row)
+
+select sum_type_recv(sum_type_send('integer(1000)'));
+ sum_type_recv 
+---------------
+ integer(1000)
+(1 row)
+
+-- Malformed input
+savepoint try;
+select sum_type_recv(E''::bytea);
+ERROR:  input is too short to fit a discriminant
+rollback to savepoint try;
+select sum_type_recv(int4send(1));
+ERROR:  insufficient data left in message
+rollback to savepoint try;
+select sum_type_recv(int4send(2));
+ERROR:  invalid discriminant
+rollback to savepoint try;
+rollback;
 -- Ensure no types are leaked
 \dT;
      List of data types


### PR DESCRIPTION
This may reduce communication efficiency.

Solution: enable binary I/O if all variants have it

The encoding is 32-bit network-order discriminant followed by the encoding of the variant.