### PR TITLE
Problem: sum types can't be changed

### DIFF
--- a/extensions/omni_types/docs/sum_types.md
+++ b/extensions/omni_types/docs/sum_types.md
@@ -145,3 +145,20 @@ variant
  point
 (1 row)
 ```
+
+## Changing the variant type
+
+Sometimes it may be desirable to change the definition of a sum type. In most cases, it would
+be prudent to define a new type and migrate to it. However, this may be undesirable to due
+involved complexity. Luckily, under certain constraints, variant types __can__ be changed:
+
+* Only __adding__ new variants is permitted
+* For fixed-size sum types (those _not_ containing variable-sized variants), the size of the new variant __may not be larger__
+  than that of the largest existing variant. [^fixed-size-alteration]
+
+```postgresql
+select omni_types.add_variant('geom', 'my_box');
+```
+
+[^fixed-size-alteration]: This is done so that Postgres would not try to read existing values using an updated, larger size, which
+is erroneous.

--- a/extensions/omni_types/expected/sum_type.out
+++ b/extensions/omni_types/expected/sum_type.out
@@ -704,6 +704,163 @@ select sum_type_recv(int4send(2));
 ERROR:  invalid discriminant
 rollback to savepoint try;
 rollback;
+-- Adding variants
+begin;
+select omni_types.sum_type('sum_type', 'boolean', 'bigint');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | sum_type | 
+(1 row)
+
+:dump_types;
+ typname  |     variants     
+----------+------------------
+ sum_type | {boolean,bigint}
+(1 row)
+
+select omni_types.add_variant('sum_type', 'integer');
+ add_variant 
+-------------
+ 
+(1 row)
+
+:dump_types;
+ typname  |         variants         
+----------+--------------------------
+ sum_type | {boolean,bigint,integer}
+(1 row)
+
+select 'integer(1000)'::sum_type;
+   sum_type    
+---------------
+ integer(1000)
+(1 row)
+
+select 'bigint(1000)'::sum_type;
+   sum_type   
+--------------
+ bigint(1000)
+(1 row)
+
+select 'boolean(t)'::sum_type;
+  sum_type  
+------------
+ boolean(t)
+(1 row)
+
+rollback;
+-- Adding variants to variable sized type
+begin;
+select omni_types.sum_type('sum_type', 'boolean', 'text');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | sum_type | 
+(1 row)
+
+:dump_types;
+ typname  |    variants    
+----------+----------------
+ sum_type | {boolean,text}
+(1 row)
+
+select omni_types.add_variant('sum_type', 'bigint');
+ add_variant 
+-------------
+ 
+(1 row)
+
+:dump_types;
+ typname  |       variants        
+----------+-----------------------
+ sum_type | {boolean,text,bigint}
+(1 row)
+
+select 'text(test)'::sum_type;
+  sum_type  
+------------
+ text(test)
+(1 row)
+
+select 'bigint(1000)'::sum_type;
+   sum_type   
+--------------
+ bigint(1000)
+(1 row)
+
+select 'boolean(t)'::sum_type;
+  sum_type  
+------------
+ boolean(t)
+(1 row)
+
+rollback;
+-- Adding larger (invalid) variants to fixed sized type
+begin;
+select omni_types.sum_type('sum_type', 'boolean');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | sum_type | 
+(1 row)
+
+:dump_types;
+ typname  | variants  
+----------+-----------
+ sum_type | {boolean}
+(1 row)
+
+select omni_types.add_variant('sum_type', 'bigint');
+ERROR:  variant type size must not be larger than that of the largest existing variant type's
+DETAIL:  largest existing variant size: 1, variant type size: 8
+rollback;
+-- Adding duplicate variants
+begin;
+select omni_types.sum_type('sum_type', 'integer');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | sum_type | 
+(1 row)
+
+:dump_types;
+ typname  | variants  
+----------+-----------
+ sum_type | {integer}
+(1 row)
+
+-- Using a different name for the same type here intentionally
+-- to make sure it is checked against OIDs
+select omni_types.add_variant('sum_type', 'int4');
+ERROR:  Sum types can not contain duplicate variants
+CONTEXT:  PL/pgSQL function omni_types.sum_type_unique_variants_trigger_func() line 12 at RAISE
+SQL statement "update omni_types.sum_types set variants = array_append(variants, $1) where typ = $2"
+rollback;
 -- Ensure no types are leaked
 \dT;
      List of data types

--- a/extensions/omni_types/omni_types--0.1.sql
+++ b/extensions/omni_types/omni_types--0.1.sql
@@ -37,6 +37,12 @@ as
 'sum_type'
     language c;
 
+create function add_variant(sum_type regtype, variant regtype) returns void
+as
+'MODULE_PATHNAME',
+'add_variant'
+    language c;
+
 create function variant(v anycompatible) returns regtype as
 'MODULE_PATHNAME',
 'sum_variant' language c;

--- a/extensions/omni_types/sql/sum_type.sql
+++ b/extensions/omni_types/sql/sum_type.sql
@@ -252,6 +252,59 @@ rollback to savepoint try;
 
 rollback;
 
+-- Adding variants
+begin;
+select omni_types.sum_type('sum_type', 'boolean', 'bigint');
+\dT
+:dump_types;
+
+select omni_types.add_variant('sum_type', 'integer');
+:dump_types;
+
+select 'integer(1000)'::sum_type;
+select 'bigint(1000)'::sum_type;
+select 'boolean(t)'::sum_type;
+
+rollback;
+
+-- Adding variants to variable sized type
+begin;
+select omni_types.sum_type('sum_type', 'boolean', 'text');
+\dT
+:dump_types;
+
+select omni_types.add_variant('sum_type', 'bigint');
+:dump_types;
+
+select 'text(test)'::sum_type;
+select 'bigint(1000)'::sum_type;
+select 'boolean(t)'::sum_type;
+
+rollback;
+
+-- Adding larger (invalid) variants to fixed sized type
+begin;
+select omni_types.sum_type('sum_type', 'boolean');
+\dT
+:dump_types;
+
+select omni_types.add_variant('sum_type', 'bigint');
+
+rollback;
+
+-- Adding duplicate variants
+begin;
+select omni_types.sum_type('sum_type', 'integer');
+\dT
+:dump_types;
+
+-- Using a different name for the same type here intentionally
+-- to make sure it is checked against OIDs
+select omni_types.add_variant('sum_type', 'int4');
+
+rollback;
+
+
 -- Ensure no types are leaked
 \dT;
 :dump_types;


### PR DESCRIPTION
This means that if we want to add a variant, we have to create a new type and migrate to it.

Solution: allow amending sum types

For variably sized sum types, adding any new variants is permitted. For fixed sized ones, only variants of the same size or smaller are accepted. The reason for this is that if it was larger, then we'd have to change the size of the type and Postgres would attempt to use this size to read existing values which is clearly wrong.