### PR TITLE
Problem: some responses have garbage in headers

### DIFF
--- a/extensions/omni_httpd/event_loop.c
+++ b/extensions/omni_httpd/event_loop.c
@@ -65,7 +65,7 @@ void h2o_queue_send_inline(request_message_t *msg, const char *body, size_t len)
   }
   static h2o_generator_t generator = {NULL, NULL};
 
-  h2o_iovec_t buf = h2o_strdup(&req->pool, body, len);
+  h2o_iovec_t buf = {.base = (char *)body, .len = len};
 
   /* the function intentionally does not set the content length, since it may be used for generating
    * 304 response, etc. */

--- a/extensions/omni_httpd/event_loop.h
+++ b/extensions/omni_httpd/event_loop.h
@@ -101,7 +101,7 @@ int event_loop_req_handler(h2o_handler_t *self, h2o_req_t *req);
 /**
  * Send inline HTTP response to `worker_event_loop`
  * @param msg request message
- * @param body body
+ * @param body body; must be allocated in the pool
  * @param len length
  */
 void h2o_queue_send_inline(request_message_t *msg, const char *body, size_t len);

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -727,6 +727,7 @@ static int handler(request_message_t *msg) {
         size_t body_len = VARSIZE_ANY_EXHDR(body_content);
         char *body_cstring = h2o_mem_alloc_pool(&req->pool, char *, body_len + 1);
         text_to_cstring_buffer(body_content, body_cstring, body_len + 1);
+        req->res.content_length = body_len;
         h2o_queue_send_inline(msg, body_cstring, body_len);
       } else {
         h2o_queue_send_inline(msg, "", 0);


### PR DESCRIPTION
Solution: ensure we actually allocate them on h2o pool

The way headers were passed, they were simply pointers to Postgres-allocated memory. It worked before when we sent response inline, in one process. But we now send them in a different I/O thread and that was causing problems.

I've made sending body follow the same pattern for consistency.

It looks like we're now able to get higher throughput with this. Not sure how to explain this, though. In my limited benchmarking, up to two times faster than before!

I wonder if we can get rid of extra allocations/copies here in the future. For example, by de-parenting the memory context and sweeping leaked contexts at a later time?