### PR TITLE
Problem: omni_httpd seems to hang

### DIFF
--- a/extensions/omni_httpd/event_loop.h
+++ b/extensions/omni_httpd/event_loop.h
@@ -62,6 +62,7 @@ typedef struct {
   h2o_multithread_message_t super;
   h2o_req_t *req;
   pthread_mutex_t mutex;
+  h2o_socket_t *server_socket; /*< server socket */
 } request_message_t;
 
 /**

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -764,3 +764,8 @@ release:
 
   return 0;
 }
+
+h2o_socket_t *get_server_socket_from_req(h2o_req_t *req) {
+  listener_ctx *lctx = H2O_STRUCT_FROM_MEMBER(listener_ctx, context, req->conn->ctx);
+  return lctx->socket;
+}


### PR DESCRIPTION
Given sufficient amount of requests, the CPU starts spinning and no new requests are served, at least not for a while.

Solution: ensure we don't let evloop poll it again

By simply returning from on_accept, evloop schedules it again to read,
in perpetuity. We disable accepting until the number of requests in flight
comes down to zero.

Importantly, we should decrement the number on the right thread
(event_loop)