### PR TITLE
Problem: HTTP handlers can only respond

### DIFF
--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -26,13 +26,15 @@ add_postgresql_extension(
         RELOCATABLE false
         SCRIPTS omni_httpd--0.1.sql
         SOURCES omni_httpd.c master_worker.c http_worker.c event_loop.c fd.c cascading_query.c
+        REQUIRES omni_types
         TESTS_REQUIRE omni_ext
         REGRESS http role_name cascading_query handler_validity port_selector http_response headers
         http2_reproxy)
 
 set_property(TARGET omni_httpd PROPERTY C_STANDARD 11)
 
-target_link_libraries(omni_httpd libh2o-evloop libpgaug libomnisql libgluepg_stc dynpgext metalang99
+target_link_libraries(omni_httpd libh2o-evloop libpgaug libomnisql libomnitypes
+        libgluepg_stc dynpgext metalang99
         Threads::Threads)
 
 # Disable full macro expansion backtraces for Metalang99.

--- a/extensions/omni_httpd/docs/reverse_proxy.md
+++ b/extensions/omni_httpd/docs/reverse_proxy.md
@@ -1,0 +1,38 @@
+# Reverse Proxy
+
+omni_httpd has a capability to respond to HTTP requests with other outcomes.
+Of a particular interest is __`http_proxy`__ as it allows us to dynamically
+proxy and re-process the incoming HTTP request to a backend:
+
+```postgresql
+select
+    omni_httpd.http_proxy('http://127.0.0.1:9000' || request.path)
+from
+    request
+```
+
+The above will simply redirect all incoming requests to 127.0.0.1
+over plain HTTP with the request path being sent as-is.
+
+This approach retrieving the target for proxying dynamically based
+on data in the database, the incoming request itself or any other data
+that can be retrieved in a query.
+
+??? danger "Potential performance implications"
+
+    This is a new feature and it hasn't been extensively benchmarked.
+    Determining proxying information in runtime _may have_ some performance
+    implications.
+
+    In the future, we may provide a dedicated configuration for backend proxying
+    that will allow for configuration-time resolution of the backends (for example,
+    to fetch them from a table), if the performance implications will be too taxing
+    in some use-cases.
+
+## Additional Options
+
+__`omni_httpd.http_proxy`__ takes the following optional parameters:
+
+| Name | Description                                                 | Default |
+|------|-------------------------------------------------------------|---------|
+| `preserve_host` | Pass `Host` header from the incoming request to the backend | `true`    |

--- a/extensions/omni_httpd/event_loop.c
+++ b/extensions/omni_httpd/event_loop.c
@@ -100,7 +100,6 @@ void h2o_queue_abort(request_message_t *msg) {
   }
 
   send_message_t *message = malloc(sizeof(*message));
-  size_t i;
   message->reqmsg = msg;
   message->kind = MSG_KIND_ABORT;
 
@@ -117,7 +116,6 @@ void h2o_queue_proxy(request_message_t *msg, char *url, bool preserve_host) {
   }
 
   send_message_t *message = malloc(sizeof(*message));
-  size_t i;
   message->reqmsg = msg;
   message->kind = MSG_KIND_PROXY;
   message->payload.proxy.url = url;

--- a/extensions/omni_httpd/event_loop.c
+++ b/extensions/omni_httpd/event_loop.c
@@ -24,13 +24,23 @@ h2o_multithread_queue_t *event_loop_queue;
 
 static size_t requests_in_flight = 0;
 
+typedef enum { MSG_KIND_SEND, MSG_KIND_ABORT, MSG_KIND_PROXY } send_message_kind;
+
 typedef struct {
   h2o_multithread_message_t super;
   request_message_t *reqmsg;
-  size_t bufcnt;
-  h2o_send_state_t state;
-  h2o_sendvec_t vecs;
-  bool abort;
+  send_message_kind kind;
+  union {
+    struct send_payload {
+      size_t bufcnt;
+      h2o_send_state_t state;
+      h2o_sendvec_t vecs;
+    } send;
+    struct {
+      char *url;
+      bool preserve_host;
+    } proxy;
+  } payload;
 } send_message_t;
 
 // Implemented in from http_worker.c
@@ -48,12 +58,12 @@ static void h2o_queue_send(request_message_t *msg, h2o_iovec_t *bufs, size_t buf
   send_message_t *message = malloc(sizeof(*message) - (sizeof(h2o_sendvec_t) * (bufcnt - 1)));
   size_t i;
   message->reqmsg = msg;
-  message->bufcnt = bufcnt;
-  message->state = state;
-  message->abort = false;
+  message->kind = MSG_KIND_SEND;
+  message->payload.send.bufcnt = bufcnt;
+  message->payload.send.state = state;
 
   for (i = 0; i != bufcnt; ++i)
-    h2o_sendvec_init_raw(&message->vecs + i, bufs[i].base, bufs[i].len);
+    h2o_sendvec_init_raw(&message->payload.send.vecs + i, bufs[i].base, bufs[i].len);
 
   message->super = (h2o_multithread_message_t){{NULL}};
 
@@ -92,11 +102,42 @@ void h2o_queue_abort(request_message_t *msg) {
   send_message_t *message = malloc(sizeof(*message));
   size_t i;
   message->reqmsg = msg;
-  message->abort = true;
+  message->kind = MSG_KIND_ABORT;
 
   message->super = (h2o_multithread_message_t){{NULL}};
 
   h2o_multithread_send_message(&event_loop_receiver, &message->super);
+}
+
+void h2o_queue_proxy(request_message_t *msg, char *url, bool preserve_host) {
+  h2o_req_t *req = msg->req;
+  if (req == NULL) {
+    // The connection is gone, bail
+    return;
+  }
+
+  send_message_t *message = malloc(sizeof(*message));
+  size_t i;
+  message->reqmsg = msg;
+  message->kind = MSG_KIND_PROXY;
+  message->payload.proxy.url = url;
+  message->payload.proxy.preserve_host = preserve_host;
+
+  message->super = (h2o_multithread_message_t){{NULL}};
+
+  h2o_multithread_send_message(&event_loop_receiver, &message->super);
+}
+
+static inline void prepare_req_for_reprocess(h2o_req_t *req) {
+  req->conn->ctx->proxy.client_ctx.tunnel_enabled = 1;
+
+  // This line below setting max_buffer_size is currently very important
+  // because
+  // https://github.com/h2o/h2o/blob/b5dca420963928865b28538a315f16cac5ae8251/lib/common/http1client.c#L881
+  // will stop reading from the socket if max_buffer_size == 0 and max_buffer_size == 0
+  // as 0 >= 0:
+  // https://github.com/h2o/h2o/issues/3225
+  req->conn->ctx->proxy.client_ctx.max_buffer_size = H2O_SOCKET_INITIAL_INPUT_BUFFER_SIZE * 2;
 }
 
 static void on_message(h2o_multithread_receiver_t *receiver, h2o_linklist_t *messages) {
@@ -114,14 +155,40 @@ static void on_message(h2o_multithread_receiver_t *receiver, h2o_linklist_t *mes
       free(reqmsg);
       goto done;
     }
-    if (send_msg->abort) {
+    h2o_req_t *req = reqmsg->req;
+    switch (send_msg->kind) {
+    case MSG_KIND_SEND:
+      h2o_sendvec(req, &send_msg->payload.send.vecs, send_msg->payload.send.bufcnt,
+                  send_msg->payload.send.state);
+      break;
+    case MSG_KIND_ABORT:
       // Abort requested, however I am not currently sure what's the best way
       // to do this with libh2o, so just sending an empty response. (TODO/FIXME)
-      reqmsg->req->res.status = 201;
-      reqmsg->req->res.content_length = 0;
-      h2o_send_inline(reqmsg->req, NULL, 0);
-    } else {
-      h2o_sendvec(reqmsg->req, &send_msg->vecs, send_msg->bufcnt, send_msg->state);
+      req->res.status = 201;
+      req->res.content_length = 0;
+      h2o_send_inline(req, NULL, 0);
+      break;
+    case MSG_KIND_PROXY: {
+      __auto_type proxy = send_msg->payload.proxy;
+      h2o_req_overrides_t *overrides = h2o_mem_alloc_pool(&req->pool, h2o_req_overrides_t, 1);
+
+      *overrides = (h2o_req_overrides_t){NULL};
+
+      overrides->use_proxy_protocol = false;
+      overrides->proxy_preserve_host = proxy.preserve_host;
+      overrides->forward_close_connection = true;
+      overrides->upstream =
+          (h2o_url_t *)h2o_mem_alloc_pool(&req->pool, sizeof(*overrides->upstream), 1);
+
+      h2o_url_parse(proxy.url, strlen(proxy.url), overrides->upstream);
+
+      prepare_req_for_reprocess(req);
+
+      h2o_reprocess_request(req, req->method, overrides->upstream->scheme,
+                            overrides->upstream->authority, overrides->upstream->path, overrides,
+                            0);
+      break;
+    }
     }
   done:
     pthread_mutex_unlock(&reqmsg->mutex);
@@ -214,6 +281,8 @@ int event_loop_req_handler(h2o_handler_t *self, h2o_req_t *req) {
     overrides->use_proxy_protocol = false;
     overrides->proxy_preserve_host = true;
     overrides->forward_close_connection = true;
+
+    prepare_req_for_reprocess(req);
 
     // request reprocess (note: path may become an empty string, to which one of the target URL
     // within the socketpool will be right-padded when lib/core/proxy connects to upstream; see

--- a/extensions/omni_httpd/event_loop.h
+++ b/extensions/omni_httpd/event_loop.h
@@ -113,4 +113,12 @@ void h2o_queue_send_inline(request_message_t *msg, const char *body, size_t len)
  */
 void h2o_queue_abort(request_message_t *msg);
 
+/**
+ * Request aborting the connection
+ * @param msg request message
+ * @param url target URL
+ * @param preserve_host whether Host header should be preserved
+ */
+void h2o_queue_proxy(request_message_t *msg, char *url, bool preserve_host);
+
 #endif // OMNI_HTTPD_EVENT_LOOP_H

--- a/extensions/omni_httpd/event_loop.h
+++ b/extensions/omni_httpd/event_loop.h
@@ -107,4 +107,10 @@ int event_loop_req_handler(h2o_handler_t *self, h2o_req_t *req);
  */
 void h2o_queue_send_inline(request_message_t *msg, const char *body, size_t len);
 
+/**
+ * Request aborting the connection
+ * @param msg request message
+ */
+void h2o_queue_abort(request_message_t *msg);
+
 #endif // OMNI_HTTPD_EVENT_LOOP_H

--- a/extensions/omni_httpd/expected/http.out
+++ b/extensions/omni_httpd/expected/http.out
@@ -29,6 +29,10 @@ with
                  ('echo',
                   $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$,
                   1),
+                 -- proxy proxies to /
+                 ('proxy',
+                  $$select omni_httpd.http_proxy('http://127.0.0.1:9000/') from request where request.path = '/proxy'$$,
+                  1),
                  -- This validates that `request CTE` can be casted to http_request
                  ('http_request',
                   $$SELECT omni_httpd.http_response(body => request.*::omni_httpd.http_request::text) FROM request WHERE request.path = '/http_request'$$,
@@ -70,7 +74,10 @@ Content-Type: text/html
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/abort
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/headers
-{"(user-agent,test-agent,t)","(accept,*/*,t)"}-- Try changing configuration
+{"(user-agent,test-agent,t)","(accept,*/*,t)"}\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/proxy
+{"method" : "GET", "path" : "/", "query_string" : null}\! echo
+
+-- Try changing configuration
 begin;
 update omni_httpd.listeners
 set

--- a/extensions/omni_httpd/expected/http.out
+++ b/extensions/omni_httpd/expected/http.out
@@ -22,6 +22,7 @@ with
        FROM request
        INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
       $$, 1),
+                 ('abort', $$select omni_httpd.abort() from request where request.path = '/abort'$$, 1),
                  ('headers',
                   $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$,
                   1),
@@ -67,6 +68,7 @@ Hello, <b>John</b>!
 200
 Content-Type: text/html
 
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/abort
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/headers
 {"(user-agent,test-agent,t)","(accept,*/*,t)"}-- Try changing configuration
 begin;

--- a/extensions/omni_httpd/expected/http_response.out
+++ b/extensions/omni_httpd/expected/http_response.out
@@ -1,115 +1,115 @@
 -- NULL status
 select omni_httpd.http_response(status => null, body => 'test');
-                                 http_response                                  
---------------------------------------------------------------------------------
- ("\\x74657374",200,"{""(content-type,\\""text/plain; charset=utf-8\\"",f)""}")
+                                              http_response                                               
+----------------------------------------------------------------------------------------------------------
+ omni_httpd.http_response(("\\x74657374",200,"{""(content-type,\\""text/plain; charset=utf-8\\"",f)""}"))
 (1 row)
 
 -- NULL headers
 select omni_httpd.http_response(headers => null, body => 'test');
-                                 http_response                                  
---------------------------------------------------------------------------------
- ("\\x74657374",200,"{""(content-type,\\""text/plain; charset=utf-8\\"",f)""}")
+                                              http_response                                               
+----------------------------------------------------------------------------------------------------------
+ omni_httpd.http_response(("\\x74657374",200,"{""(content-type,\\""text/plain; charset=utf-8\\"",f)""}"))
 (1 row)
 
 -- NULL body
 select omni_httpd.http_response(body => null);
- http_response 
----------------
- (,200,)
+           http_response           
+-----------------------------------
+ omni_httpd.http_response((,200,))
 (1 row)
 
 select omni_httpd.http_response();
- http_response 
----------------
- (,200,)
+           http_response           
+-----------------------------------
+ omni_httpd.http_response((,200,))
 (1 row)
 
 -- Text body
 select omni_httpd.http_response(body => 'text');
-                                 http_response                                  
---------------------------------------------------------------------------------
- ("\\x74657874",200,"{""(content-type,\\""text/plain; charset=utf-8\\"",f)""}")
+                                              http_response                                               
+----------------------------------------------------------------------------------------------------------
+ omni_httpd.http_response(("\\x74657874",200,"{""(content-type,\\""text/plain; charset=utf-8\\"",f)""}"))
 (1 row)
 
 -- JSON body
 select omni_httpd.http_response(body => '{}'::json);
-                   http_response                    
-----------------------------------------------------
- ("\\x7b7d",200,"{""(content-type,text/json,f)""}")
+                                http_response                                 
+------------------------------------------------------------------------------
+ omni_httpd.http_response(("\\x7b7d",200,"{""(content-type,text/json,f)""}"))
 (1 row)
 
 -- JSONB body
 select omni_httpd.http_response(body => '{}'::jsonb);
-                   http_response                    
-----------------------------------------------------
- ("\\x7b7d",200,"{""(content-type,text/json,f)""}")
+                                http_response                                 
+------------------------------------------------------------------------------
+ omni_httpd.http_response(("\\x7b7d",200,"{""(content-type,text/json,f)""}"))
 (1 row)
 
 -- Binary body
 select omni_httpd.http_response(body => convert_to('binary', 'UTF8'));
-                               http_response                               
----------------------------------------------------------------------------
- ("\\x62696e617279",200,"{""(content-type,application/octet-stream,f)""}")
+                                            http_response                                            
+-----------------------------------------------------------------------------------------------------
+ omni_httpd.http_response(("\\x62696e617279",200,"{""(content-type,application/octet-stream,f)""}"))
 (1 row)
 
 -- Specifying status
 select omni_httpd.http_response(status => 404);
- http_response 
----------------
- (,404,)
+           http_response           
+-----------------------------------
+ omni_httpd.http_response((,404,))
 (1 row)
 
 -- Specifying headers
 select
     omni_httpd.http_response(headers => array [omni_httpd.http_header('test', 'value')]::omni_httpd.http_header[],
                              body => null);
-         http_response         
--------------------------------
- (,200,"{""(test,value,f)""}")
+                      http_response                      
+---------------------------------------------------------
+ omni_httpd.http_response((,200,"{""(test,value,f)""}"))
 (1 row)
 
 -- Merging headers with inferred ones
 select
     omni_httpd.http_response(headers => array [omni_httpd.http_header('test', 'value')]::omni_httpd.http_header[],
                              body => 'test');
-                                           http_response                                           
----------------------------------------------------------------------------------------------------
- ("\\x74657374",200,"{""(test,value,f)"",""(content-type,\\""text/plain; charset=utf-8\\"",f)""}")
+                                                        http_response                                                        
+-----------------------------------------------------------------------------------------------------------------------------
+ omni_httpd.http_response(("\\x74657374",200,"{""(test,value,f)"",""(content-type,\\""text/plain; charset=utf-8\\"",f)""}"))
 (1 row)
 
 -- Overriding content type
 select
     omni_httpd.http_response(headers => array [omni_httpd.http_header('content-type', 'text/html')], body => 'test');
-                     http_response                      
---------------------------------------------------------
- ("\\x74657374",200,"{""(content-type,text/html,f)""}")
+                                  http_response                                   
+----------------------------------------------------------------------------------
+ omni_httpd.http_response(("\\x74657374",200,"{""(content-type,text/html,f)""}"))
 (1 row)
 
 -- Overriding content type, with a different case
 select
     omni_httpd.http_response(headers => array [omni_httpd.http_header('Content-Type', 'text/html')], body => 'test');
-                     http_response                      
---------------------------------------------------------
- ("\\x74657374",200,"{""(Content-Type,text/html,f)""}")
+                                  http_response                                   
+----------------------------------------------------------------------------------
+ omni_httpd.http_response(("\\x74657374",200,"{""(Content-Type,text/html,f)""}"))
 (1 row)
 
 --- Shortcut syntax with body first
 select omni_httpd.http_response('test');
-                                 http_response                                  
---------------------------------------------------------------------------------
- ("\\x74657374",200,"{""(content-type,\\""text/plain; charset=utf-8\\"",f)""}")
+                                              http_response                                               
+----------------------------------------------------------------------------------------------------------
+ omni_httpd.http_response(("\\x74657374",200,"{""(content-type,\\""text/plain; charset=utf-8\\"",f)""}"))
 (1 row)
 
 select omni_httpd.http_response('"test"'::json);
-                       http_response                        
-------------------------------------------------------------
- ("\\x227465737422",200,"{""(content-type,text/json,f)""}")
+                                    http_response                                     
+--------------------------------------------------------------------------------------
+ omni_httpd.http_response(("\\x227465737422",200,"{""(content-type,text/json,f)""}"))
 (1 row)
 
 select omni_httpd.http_response('"test"'::jsonb);
-                       http_response                        
-------------------------------------------------------------
- ("\\x227465737422",200,"{""(content-type,text/json,f)""}")
+                                    http_response                                     
+--------------------------------------------------------------------------------------
+ omni_httpd.http_response(("\\x227465737422",200,"{""(content-type,text/json,f)""}"))
 (1 row)
 

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -48,6 +48,7 @@
 
 #include <libpgaug.h>
 #include <omni_sql.h>
+#include <sum_type.h>
 
 #include <dynpgext.h>
 
@@ -665,74 +666,86 @@ static int handler(request_message_t *msg) {
 
     int c = 1;
     for (int i = 0; i < tupdesc->natts; i++) {
-      if (http_response_oid() == tupdesc->attrs[i].atttypid) {
+      if (http_outcome_oid() == tupdesc->attrs[i].atttypid) {
         c = i + 1;
         break; // TODO: continue but issue a warning if another response is found?
       }
     }
 
     bool isnull = false;
-    Datum response = SPI_getbinval(tuple, tupdesc, c, &isnull);
+    Datum outcome = SPI_getbinval(tuple, tupdesc, c, &isnull);
     if (!isnull) {
-      HeapTupleHeader response_tuple = DatumGetHeapTupleHeader(response);
+      // We know that the outcome is a variable-length type
+      struct varlena *outcome_value = (struct varlena *)PG_DETOAST_DATUM_PACKED(outcome);
 
-      // Status
-      req->res.status =
-          DatumGetUInt16(GetAttributeByIndex(response_tuple, HTTP_RESPONSE_TUPLE_STATUS, &isnull));
-      if (isnull) {
-        req->res.status = 200;
-      }
+      VarSizeVariant *variant = (VarSizeVariant *)VARDATA_ANY(outcome_value);
 
-      // Headers
-      Datum array_datum = GetAttributeByIndex(response_tuple, HTTP_RESPONSE_TUPLE_HEADERS, &isnull);
-      if (!isnull) {
-        ArrayType *headers = DatumGetArrayTypeP(array_datum);
-        ArrayIterator iter = array_create_iterator(headers, 0, NULL);
-        Datum header;
-        while (array_iterate(iter, &header, &isnull)) {
-          if (!isnull) {
-            HeapTupleHeader header_tuple = DatumGetHeapTupleHeader(header);
-            Datum name = GetAttributeByNum(header_tuple, 1, &isnull);
+      switch (variant->discriminant) {
+      case HTTP_OUTCOME_RESPONSE: {
+        HeapTupleHeader response_tuple = (HeapTupleHeader)&variant->data;
+
+        // Status
+        req->res.status = DatumGetUInt16(
+            GetAttributeByIndex(response_tuple, HTTP_RESPONSE_TUPLE_STATUS, &isnull));
+        if (isnull) {
+          req->res.status = 200;
+        }
+
+        // Headers
+        Datum array_datum =
+            GetAttributeByIndex(response_tuple, HTTP_RESPONSE_TUPLE_HEADERS, &isnull);
+        if (!isnull) {
+          ArrayType *headers = DatumGetArrayTypeP(array_datum);
+          ArrayIterator iter = array_create_iterator(headers, 0, NULL);
+          Datum header;
+          while (array_iterate(iter, &header, &isnull)) {
             if (!isnull) {
-              text *name_text = DatumGetTextPP(name);
-              size_t name_len = VARSIZE_ANY_EXHDR(name_text);
-              char *name_cstring = h2o_mem_alloc_pool(&req->pool, char *, name_len + 1);
-              text_to_cstring_buffer(name_text, name_cstring, name_len + 1);
-              Datum value = GetAttributeByNum(header_tuple, 2, &isnull);
+              HeapTupleHeader header_tuple = DatumGetHeapTupleHeader(header);
+              Datum name = GetAttributeByNum(header_tuple, 1, &isnull);
               if (!isnull) {
-                text *value_text = DatumGetTextPP(value);
-                size_t value_len = VARSIZE_ANY_EXHDR(value_text);
-                char *value_cstring = h2o_mem_alloc_pool(&req->pool, char *, value_len + 1);
-                text_to_cstring_buffer(value_text, value_cstring, value_len + 1);
-                Datum append = GetAttributeByNum(header_tuple, 3, &isnull);
-                if (isnull || !DatumGetBool(append)) {
-                  h2o_set_header_by_str(&req->pool, &req->res.headers, name_cstring, name_len, 0,
-                                        value_cstring, value_len, true);
-                } else {
-                  h2o_add_header_by_str(&req->pool, &req->res.headers, name_cstring, name_len, 0,
-                                        NULL, value_cstring, value_len);
+                text *name_text = DatumGetTextPP(name);
+                size_t name_len = VARSIZE_ANY_EXHDR(name_text);
+                char *name_cstring = h2o_mem_alloc_pool(&req->pool, char *, name_len + 1);
+                text_to_cstring_buffer(name_text, name_cstring, name_len + 1);
+                Datum value = GetAttributeByNum(header_tuple, 2, &isnull);
+                if (!isnull) {
+                  text *value_text = DatumGetTextPP(value);
+                  size_t value_len = VARSIZE_ANY_EXHDR(value_text);
+                  char *value_cstring = h2o_mem_alloc_pool(&req->pool, char *, value_len + 1);
+                  text_to_cstring_buffer(value_text, value_cstring, value_len + 1);
+                  Datum append = GetAttributeByNum(header_tuple, 3, &isnull);
+                  if (isnull || !DatumGetBool(append)) {
+                    h2o_set_header_by_str(&req->pool, &req->res.headers, name_cstring, name_len, 0,
+                                          value_cstring, value_len, true);
+                  } else {
+                    h2o_add_header_by_str(&req->pool, &req->res.headers, name_cstring, name_len, 0,
+                                          NULL, value_cstring, value_len);
+                  }
                 }
               }
             }
           }
+          array_free_iterator(iter);
         }
-        array_free_iterator(iter);
+
+        Datum body = GetAttributeByIndex(response_tuple, HTTP_RESPONSE_TUPLE_BODY, &isnull);
+
+        if (!isnull) {
+          bytea *body_content = DatumGetByteaPP(body);
+          size_t body_len = VARSIZE_ANY_EXHDR(body_content);
+          char *body_cstring = h2o_mem_alloc_pool(&req->pool, char *, body_len + 1);
+          text_to_cstring_buffer(body_content, body_cstring, body_len + 1);
+          req->res.content_length = body_len;
+          h2o_queue_send_inline(msg, body_cstring, body_len);
+        } else {
+          h2o_queue_send_inline(msg, "", 0);
+        }
+        break;
       }
-
-      // Body
-      Datum body = GetAttributeByIndex(response_tuple, HTTP_RESPONSE_TUPLE_BODY, &isnull);
-
-      if (!isnull) {
-        bytea *body_content = DatumGetByteaPP(body);
-        size_t body_len = VARSIZE_ANY_EXHDR(body_content);
-        char *body_cstring = h2o_mem_alloc_pool(&req->pool, char *, body_len + 1);
-        text_to_cstring_buffer(body_content, body_cstring, body_len + 1);
-        req->res.content_length = body_len;
-        h2o_queue_send_inline(msg, body_cstring, body_len);
-      } else {
-        h2o_queue_send_inline(msg, "", 0);
+      case HTTP_OUTCOME_ABORT: {
+        h2o_queue_abort(msg);
       }
-
+      }
     } else {
       h2o_queue_send_inline(msg, "", 0);
     }

--- a/extensions/omni_httpd/http_worker.h
+++ b/extensions/omni_httpd/http_worker.h
@@ -142,4 +142,7 @@ static int handler(request_message_t *msg);
 
 static h2o_evloop_t *handler_event_loop;
 
+#define HTTP_OUTCOME_RESPONSE 0
+#define HTTP_OUTCOME_ABORT 1
+
 #endif // OMNIGRES_HTTP_WORKER_H

--- a/extensions/omni_httpd/http_worker.h
+++ b/extensions/omni_httpd/http_worker.h
@@ -144,5 +144,6 @@ static h2o_evloop_t *handler_event_loop;
 
 #define HTTP_OUTCOME_RESPONSE 0
 #define HTTP_OUTCOME_ABORT 1
+#define HTTP_OUTCOME_PROXY 2
 
 #endif // OMNIGRES_HTTP_WORKER_H

--- a/extensions/omni_httpd/mkdocs.yml
+++ b/extensions/omni_httpd/mkdocs.yml
@@ -4,3 +4,4 @@ nav:
   - Intro: 'intro.md'
   - Headers: 'headers.md'
   - Architecture: 'architecture.md'
+  - Reverse Proxy: 'reverse_proxy.md'

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -49,6 +49,7 @@ create type http_request as
     headers      http_headers
 );
 
+
 create type http_response as
 (
     body    bytea,
@@ -56,12 +57,21 @@ create type http_response as
     headers http_headers
 );
 
+create domain abort as omni_types.unit;
+
+select omni_types.sum_type('http_outcome', 'http_response', 'abort');
+
+create function abort() returns http_outcome as
+$$
+select omni_httpd.http_outcome_from_abort(omni_types.unit())
+$$ language sql;
+
 create function http_response(
     body anycompatible default null,
     status int default 200,
     headers http_headers default null
 )
-    returns http_response
+    returns http_outcome
 as
 'MODULE_PATHNAME',
 'http_response'
@@ -189,7 +199,7 @@ create aggregate cascading_query (name text, query text) (
     stype = internal
     );
 
-create function default_page(request http_request) returns setof http_response as
+create function default_page(request http_request) returns setof http_outcome as
 $$
 begin
     return query (with

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -36,6 +36,9 @@ static const char *OMNI_HTTPD_CONFIGURATION_RELOAD_SEMAPHORE =
 #define HTTP_RESPONSE_TUPLE_STATUS 1
 #define HTTP_RESPONSE_TUPLE_HEADERS 2
 
+#define HTTP_PROXY_TUPLE_URL 0
+#define HTTP_PROXY_TUPLE_PRESERVE_HOST 1
+
 /**
  * Indicates whether this process is `master_worker`
  */

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -14,6 +14,9 @@
 
 Oid http_method_oid();
 Oid http_response_oid();
+
+Oid http_outcome_oid();
+
 Oid http_header_oid();
 
 Oid http_header_array_oid();

--- a/extensions/omni_httpd/sql/http.sql
+++ b/extensions/omni_httpd/sql/http.sql
@@ -31,6 +31,10 @@ with
                  ('echo',
                   $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$,
                   1),
+                 -- proxy proxies to /
+                 ('proxy',
+                  $$select omni_httpd.http_proxy('http://127.0.0.1:9000/') from request where request.path = '/proxy'$$,
+                  1),
                  -- This validates that `request CTE` can be casted to http_request
                  ('http_request',
                   $$SELECT omni_httpd.http_response(body => request.*::omni_httpd.http_request::text) FROM request WHERE request.path = '/http_request'$$,
@@ -68,6 +72,10 @@ call omni_httpd.wait_for_configuration_reloads(1);
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/abort
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/headers
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/proxy
+
+\! echo
 
 -- Try changing configuration
 

--- a/extensions/omni_httpd/sql/http.sql
+++ b/extensions/omni_httpd/sql/http.sql
@@ -24,6 +24,7 @@ with
        FROM request
        INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
       $$, 1),
+                 ('abort', $$select omni_httpd.abort() from request where request.path = '/abort'$$, 1),
                  ('headers',
                   $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$,
                   1),
@@ -63,6 +64,8 @@ call omni_httpd.wait_for_configuration_reloads(1);
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' -d 'hello world' http://localhost:9000/echo
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -w '\n%{response_code}\nContent-Type: %header{content-type}\n\n' http://localhost:9000/users/johndoe
+
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/abort
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent -A test-agent http://localhost:9000/headers
 

--- a/extensions/omni_types/CMakeLists.txt
+++ b/extensions/omni_types/CMakeLists.txt
@@ -16,6 +16,9 @@ add_postgresql_extension(
         SCHEMA omni_types
         RELOCATABLE false
         SCRIPTS omni_types--0.1.sql
-        SOURCES sum_type.c
-        REGRESS sum_type
+        SOURCES omni_types.c unit.c sum_type.c
+        REGRESS unit sum_type
 )
+
+add_library(libomnitypes INTERFACE)
+target_include_directories(libomnitypes INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/extensions/omni_types/expected/sum_type.out
+++ b/extensions/omni_types/expected/sum_type.out
@@ -861,15 +861,51 @@ ERROR:  Sum types can not contain duplicate variants
 CONTEXT:  PL/pgSQL function omni_types.sum_type_unique_variants_trigger_func() line 12 at RAISE
 SQL statement "update omni_types.sum_types set variants = array_append(variants, $1) where typ = $2"
 rollback;
--- Ensure no types are leaked
-\dT;
-     List of data types
- Schema | Name | Description 
---------+------+-------------
-(0 rows)
+-- Sum type with unit
+begin;
+create domain ok as omni_types.unit;
+create domain result as integer;
+select omni_types.sum_type('sum_type', 'ok', 'result');
+ sum_type 
+----------
+ sum_type
+(1 row)
+
+\dT
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | ok       | 
+ public | result   | 
+ public | sum_type | 
+(3 rows)
 
 :dump_types;
- typname | variants 
----------+----------
-(0 rows)
+ typname  |  variants   
+----------+-------------
+ sum_type | {ok,result}
+(1 row)
+
+select sum_type_from_ok(omni_types.unit());
+ sum_type_from_ok 
+------------------
+ ok()
+(1 row)
+
+end;
+-- Ensure no types are leaked
+\dT;
+       List of data types
+ Schema |   Name   | Description 
+--------+----------+-------------
+ public | ok       | 
+ public | result   | 
+ public | sum_type | 
+(3 rows)
+
+:dump_types;
+ typname  |  variants   
+----------+-------------
+ sum_type | {ok,result}
+(1 row)
 

--- a/extensions/omni_types/expected/unit.out
+++ b/extensions/omni_types/expected/unit.out
@@ -1,0 +1,32 @@
+select omni_types.unit();
+ unit 
+------
+ 
+(1 row)
+
+select pg_column_size(omni_types.unit());
+ pg_column_size 
+----------------
+              1
+(1 row)
+
+-- in/out
+select ''::omni_types.unit;
+ unit 
+------
+ 
+(1 row)
+
+select ''::omni_types.unit::text;
+ text 
+------
+ 
+(1 row)
+
+-- binary send/recv
+select omni_types.unit_send(omni_types.unit());
+ unit_send 
+-----------
+ \x
+(1 row)
+

--- a/extensions/omni_types/omni_types--0.1.sql
+++ b/extensions/omni_types/omni_types--0.1.sql
@@ -1,3 +1,38 @@
+create type unit;
+
+create function unit_in(cstring) returns unit
+as
+'MODULE_PATHNAME' language c immutable;
+
+create function unit_out(unit) returns cstring
+as
+'MODULE_PATHNAME' language c immutable;
+
+create function unit_recv(internal) returns unit
+as
+'MODULE_PATHNAME' language c immutable;
+
+create function unit_send(unit) returns bytea
+as
+'MODULE_PATHNAME' language c immutable;
+
+
+create type unit
+(
+    input = unit_in,
+    output = unit_out,
+    send = unit_send,
+    receive = unit_recv,
+    internallength = 1,
+    alignment = char,
+    storage = plain,
+    passedbyvalue
+);
+
+create function unit() returns unit
+as
+'MODULE_PATHNAME' language c immutable;
+
 create table sum_types
 (
     typ      regtype primary key unique,

--- a/extensions/omni_types/omni_types.c
+++ b/extensions/omni_types/omni_types.c
@@ -1,0 +1,11 @@
+/**
+ * @file omni_types.c
+ *
+ */
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
+PG_MODULE_MAGIC;

--- a/extensions/omni_types/sql/sum_type.sql
+++ b/extensions/omni_types/sql/sum_type.sql
@@ -304,6 +304,16 @@ select omni_types.add_variant('sum_type', 'int4');
 
 rollback;
 
+-- Sum type with unit
+begin;
+create domain ok as omni_types.unit;
+create domain result as integer;
+select omni_types.sum_type('sum_type', 'ok', 'result');
+\dT
+:dump_types;
+
+select sum_type_from_ok(omni_types.unit());
+end;
 
 -- Ensure no types are leaked
 \dT;

--- a/extensions/omni_types/sql/unit.sql
+++ b/extensions/omni_types/sql/unit.sql
@@ -1,0 +1,10 @@
+select omni_types.unit();
+
+select pg_column_size(omni_types.unit());
+
+-- in/out
+select ''::omni_types.unit;
+select ''::omni_types.unit::text;
+
+-- binary send/recv
+select omni_types.unit_send(omni_types.unit());

--- a/extensions/omni_types/sum_type.h
+++ b/extensions/omni_types/sum_type.h
@@ -1,0 +1,35 @@
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
+typedef int32 Discriminant;
+// This is to basically ensure a theoretical limit of types can be covered by the discriminant
+// (although it is generally excessive)
+StaticAssertDecl(sizeof(uint32_t) <= sizeof(Oid),
+                 "discriminant size should not be able to cover more than there can be types");
+StaticAssertDecl(sizeof(uint32_t) == sizeof(Oid), "discriminant size should match that of Oid");
+
+/**
+ * Fixed-size type layout
+ */
+typedef struct {
+  Discriminant discriminant;
+  char data[FLEXIBLE_ARRAY_MEMBER];
+} FixedSizeVariant;
+
+/**
+ * Variable-size type layout
+ */
+typedef struct {
+  Discriminant discriminant;
+  /**
+   * @note If the variant iself is a `varlena`, `data` will embed that `varlena` in its entirety
+   * to make it easier to work with (no need to create a new varlena with the reduced size).
+   * It increases the size of the overall structure by the size of  the `varlena` header.
+   */
+  struct varlena data;
+} VarSizeVariant;
+
+StaticAssertDecl(offsetof(VarSizeVariant, discriminant) == offsetof(FixedSizeVariant, discriminant),
+                 "discriminant offset should be equal");

--- a/extensions/omni_types/unit.c
+++ b/extensions/omni_types/unit.c
@@ -1,0 +1,92 @@
+/**
+ * @file unit.c
+ *
+ */
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+#include <access/heapam.h>
+#include <access/htup_details.h>
+#include <access/table.h>
+#include <catalog/namespace.h>
+#include <catalog/pg_cast.h>
+#include <catalog/pg_collation.h>
+#include <catalog/pg_language.h>
+#include <catalog/pg_proc.h>
+#include <catalog/pg_type.h>
+#include <commands/typecmds.h>
+#include <executor/spi.h>
+#include <miscadmin.h>
+#include <utils/array.h>
+#include <utils/builtins.h>
+#include <utils/fmgroids.h>
+#include <utils/lsyscache.h>
+#include <utils/syscache.h>
+
+/**
+ * Converts cstring into a unit type
+ * @param fcinfo
+ * @return
+ */
+PG_FUNCTION_INFO_V1(unit_in);
+/**
+ * Converts unit type to a cstring
+ * @param fcinfo
+ * @return
+ */
+PG_FUNCTION_INFO_V1(unit_out);
+
+/**
+ * Converts internal into a unit type
+ * @param fcinfo
+ * @return
+ */
+PG_FUNCTION_INFO_V1(unit_recv);
+/**
+ * Converts unit type to a byte array
+ * @param fcinfo
+ * @return
+ */
+PG_FUNCTION_INFO_V1(unit_send);
+
+/**
+ * Makes unit type
+ * @param fcinfo
+ * @return
+ */
+PG_FUNCTION_INFO_V1(unit);
+
+Datum unit_in(PG_FUNCTION_ARGS) {
+  if (PG_ARGISNULL(0)) {
+    PG_RETURN_NULL();
+  }
+  PG_RETURN_CHAR(0);
+}
+
+Datum unit_out(PG_FUNCTION_ARGS) {
+  if (PG_ARGISNULL(0)) {
+    PG_RETURN_NULL();
+  }
+  PG_RETURN_CSTRING("");
+}
+
+Datum unit_recv(PG_FUNCTION_ARGS) {
+  if (PG_ARGISNULL(0)) {
+    PG_RETURN_NULL();
+  }
+  PG_RETURN_CHAR(0);
+}
+
+Datum unit_send(PG_FUNCTION_ARGS) {
+  if (PG_ARGISNULL(0)) {
+    PG_RETURN_NULL();
+  }
+  static varattrib_1b bytearr = {
+      .va_header = 1 << 1 | 0x01 // 0
+  };
+  PG_RETURN_POINTER(&bytearr);
+}
+
+Datum unit(PG_FUNCTION_ARGS) { PG_RETURN_CHAR(0); }

--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -40,6 +40,7 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
+  - tables
 
 plugins:
   - search


### PR DESCRIPTION
There's currently no way to do anything else like proxying a connection,
upgrading to WebSockets, etc.

Solution: use omni_types to make http_outcome sum type

There are now few outcomes: http_response, abort and http_proxy.
    
This also adds `omni_types.unit` to be used as a unit variant.
    
