### PR TITLE
Problem: unsure if omni_httpd handlers can escalate privileges

### DIFF
--- a/extensions/omni_httpd/docs/security.md
+++ b/extensions/omni_httpd/docs/security.md
@@ -1,0 +1,29 @@
+# Security
+
+
+!!! warning "HTTP server hardening"
+
+    At this moment, this extension does not provide any additional
+    hardening for the HTTP server functionality to prevent any unintended
+    interaction between the server and the database outside of strict confines
+    of the message passing approach used for their intended way of communication.
+
+    We are eager to add support for such hardening (perhaps as an opt-in if it 
+    significantly decreases performance). Please consider
+    [contributing](https://github.com/omnigres/omnigres/pulls).
+    
+
+
+## Handler Queries
+
+The security model behind handler query execution relies on the
+`role_name` column in the `handlers` table. It can be set only
+to the role that is "accessible" to the current user (meaning either
+it is the same role or the current user can set this role given its
+permissions.)
+
+Each request will be executed with this role as a _security
+restricted mode that disallows `SET ROLE`_ (`SECURITY_LOCAL_USERID_CHANGE`)[^unless-superuser],
+prevent the code to elevate its privileges.
+
+[^unless-superuser]: unless this role is a superuser itself

--- a/extensions/omni_httpd/expected/role_name.out
+++ b/extensions/omni_httpd/expected/role_name.out
@@ -1,13 +1,75 @@
 create role test_user inherit in role current_user;
 create role test_user1 inherit in role current_user;
-create role anotherrole nosuperuser;
+create role anotherrole inherit in role current_user;
+alter role anotherrole nosuperuser;
+create role another_superuser superuser;
 set role test_user;
+create function reset_role() returns omni_httpd.http_outcome
+as
+$$
+declare
+    outcome omni_httpd.http_outcome;
+begin
+    begin
+        reset role;
+        select omni_httpd.http_response('ok') into outcome;
+    exception
+        when others then
+            select omni_httpd.http_response('failed resetting') into outcome;
+    end;
+    return outcome;
+end;
+$$ language plpgsql;
+create function set_role_none() returns omni_httpd.http_outcome
+as
+$$
+declare
+    outcome omni_httpd.http_outcome;
+begin
+    begin
+        set role none;
+        select omni_httpd.http_response('ok') into outcome;
+    exception
+        when others then
+            select omni_httpd.http_response('failed setting to none') into outcome;
+    end;
+    return outcome;
+end;
+$$ language plpgsql;
+create function set_superuser_role() returns omni_httpd.http_outcome
+as
+$$
+declare
+    outcome omni_httpd.http_outcome;
+begin
+    begin
+        set role another_superuser;
+        select omni_httpd.http_response('ok') into outcome;
+    exception
+        when others then
+            select omni_httpd.http_response('failed setting superuser role') into outcome;
+    end;
+    return outcome;
+end;
+$$ language plpgsql;
 -- Should use current_user as a default role_name
 begin;
 with
     listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 9003) returning id),
-    handler as (insert into omni_httpd.handlers (query) values
-                                                            ($$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$) returning id)
+    handler as (insert into omni_httpd.handlers (query)
+        values
+            ($$select
+                     (case
+                       when request.path = '/' then
+                         omni_httpd.http_response(body => current_user::text)
+                       when request.path = '/reset-role' then
+                         reset_role()
+                       when request.path = '/set-role-none' then
+                         set_role_none()
+                       when request.path = '/superuser-role' then
+                         set_superuser_role()
+                      end)
+                    from request$$) returning id)
 insert
 into
     omni_httpd.listeners_handlers (listener_id, handler_id)
@@ -30,7 +92,9 @@ set
 where
     role_name = 'test_user';
 ERROR:  new row for relation "handlers" violates check constraint "handlers_role_name_check"
-DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., some_role).
+DETAIL:  Failing row contains (3, select
+                     (case
+                       when re..., some_role).
 delete
 from
     omni_httpd.configuration_reloads;
@@ -86,7 +150,78 @@ set
 where
     role_name = 'test_user1';
 ERROR:  new row for relation "handlers" violates check constraint "handlers_role_name_check"
-DETAIL:  Failing row contains (3, SELECT omni_httpd.http_response(body => current_user::text) FROM..., anotherrole).
+DETAIL:  Failing row contains (3, select
+                     (case
+                       when re..., anotherrole).
 rollback;
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/
-test_user1
+test_user1begin;
+reset role;
+update omni_httpd.handlers
+set
+    role_name = 'anotherrole'
+where
+    role_name = 'test_user1';
+delete
+from
+    omni_httpd.configuration_reloads;
+commit;
+call omni_httpd.wait_for_configuration_reloads(1);
+-- Ensure this role is not a superuser
+select
+    rolsuper
+from
+    pg_roles
+where
+    rolname = 'anotherrole';
+ rolsuper 
+----------
+ f
+(1 row)
+
+-- Check current role
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/
+anotherrole\! echo
+
+--- Ensure it's not possible to reset session to superuser
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/reset-role
+failed resetting\! echo
+
+--- Ensure it's not possible to set session to superuser
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/superuser-role
+failed setting superuser role\! echo
+
+--- Ensure it's not possible to set session to none
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/set-role-none
+failed setting to none\! echo
+
+-- Ensure that administrator can reset
+alter role anotherrole superuser;
+begin;
+delete
+from
+    omni_httpd.configuration_reloads;
+select omni_httpd.reload_configuration();
+ reload_configuration 
+----------------------
+ t
+(1 row)
+
+commit;
+call omni_httpd.wait_for_configuration_reloads(1);
+-- Check current role
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/
+anotherrole\! echo
+
+--- Ensure it's now possible to reset session to superuser
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/reset-role
+ok\! echo
+
+--- Ensure it's now possible to set session to superuser
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/superuser-role
+ok\! echo
+
+--- Ensure it's now possible to set session to none
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/set-role-none
+ok\! echo
+

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -599,7 +599,7 @@ static int handler(request_message_t *msg) {
   if (CurrentHandlerUser != lctx->role_id) {
     CurrentHandlerUser = lctx->role_id;
     SetUserIdAndSecContext(CurrentHandlerUser,
-                           lctx->role_is_superuser ? 0 : SECURITY_RESTRICTED_OPERATION);
+                           lctx->role_is_superuser ? 0 : SECURITY_LOCAL_USERID_CHANGE);
   }
 
   // Execute listener's query

--- a/extensions/omni_httpd/http_worker.h
+++ b/extensions/omni_httpd/http_worker.h
@@ -35,7 +35,7 @@ typedef struct st_listener_ctx {
   /**
    * @brief Is role a superuser?
    */
-  bool role_supervisor;
+  bool role_is_superuser;
   /**
    * @brief Associated socket
    *

--- a/extensions/omni_httpd/mkdocs.yml
+++ b/extensions/omni_httpd/mkdocs.yml
@@ -4,4 +4,5 @@ nav:
   - Intro: 'intro.md'
   - Headers: 'headers.md'
   - Architecture: 'architecture.md'
+  - Security: 'security.md'
   - Reverse Proxy: 'reverse_proxy.md'

--- a/extensions/omni_httpd/sql/role_name.sql
+++ b/extensions/omni_httpd/sql/role_name.sql
@@ -1,15 +1,84 @@
 create role test_user inherit in role current_user;
 create role test_user1 inherit in role current_user;
-create role anotherrole nosuperuser;
+
+create role anotherrole inherit in role current_user;
+alter role anotherrole nosuperuser;
+
+create role another_superuser superuser;
 
 set role test_user;
+
+create function reset_role() returns omni_httpd.http_outcome
+as
+$$
+declare
+    outcome omni_httpd.http_outcome;
+begin
+    begin
+        reset role;
+        select omni_httpd.http_response('ok') into outcome;
+    exception
+        when others then
+            select omni_httpd.http_response('failed resetting') into outcome;
+    end;
+    return outcome;
+end;
+$$ language plpgsql;
+
+create function set_role_none() returns omni_httpd.http_outcome
+as
+$$
+declare
+    outcome omni_httpd.http_outcome;
+begin
+    begin
+        set role none;
+        select omni_httpd.http_response('ok') into outcome;
+    exception
+        when others then
+            select omni_httpd.http_response('failed setting to none') into outcome;
+    end;
+    return outcome;
+end;
+$$ language plpgsql;
+
+
+create function set_superuser_role() returns omni_httpd.http_outcome
+as
+$$
+declare
+    outcome omni_httpd.http_outcome;
+begin
+    begin
+        set role another_superuser;
+        select omni_httpd.http_response('ok') into outcome;
+    exception
+        when others then
+            select omni_httpd.http_response('failed setting superuser role') into outcome;
+    end;
+    return outcome;
+end;
+$$ language plpgsql;
+
 
 -- Should use current_user as a default role_name
 begin;
 with
     listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 9003) returning id),
-    handler as (insert into omni_httpd.handlers (query) values
-                                                            ($$SELECT omni_httpd.http_response(body => current_user::text) FROM request$$) returning id)
+    handler as (insert into omni_httpd.handlers (query)
+        values
+            ($$select
+                     (case
+                       when request.path = '/' then
+                         omni_httpd.http_response(body => current_user::text)
+                       when request.path = '/reset-role' then
+                         reset_role()
+                       when request.path = '/set-role-none' then
+                         set_role_none()
+                       when request.path = '/superuser-role' then
+                         set_superuser_role()
+                      end)
+                    from request$$) returning id)
 insert
 into
     omni_httpd.listeners_handlers (listener_id, handler_id)
@@ -88,3 +157,70 @@ where
 rollback;
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/
+
+
+begin;
+reset role;
+update omni_httpd.handlers
+set
+    role_name = 'anotherrole'
+where
+    role_name = 'test_user1';
+
+delete
+from
+    omni_httpd.configuration_reloads;
+
+commit;
+call omni_httpd.wait_for_configuration_reloads(1);
+
+-- Ensure this role is not a superuser
+select
+    rolsuper
+from
+    pg_roles
+where
+    rolname = 'anotherrole';
+
+-- Check current role
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/
+\! echo
+
+--- Ensure it's not possible to reset session to superuser
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/reset-role
+\! echo
+
+--- Ensure it's not possible to set session to superuser
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/superuser-role
+\! echo
+
+--- Ensure it's not possible to set session to none
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/set-role-none
+\! echo
+
+-- Ensure that administrator can reset
+alter role anotherrole superuser;
+begin;
+delete
+from
+    omni_httpd.configuration_reloads;
+select omni_httpd.reload_configuration();
+commit;
+call omni_httpd.wait_for_configuration_reloads(1);
+
+
+-- Check current role
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/
+\! echo
+
+--- Ensure it's now possible to reset session to superuser
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/reset-role
+\! echo
+
+--- Ensure it's now possible to set session to superuser
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/superuser-role
+\! echo
+
+--- Ensure it's now possible to set session to none
+\! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/set-role-none
+\! echo


### PR DESCRIPTION
Solution: write a test case and fix it

Turns out, they can by setting role to NONE or resetting the role.

Fix it by using SECURITY_LOCAL_USERID_CHANGE unless the requested role is a supervisor.