### PR TITLE
Problem: using role_name in omni_httpd.handlers

### DIFF
--- a/extensions/omni_httpd/docs/security.md
+++ b/extensions/omni_httpd/docs/security.md
@@ -1,3 +1,5 @@
+<!-- @formatter:off -->
+
 # Security
 
 
@@ -17,7 +19,7 @@
 ## Handler Queries
 
 The security model behind handler query execution relies on the
-`role_name` column in the `handlers` table. It can be set only
+`role` column in the `handlers` table. It can be set only
 to the role that is "accessible" to the current user (meaning either
 it is the same role or the current user can set this role given its
 permissions.)

--- a/extensions/omni_httpd/expected/role_name.out
+++ b/extensions/omni_httpd/expected/role_name.out
@@ -52,7 +52,7 @@ begin
     return outcome;
 end;
 $$ language plpgsql;
--- Should use current_user as a default role_name
+-- Should use current_user as a default role
 begin;
 with
     listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 9003) returning id),
@@ -88,13 +88,12 @@ call omni_httpd.wait_for_configuration_reloads(1);
 begin;
 update omni_httpd.handlers
 set
-    role_name = 'some_role'
+    role = 'some_role'::regrole
 where
-    role_name = 'test_user';
-ERROR:  new row for relation "handlers" violates check constraint "handlers_role_name_check"
-DETAIL:  Failing row contains (3, select
-                     (case
-                       when re..., some_role).
+    role = 'test_user'::regrole;
+ERROR:  role "some_role" does not exist
+LINE 3:     role = 'some_role'::regrole
+                   ^
 delete
 from
     omni_httpd.configuration_reloads;
@@ -105,9 +104,9 @@ call omni_httpd.wait_for_configuration_reloads(1);
 begin;
 update omni_httpd.handlers
 set
-    role_name = 'test_user1'
+    role = 'test_user1'::regrole
 where
-    role_name = 'test_user';
+    role = 'test_user'::regrole;
 delete
 from
     omni_httpd.configuration_reloads;
@@ -118,9 +117,9 @@ set role test_user1;
 begin;
 update omni_httpd.handlers
 set
-    role_name = 'test_user1'
+    role = 'test_user1'::regrole
 where
-    role_name = 'test_user';
+    role = 'test_user'::regrole;
 delete
 from
     omni_httpd.configuration_reloads;
@@ -130,9 +129,9 @@ call omni_httpd.wait_for_configuration_reloads(1);
 begin;
 update omni_httpd.handlers
 set
-    role_name = 'anotherrole'
+    role = 'anotherrole'::regrole
 where
-    role_name = 'test_user1';
+    role = 'test_user1'::regrole;
 select current_user;
  current_user 
 --------------
@@ -146,10 +145,10 @@ reset role;
 alter role current_user nosuperuser;
 update omni_httpd.handlers
 set
-    role_name = 'anotherrole'
+    role = 'anotherrole'::regrole
 where
-    role_name = 'test_user1';
-ERROR:  new row for relation "handlers" violates check constraint "handlers_role_name_check"
+    role = 'test_user1'::regrole;
+ERROR:  new row for relation "handlers" violates check constraint "handlers_role_check"
 DETAIL:  Failing row contains (3, select
                      (case
                        when re..., anotherrole).
@@ -159,9 +158,9 @@ test_user1begin;
 reset role;
 update omni_httpd.handlers
 set
-    role_name = 'anotherrole'
+    role = 'anotherrole'::regrole
 where
-    role_name = 'test_user1';
+    role = 'test_user1'::regrole;
 delete
 from
     omni_httpd.configuration_reloads;

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -102,7 +102,7 @@ create table listeners
     protocol       http_protocol not null default 'http'
 );
 
-create function check_if_role_accessible_to_current_user(role name) returns boolean
+create function check_if_role_accessible_to_current_user(role regrole) returns boolean
 as
 $$
 declare
@@ -124,9 +124,9 @@ $$ language plpgsql;
 
 create table handlers
 (
-    id        integer primary key generated always as identity,
-    query     text not null,
-    role_name name not null default current_user check (check_if_role_accessible_to_current_user(role_name))
+    id    integer primary key generated always as identity,
+    query text    not null,
+    role  regrole not null default current_user::regrole check (check_if_role_accessible_to_current_user(role))
 );
 
 create function handlers_query_validity_trigger() returns trigger

--- a/extensions/omni_httpd/sql/role_name.sql
+++ b/extensions/omni_httpd/sql/role_name.sql
@@ -61,7 +61,7 @@ end;
 $$ language plpgsql;
 
 
--- Should use current_user as a default role_name
+-- Should use current_user as a default role
 begin;
 with
     listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 9003) returning id),
@@ -99,9 +99,9 @@ call omni_httpd.wait_for_configuration_reloads(1);
 begin;
 update omni_httpd.handlers
 set
-    role_name = 'some_role'
+    role = 'some_role'::regrole
 where
-    role_name = 'test_user';
+    role = 'test_user'::regrole;
 delete
 from
     omni_httpd.configuration_reloads;
@@ -112,9 +112,9 @@ call omni_httpd.wait_for_configuration_reloads(1);
 begin;
 update omni_httpd.handlers
 set
-    role_name = 'test_user1'
+    role = 'test_user1'::regrole
 where
-    role_name = 'test_user';
+    role = 'test_user'::regrole;
 delete
 from
     omni_httpd.configuration_reloads;
@@ -126,9 +126,9 @@ set role test_user1;
 begin;
 update omni_httpd.handlers
 set
-    role_name = 'test_user1'
+    role = 'test_user1'::regrole
 where
-    role_name = 'test_user';
+    role = 'test_user'::regrole;
 delete
 from
     omni_httpd.configuration_reloads;
@@ -139,9 +139,9 @@ call omni_httpd.wait_for_configuration_reloads(1);
 begin;
 update omni_httpd.handlers
 set
-    role_name = 'anotherrole'
+    role = 'anotherrole'::regrole
 where
-    role_name = 'test_user1';
+    role = 'test_user1'::regrole;
 select current_user;
 rollback;
 
@@ -151,9 +151,9 @@ reset role;
 alter role current_user nosuperuser;
 update omni_httpd.handlers
 set
-    role_name = 'anotherrole'
+    role = 'anotherrole'::regrole
 where
-    role_name = 'test_user1';
+    role = 'test_user1'::regrole;
 rollback;
 
 \! curl --retry-connrefused --retry 10  --retry-max-time 10 --silent http://localhost:9003/
@@ -163,9 +163,9 @@ begin;
 reset role;
 update omni_httpd.handlers
 set
-    role_name = 'anotherrole'
+    role = 'anotherrole'::regrole
 where
-    role_name = 'test_user1';
+    role = 'test_user1'::regrole;
 
 delete
 from


### PR DESCRIPTION
This refers to roles by name, which are resolved to OIDs during configuration reload.

This is potentially problematic as it means the role can be unavailable at the time of the configuration reload.

It can be fragile if something is to happen to the search path in the future.

Solution: make `role_name` become `role` of type `regrole`

It's not *substantially* better but it feels like it's more of the right thing to do.

This can enable us to use `pg_shdepend` to ensure we can't drop the roles that are used.