### PR TITLE
Problem: testing binary encoding of Postgres types

### DIFF
--- a/pg_yregress/CMakeLists.txt
+++ b/pg_yregress/CMakeLists.txt
@@ -16,7 +16,7 @@ CPMAddPackage(GITHUB_REPOSITORY "pantoniou/libfyaml" GIT_TAG "v0.8" EXCLUDE_FROM
 
 include(CTest)
 
-add_executable(pg_yregress pg_yregress.c instance.c test.c sighandler.c str.c)
+add_executable(pg_yregress pg_yregress.c instance.c test.c sighandler.c str.c yaml.c)
 target_link_libraries(pg_yregress PRIVATE fyaml pq)
 
 # Enable GNU extensions for `asprintf`, `nftw`, etc.

--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -167,3 +167,42 @@ tests:
     notices:
     - test 2
 ```
+
+## Binary format
+
+Sometimes there's a need to test binary encoding of types[^send-recv]. `pg_yregress`
+allows this to be done by manipulating the `binary` property of the `query` test.
+
+| Value | Description |
+|------|-------------|
+| `true` | Both `params` and `results` are binary |
+| `params` | `params` are binary |
+| `results` | `results` are binary |
+
+Binary encodings are done using hexadecimal notiation prefixed by `0x`.
+
+This will return results as binary:
+
+```yaml
+tests:
+- name: binary format
+  query: select true as value
+  binary: true
+  results:
+  - value: 0x01
+```
+
+And this will return results as characters but take parameters as binary:
+
+```yaml
+tests:
+- name: binary format for params
+  query: select $1::bool as value
+  binary: params
+  params:
+  - 0x01
+  results:
+  - value: t
+```
+
+[^send-recv]: The encoding that is used by `SEND` and `RECEIVE` functions of the type.

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -87,4 +87,9 @@ void register_sighandler();
 
 void trim_trailing_whitespace(char *str);
 
+// YAML
+bool fy_node_is_boolean(struct fy_node *node);
+
+bool fy_node_get_boolean(struct fy_node *node);
+
 #endif // PG_YREGRESS_H

--- a/pg_yregress/test.c
+++ b/pg_yregress/test.c
@@ -46,25 +46,77 @@ bool ytest_run_internal(PGconn *default_conn, ytest *test, bool in_transaction) 
 
     PGresult *result;
 
+    int result_format = 0;      // result format,  characters by default
+    bool binary_params = false; // parameter format, characters by default
+
+    struct fy_node *binary = fy_node_mapping_lookup_value_by_string(test->node, STRLIT("binary"));
+
+    if (binary != NULL) {
+      if (fy_node_is_boolean(binary) && fy_node_get_boolean(binary)) {
+        result_format = 1;
+        binary_params = true;
+      }
+      if (fy_node_compare_text(binary, STRLIT("results"))) {
+        result_format = 1;
+      } else if (fy_node_compare_text(binary, STRLIT("params"))) {
+        binary_params = true;
+      }
+    }
+
     struct fy_node *params = fy_node_mapping_lookup_by_string(test->node, STRLIT("params"));
 
     if (params == NULL) {
-      result = PQexec(conn, query);
+      result = PQexecParams(conn, query, 0, NULL, (const char **)NULL, NULL, NULL, result_format);
     } else if (fy_node_is_sequence(params)) {
       int nparams = fy_node_sequence_item_count(params);
       const char **values = calloc(nparams, sizeof(char *));
+      int *param_formats = calloc(nparams, sizeof(int));
+      int *param_length = calloc(nparams, sizeof(int));
       for (int i = 0; i < nparams; i++) {
+        param_formats[i] = binary_params ? 1 : 0;
         struct fy_node *param_node = fy_node_sequence_get_by_index(params, i);
         switch (fy_node_get_type(param_node)) {
-        case FYNT_SCALAR:
-          values[i] = fy_node_get_scalar(param_node, NULL);
+        case FYNT_SCALAR: {
+          size_t len;
+          values[i] = fy_node_get_scalar(param_node, &len);
+          if (binary_params) {
+            if (strncasecmp(values[i], "0x", 2) == 0) {
+              size_t sz = (len - 2) / 2;
+              char *binary_encoded_value = malloc(sz);
+              for (size_t j = 0; j < len; j++) {
+                sscanf(values[i] + 2 + 2 * j, "%2hhx", &binary_encoded_value[j]);
+              }
+              values[i] = binary_encoded_value;
+              param_length[i] = sz;
+            } else {
+              // Use the supplied string as the source for binary
+              // if it is not a hex
+              param_length[i] = strlen(values[i]);
+              // This way we can free it, too
+              values[i] = strdup(values[i]);
+            }
+          } else {
+            // This way we can free it, too
+            values[i] = strdup(values[i]);
+          }
           break;
+        }
         default:
-          // FXIME: handle unsupported type
+          // FIXME: handle unsupported type
           break;
         }
       }
-      result = PQexecParams(conn, query, nparams, NULL, (const char **)values, NULL, NULL, 0);
+      result = PQexecParams(conn, query, nparams, NULL, (const char **)values, param_length,
+                            param_formats, result_format);
+
+      if (binary_params) {
+        // Free parsed values
+        for (int i = 0; i < nparams; i++) {
+          free((void *)values[i]);
+        }
+      }
+      free((void *)values);
+      free(param_formats);
     }
 
     ExecStatusType status = PQresultStatus(result);
@@ -129,8 +181,24 @@ bool ytest_run_internal(PGconn *default_conn, ytest *test, bool in_transaction) 
           for (int column = 0; column < ncolumns; column++) {
             char *str_value =
                 PQgetisnull(result, row, column) ? "null" : PQgetvalue(result, row, column);
-            struct fy_node *value =
-                fy_node_create_scalar(fy_node_document(test->node), STRLIT(str_value));
+            struct fy_node *value;
+            // If results are returned as binary
+            if (result_format == 1) {
+              // output hexadecimal representation
+              int len = PQgetlength(result, row, column);
+              int sz = /* 0x */ 2 + /* FF */ len * 2 + /* null */ 1;
+              char *hex = malloc(sz);
+              char *ptr = hex;
+              ptr += sprintf(ptr, "0x");
+              for (int i = 0; i < len; i++) {
+                ptr += sprintf(ptr, "%02x", str_value[i]);
+              }
+              // create a copy as we'll deallocate hex
+              value = fy_node_create_scalar_copy(fy_node_document(test->node), hex, sz - 1);
+              free(hex);
+            } else {
+              value = fy_node_create_scalar(fy_node_document(test->node), STRLIT(str_value));
+            }
 
             fy_node_mapping_append(row_map,
                                    fy_node_create_scalar(fy_node_document(test->node),

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -121,3 +121,42 @@ tests:
     - test 2
   # Ensure no notices get here
   notices: [ ]
+
+- name: binary format
+  query: select true as value
+  binary: true
+  results:
+  - value: 0x01
+
+- name: binary format
+  query: select $1::bool as value
+  binary: true
+  params:
+  - 0x01
+  results:
+  - value: 0x01
+
+- name: binary format for params
+  query: select $1::bool as value
+  binary: params
+  params:
+  - 0x01
+  results:
+  - value: t
+
+- name: binary format for results
+  query: select $1::bool as value
+  binary: results
+  params:
+  - true
+  results:
+  - value: 0x01
+
+- name: non-hexadecimal binary format for params
+  query: select $1::text as value
+  binary: params
+  params:
+  # This is supplied as a binary, but it's not hex
+  - hello
+  results:
+  - value: hello

--- a/pg_yregress/yaml.c
+++ b/pg_yregress/yaml.c
@@ -1,0 +1,33 @@
+#include <libfyaml.h>
+
+bool fy_node_is_boolean(struct fy_node *node) {
+  if (!fy_node_is_scalar(node)) {
+    return false;
+  }
+  size_t sz;
+  const char *val = fy_node_get_scalar(node, &sz);
+#define match(pat)                                                                                 \
+  if (strncmp(val, pat, sz) == 0) {                                                                \
+    return true;                                                                                   \
+  }
+  // clang-format off
+  match("y") else match("Y") else match("yes") else match("Yes") else match("YES") else
+  match("n") else match("N") else match("no") else match("No") else match("NO") else
+  match("true") else match("True") else match("TRUE") else
+  match("false") else match("False") else match("FALSE") else
+  match("on") else match("On") else match("ON") else
+  match("off") else match("Off") else match("OFF") else
+  return false;
+  // clang-format on
+#undef match
+}
+
+bool fy_node_get_boolean(struct fy_node *node) {
+  size_t sz;
+  const char *val = fy_node_get_scalar(node, &sz);
+#define match(pat) strncmp(val, pat, sz) == 0
+  return (match("y") || match("Y") || match("yes") || match("Yes") || match("YES") ||
+          match("true") || match("True") || match("TRUE") || match("on") || match("On") ||
+          match("ON"));
+#undef match
+}


### PR DESCRIPTION
This is problematic as both pg_regress text-based tests and current pg_yregress tests are not a great fit for these.

Solution: provide `binary` property that regulates the format