### PR TITLE
Problem: pg_yregress may not always terminate postgres

### DIFF
--- a/pg_yregress/pg_yregress.c
+++ b/pg_yregress/pg_yregress.c
@@ -255,9 +255,14 @@ static void get_path_from_popen(char *cmd, char *path) {
   }
 }
 
+pid_t pgid;
+
 int main(int argc, char **argv) {
 
   if (argc >= 2) {
+    // Get a process group
+    pgid = getpgrp();
+
     // Hanle signals for cleanup, etc.
     register_sighandler();
 

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -1,8 +1,15 @@
 #ifndef PG_YREGRESS_H
 #define PG_YREGRESS_H
 
+#include <unistd.h>
+
 #include <libfyaml.h>
 #include <libpq-fe.h>
+
+/**
+ * pg_yregress' process group
+ */
+extern pid_t pgid;
 
 typedef struct {
   const char *base;
@@ -30,6 +37,7 @@ typedef struct {
     } unmanaged;
   } info;
   PGconn *conn;
+  pid_t pid;
   struct fy_node *node;
 } yinstance;
 


### PR DESCRIPTION
This can happen in some abnormal termination scenarios.

Solution: link instances into the same process group as pg_yregress