### PR TITLE
Problem: specifying multiple pg_yregress instances

### DIFF
--- a/pg_yregress/instance.c
+++ b/pg_yregress/instance.c
@@ -21,6 +21,20 @@ default_yinstance_result default_instance(struct fy_node *instances, yinstance *
 
   default:
     // There are more than one instance to choose from
+    {
+      // Try to see if any is set as default
+      void *iter = NULL;
+
+      struct fy_node_pair *instance_pair;
+      while ((instance_pair = fy_node_mapping_iterate(instances, &iter)) != NULL) {
+        struct fy_node *instance_node = fy_node_pair_value(instance_pair);
+        yinstance *y_instance = (yinstance *)fy_node_get_meta(instance_node);
+        if (y_instance->is_default) {
+          *instance = y_instance;
+          return default_instance_found;
+        }
+      }
+    }
     return default_instance_ambiguous;
   }
 }

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -39,6 +39,7 @@ typedef struct {
   PGconn *conn;
   pid_t pid;
   struct fy_node *node;
+  bool is_default;
 } yinstance;
 
 typedef enum {

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -1,3 +1,7 @@
+instances:
+  main:
+    default: true
+  aux:
 tests:
 
 - name: simple query


### PR DESCRIPTION
If one is to be used often, it'll have to be specified in each test.

Solution: make it possible to declare an instance a default one