### PR TITLE
Problem: impossible to restart tested instance

### DIFF
--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -206,3 +206,25 @@ tests:
 ```
 
 [^send-recv]: The encoding that is used by `SEND` and `RECEIVE` functions of the type.
+
+## Configuring instances
+
+Tests may have one more instances they run on. By default, `pg_yregress` will provision one. However, if you want to configure the instance or add more than one, you can use
+`instances` configuration which is a mapping of names to the configuration dictionaries:
+
+```yaml
+instances:
+  default:
+    init:
+    # Executes a sequence of queries
+    - create extension my_extension
+    # One instance may be specified as default 
+    default: yes
+  other:
+    init:
+    - alter system set config_param = '...'
+    # Initialization may require restarting the instance
+    - restart: true
+```
+
+Each test will run on a default instance, unless `instance` property is specified and the name of the instance is referenced.

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -40,6 +40,7 @@ typedef struct {
   pid_t pid;
   struct fy_node *node;
   bool is_default;
+  int init_step;
 } yinstance;
 
 typedef enum {
@@ -50,7 +51,13 @@ typedef enum {
 
 void yinstance_start(yinstance *instance);
 
-PGconn *yinstance_connect(yinstance *instance);
+typedef enum {
+  yinstance_connect_success,
+  yinstance_connect_failure,
+  yinstance_connect_restart
+} yinstance_connect_result;
+
+yinstance_connect_result yinstance_connect(yinstance *instance);
 
 default_yinstance_result default_instance(struct fy_node *instances, yinstance **instance);
 

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -2,6 +2,11 @@ instances:
   main:
     default: true
   aux:
+    init:
+    # This will be tested
+    - alter system set shared_buffers = '193MB'
+    - restart:
+
 tests:
 
 - name: simple query
@@ -164,3 +169,9 @@ tests:
   - hello
   results:
   - value: hello
+
+- name: init restart
+  instance: aux
+  query: select current_setting('shared_buffers')
+  results:
+  - current_setting: 193MB


### PR DESCRIPTION
Sometimes this may be necessary, like changing some system parameters with SQL.

Solution: allow use of `restart` key in instance configuration