### PR TITLE
Problem: configuring pg_yregress instances requires a restart

### DIFF
--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -214,6 +214,14 @@ Tests may have one more instances they run on. By default, `pg_yregress` will pr
 
 ```yaml
 instances:
+  configured:
+    # Can be configured with a mapping
+    config:
+      log_connections: yes
+  configured_1:
+    # Can be configured with a string using `postgresql.conf` format
+    config: |
+      log_connections = yes
   default:
     init:
     # Executes a sequence of queries

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -1,11 +1,19 @@
 instances:
   main:
     default: true
-  aux:
+  restarted:
     init:
     # This will be tested
     - alter system set shared_buffers = '193MB'
     - restart:
+  configured_text:
+    config: |
+      shared_buffers = '194MB'
+      log_connections = yes
+  configured_mapping:
+    config:
+      shared_buffers: 195MB
+      log_connections: yes
 
 tests:
 
@@ -171,7 +179,25 @@ tests:
   - value: hello
 
 - name: init restart
-  instance: aux
+  instance: restarted
   query: select current_setting('shared_buffers')
   results:
   - current_setting: 193MB
+
+- name: configured (text)
+  instance: configured_text
+  query: |
+    select current_setting('shared_buffers') as shared_buffers,
+           current_setting('log_connections') as log_connections
+  results:
+  - shared_buffers: 194MB
+    log_connections: on
+
+- name: configured (mapping)
+  instance: configured_mapping
+  query: |
+    select current_setting('shared_buffers') as shared_buffers,
+           current_setting('log_connections') as log_connections
+  results:
+  - shared_buffers: 195MB
+    log_connections: on


### PR DESCRIPTION
Sometimes this is warranted (we want to execute some SQL before modifying the config), but oftentimes it is not.

Solution: allow passing configuration through `config` property