### PR TITLE
Problem: unable to pass configuration to the test suite

### DIFF
--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -236,3 +236,18 @@ instances:
 ```
 
 Each test will run on a default instance, unless `instance` property is specified and the name of the instance is referenced.
+
+## Configuring test suite
+
+In certain cases, it may be useful to pass some configuration information to the test suite itself. While it is generally recommended to avoid this, sometimes it's right answer.
+
+All test suites receive an implicit `env` mapping at the root that contains a mapping of all environment variables. Using YAML Path (YPath) notation, one can retrieve configuration specified through environment variables:
+
+```yaml
+- name: env
+  query: select $1::text as user
+  params:
+  - */env/USER
+  results:
+  - user: */env/USER
+```

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -201,3 +201,10 @@ tests:
   results:
   - shared_buffers: 195MB
     log_connections: on
+
+- name: env
+  query: select $1::text as user
+  params:
+  - */env/USER
+  results:
+  - user: */env/USER


### PR DESCRIPTION
Sometimes it is useful to do so if not everything can be hard-coded.

Solution: pass environment variables through `env` property