### PR TITLE
Problem: some simple tests in pg_yregress are verbose

### DIFF
--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -34,6 +34,16 @@ tests:
   query: select 1 as value
 ```
 
+??? tip "The above test can be further simplified"
+
+    There's a reduced syntax for checking whether query is successful
+    without naming it. You can even drop the `query` key and simply write the query
+    as a test:
+
+    ```yaml
+    - select 1 as value
+    ```
+
 Nothing very interesting. Now, let's amend this test to test the result of this query. For a moment, let's assume we don't know what results are to be returned.
 
 ```yaml

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -40,7 +40,7 @@ typedef struct {
   pid_t pid;
   struct fy_node *node;
   bool is_default;
-  int init_step;
+  bool restarted;
 } yinstance;
 
 typedef enum {
@@ -51,17 +51,15 @@ typedef enum {
 
 void yinstance_start(yinstance *instance);
 
-typedef enum {
-  yinstance_connect_success,
-  yinstance_connect_failure,
-  yinstance_connect_restart
-} yinstance_connect_result;
+typedef enum { yinstance_connect_success, yinstance_connect_failure } yinstance_connect_result;
 
 yinstance_connect_result yinstance_connect(yinstance *instance);
 
 default_yinstance_result default_instance(struct fy_node *instances, yinstance **instance);
 
 iovec_t yinstance_name(yinstance *instance);
+
+void restart_instance(yinstance *instance);
 
 /**
  * List of all instances
@@ -73,7 +71,7 @@ extern struct fy_node *instances;
  */
 void instances_cleanup();
 
-typedef enum { ytest_kind_none, ytest_kind_query, ytest_kind_steps } ytest_kind;
+typedef enum { ytest_kind_none, ytest_kind_query, ytest_kind_steps, ytest_kind_restart } ytest_kind;
 
 typedef struct {
   iovec_t name;
@@ -89,6 +87,7 @@ typedef struct {
 } ytest;
 
 void ytest_run(ytest *test);
+void ytest_run_without_transaction(ytest *test);
 
 iovec_t ytest_name(ytest *test);
 

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -208,3 +208,8 @@ tests:
   - */env/USER
   results:
   - user: */env/USER
+
+# Success test
+- select true
+# We are not testing this as it'll change the node type
+# - select tru

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -7,6 +7,10 @@ instances:
     - alter system set shared_buffers = '193MB'
     - restart:
   configured_text:
+    init:
+    # Test that we can init using usual test
+    - query: select tru
+      success: false
     config: |
       shared_buffers = '194MB'
       log_connections = yes
@@ -208,6 +212,9 @@ tests:
   - */env/USER
   results:
   - user: */env/USER
+
+- name: restart
+  restart: true
 
 # Success test
 - select true


### PR DESCRIPTION
One needs to write

```yaml
- query: ...
```

This is not the case in `init:`

Solution: allow simple string values for queries

Those will be checked for success.

This has paved the way to unifying `init` and test execution and error reporting methods.