### PR TITLE
Problem: reading pg_yregress reports

### DIFF
--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -261,3 +261,19 @@ All test suites receive an implicit `env` mapping at the root that contains a ma
   results:
   - user: */env/USER
 ```
+
+## TAP output
+
+`pg_yregress` can also provide a [TAP](https://testanything.org), Test Anything Protocol for human or machine consumption.
+
+It is currently
+_hidden_ in an output to file descriptor 1001 (if one is defined), and if you want to collect or print it, simply pipe that out to a program processing it (like `tapview'):
+
+```shell
+# Bash
+$ pg_yregress test.yml 1001> >(tapview) 1>/dev/null 2>/dev/null
+# Fish
+$ pg_yregress test.yml 1>/dev/null 2>/dev/null 1001>|tapview
+```
+
+As the tool will evolve, there will likely be another way to activate this.

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -107,4 +107,8 @@ bool fy_node_is_boolean(struct fy_node *node);
 
 bool fy_node_get_boolean(struct fy_node *node);
 
+// TAP
+extern FILE *tap_file;
+extern int tap_counter;
+
 #endif // PG_YREGRESS_H


### PR DESCRIPTION
They require diffing YAML (manually or automated) and sometimes this is just an extra step.

Solution: provide TAP output for TAP consumers

This is useful for reporting test execution and can be used to easily identify which tests failed.