### PR TITLE
Problem: dealing with JSON in pg_yregress

### DIFF
--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -82,6 +82,34 @@ return zero again (thus, signal that the specification is executed as expected.)
     Every `query` item is executed within an individual transaction that is rolled back
     at the end to ensure it does not interfere with other items.
 
+## Handling JSON and JSONB
+
+`pg_yregress` supports JSON types.
+
+* If a supplied query parameter is a mapping or a sequence, it will be automatically converted to JSON strings
+* If result value is of a JSON type, it will be converted to YAML value.
+
+```yaml
+- name: json and jsonb params
+  query: select $1::json as json, $2::jsonb as jsonb
+  params:
+  - hello: 1
+  - hello: 2
+  results:
+  - json:
+      hello: 1
+    jsonb:
+      hello: 2
+
+- name: json and jsonb results
+  query: select json_build_object('hello', 1), jsonb_build_object('hello', 2)
+  results:
+  - json_build_object:
+      hello: 1
+    jsonb_build_object:
+      hello: 2
+```
+
 ## Testing for failures
 
 You can simply test that a certain query will fail:

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -41,6 +41,10 @@ typedef struct {
   struct fy_node *node;
   bool is_default;
   bool restarted;
+  struct {
+    Oid json;
+    Oid jsonb;
+  } types;
 } yinstance;
 
 typedef enum {
@@ -51,7 +55,11 @@ typedef enum {
 
 void yinstance_start(yinstance *instance);
 
-typedef enum { yinstance_connect_success, yinstance_connect_failure } yinstance_connect_result;
+typedef enum {
+  yinstance_connect_success,
+  yinstance_connect_failure,
+  yinstance_connect_error
+} yinstance_connect_result;
 
 yinstance_connect_result yinstance_connect(yinstance *instance);
 

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -220,3 +220,22 @@ tests:
 - select true
 # We are not testing this as it'll change the node type
 # - select tru
+
+- name: json and jsonb params
+  query: select $1::json as json, $2::jsonb as jsonb
+  params:
+  - hello: 1
+  - hello: 2
+  results:
+  - json:
+      hello: 1
+    jsonb:
+      hello: 2
+
+- name: json and jsonb results
+  query: select json_build_object('hello', 1), jsonb_build_object('hello', 2)
+  results:
+  - json_build_object:
+      hello: 1
+    jsonb_build_object:
+      hello: 2


### PR DESCRIPTION
Testing JSON and JSONB parameters and results requires writing JSON as string, which is annoying and error-prone.

Solution: detect the use of JSON and use YAML to represent it