### PR TITLE
Problem: impossible to test side-effects of transactions

### DIFF
--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -162,6 +162,19 @@ tests:
     every item is not wrapped into a transaction and the results of each step are visible 
     in the next step.
 
+## Committing Tests
+
+By default, all tests are rolled back to ensure clean environment. However, in some cases, tests need to commit (for example, to test deferred constraints).
+
+When this is necessary, the `commit` property of a test should be set to `false`:
+
+```yaml
+- query: insert into table values (...)
+  commit: true
+```
+
+This can be also used for multi-step tests. If any of the steps is committed but the multi-step test itself isn't, it'll roll back the uncommitted steps.
+
 ## Notices
 
 One can also check their tests for notices:

--- a/pg_yregress/pg_yregress.c
+++ b/pg_yregress/pg_yregress.c
@@ -36,6 +36,19 @@ static bool populate_ytest_from_fy_node(struct fy_document *fyd, struct fy_node 
     y_test->name.base =
         fy_node_mapping_lookup_scalar_by_simple_key(test, &y_test->name.len, STRLIT("name"));
 
+    struct fy_node *commit = fy_node_mapping_lookup_by_string(test, STRLIT("commit"));
+
+    if (commit != NULL) {
+      if (!fy_node_is_boolean(commit)) {
+        fprintf(stderr, "commit should be a boolean, got: %s",
+                fy_emit_node_to_string(commit, FYECF_DEFAULT));
+        return false;
+      }
+      y_test->commit = fy_node_get_boolean(commit);
+    } else {
+      y_test->commit = false;
+    }
+
     // Determine the instance to run
 
     // Is it explicitly specified?

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -92,6 +92,7 @@ typedef struct {
     } query;
   } info;
   struct fy_node *node;
+  bool commit;
 } ytest;
 
 void ytest_run(ytest *test);

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -239,3 +239,43 @@ tests:
       hello: 1
     jsonb_build_object:
       hello: 2
+
+- name: committed query
+  query: create table this_table_will_exist()
+  commit: true
+
+- name: check committed query
+  query: table this_table_will_exist
+
+- name: committed steps
+  steps:
+  - query: create table committed_step1()
+    commit: true
+  - create table committed_step2()
+
+- name: commit uncommitted steps
+  steps:
+  - query: create table committed_step1_1()
+    commit: true
+  - create table committed_step1_2()
+  commit: true
+
+- name: nested committed steps
+  steps:
+  - steps:
+    - query: create table committed_step2_1()
+      commit: true
+    - query: create table committed_step2_2()
+      commit: false
+  commit: true
+
+- name: check committed steps
+  steps:
+  - table committed_step1
+  - query: table committed_step2
+    success: false
+  - table committed_step_1_1
+  - table committed_step_1_2
+  - table committed_step2_1
+  # this will work because nested transactions commit everything
+  - table committed_step2_2


### PR DESCRIPTION
For example, when transaction is committed, constraints can be checked at the transaction boundary.

Solution: allow specifying whether test should be committed (false by default)