### PR TITLE
Problem: pg_yregress under-reports tests

### DIFF
--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -292,8 +292,8 @@ tests:
   - table committed_step1
   - query: table committed_step2
     success: false
-  - table committed_step_1_1
-  - table committed_step_1_2
+  - table committed_step1_1
+  - table committed_step1_2
   - table committed_step2_1
   # this will work because nested transactions commit everything
   - table committed_step2_2


### PR DESCRIPTION
This is happening with its own test suite.

Solution: ensure errored transactions are restarted and pg_yregress counts skipped tests.

If steps are skipped because the sequence of steps has failed, count them as skipped.

However, if the transaction has failed expectably (an expected error), roll it back and start it anew so that remaining tests can be used. This helped finding a test that should have failed but didn't.