### PR TITLE
Problem: different states of tests in pg_yregress

### DIFF
--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -294,6 +294,16 @@ tests:
 
 Skipped tests don't need to have a valid instruction (`query` or `steps`).
 
+If a skipped test is meant to be executed but shouldn't fail the execution of test suite in case if it fails,
+`todo` directive can be used instead of `skip`.
+
+```yaml
+tests:
+- name: WIP
+  todo: true
+  query: select
+```
+
 ## Configuring instances
 
 Tests may have one more instances they run on. By default, `pg_yregress` will provision one. However, if you want to configure the instance or add more than one, you can use

--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -280,6 +280,20 @@ tests:
 
 [^send-recv]: The encoding that is used by `SEND` and `RECEIVE` functions of the type.
 
+## Skipping tests
+
+If a test not meant to be executed, one can use `skip` directive to suppress its execution. Given a boolean scalar, if it is positive, the test will be skipped. If a negative boolean scalar will be given, it will not be skipped. If any other scalar will be given, it will be used as a reason for skipping the test.
+
+```yaml
+tests:
+- name: skip this
+  skip: true
+- name: skip this for a reason
+  skip: reason
+```
+
+Skipped tests don't need to have a valid instruction (`query` or `steps`).
+
 ## Configuring instances
 
 Tests may have one more instances they run on. By default, `pg_yregress` will provision one. However, if you want to configure the instance or add more than one, you can use

--- a/pg_yregress/pg_yregress.c
+++ b/pg_yregress/pg_yregress.c
@@ -143,8 +143,16 @@ static bool populate_ytest_from_fy_node(struct fy_document *fyd, struct fy_node 
       instruction_found = true;
     }
 
+    // Is this test being skipped?
+    struct fy_node *skip = fy_node_mapping_lookup_by_string(test, STRLIT("skip"));
+    if (skip != NULL) {
+      if (!(fy_node_is_boolean(skip) && !fy_node_get_boolean(skip))) {
+        instruction_found = true;
+      }
+    }
+
     if (!instruction_found) {
-      fprintf(stderr, "Test %.*s doesn't have a valid instruction (any of: query, step)",
+      fprintf(stderr, "Test %.*s doesn't have a valid instruction (any of: query, step, skip)",
               (int)IOVEC_STRLIT(ytest_name(y_test)));
       return false;
     }

--- a/pg_yregress/pg_yregress.c
+++ b/pg_yregress/pg_yregress.c
@@ -151,8 +151,17 @@ static bool populate_ytest_from_fy_node(struct fy_document *fyd, struct fy_node 
       }
     }
 
+    // Is this test being developed?
+    struct fy_node *todo = fy_node_mapping_lookup_by_string(test, STRLIT("todo"));
+    if (todo != NULL) {
+      if (!(fy_node_is_boolean(todo) && !fy_node_get_boolean(todo))) {
+        instruction_found = true;
+      }
+    }
+
     if (!instruction_found) {
-      fprintf(stderr, "Test %.*s doesn't have a valid instruction (any of: query, step, skip)",
+      fprintf(stderr,
+              "Test %.*s doesn't have a valid instruction (any of: query, step, skip, todo)",
               (int)IOVEC_STRLIT(ytest_name(y_test)));
       return false;
     }
@@ -318,6 +327,7 @@ static int execute_document(struct fy_document *fyd, FILE *out) {
 
   // Run tests
   int test_count = 1 + count_tests(tests); // count from 1, so add 1
+  bool succeeded = true;
   fprintf(tap_file, "TAP version 14\n");
   fprintf(tap_file, "1..%d\n", test_count);
 
@@ -327,7 +337,9 @@ static int execute_document(struct fy_document *fyd, FILE *out) {
 
     while ((test = fy_node_sequence_iterate(tests, &iter)) != NULL) {
       ytest *y_test = fy_node_get_meta(test);
-      ytest_run(y_test);
+      if (!ytest_run(y_test)) {
+        succeeded = false;
+      }
       // Currently, ytest_run() may change the node by replacing node of one type
       // with another, and we need to continue from there on.
       // This is a little hacky and exploits the internal knowledge of how the
@@ -356,7 +368,7 @@ static int execute_document(struct fy_document *fyd, FILE *out) {
   fy_emit_document_to_fp(
       fyd, FYECF_MODE_ORIGINAL | FYECF_OUTPUT_COMMENTS | FYECF_INDENT_2 | FYECF_WIDTH_80, out);
 
-  return fy_node_compare(original_root, root) ? 0 : 1;
+  return succeeded ? 0 : 1;
 }
 
 char *pg_config;

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -95,7 +95,7 @@ typedef struct {
   bool commit;
 } ytest;
 
-void ytest_run(ytest *test);
+bool ytest_run(ytest *test);
 void ytest_run_without_transaction(ytest *test);
 
 iovec_t ytest_name(ytest *test);

--- a/pg_yregress/test.c
+++ b/pg_yregress/test.c
@@ -407,12 +407,45 @@ proceed:
 
   PQsetNoticeReceiver(conn, prev_notice_receiver, NULL);
 
+  // Handle `todo` tests
+  struct fy_node *todo = fy_node_mapping_lookup_by_string(test->node, STRLIT("todo"));
+
+  bool todo_allocated = false;
+  iovec_t todo_reason = {.base = "", .len = 0};
+  bool is_todo = false;
+  if (todo != NULL) {
+    if (fy_node_is_boolean(todo)) {
+      if (!fy_node_get_boolean(todo)) {
+        goto report;
+      }
+    } else if (fy_node_is_scalar(todo)) {
+      todo_reason.base = fy_node_get_scalar(todo, &todo_reason.len);
+    } else {
+      todo_reason.base = fy_emit_node_to_string(todo, FYECF_NO_ENDING_NEWLINE | FYECF_WIDTH_INF |
+                                                          FYECF_MODE_FLOW_ONELINE);
+      todo_reason.len = strlen(todo_reason.base);
+      todo_allocated = true;
+    }
+    is_todo = true;
+  }
+
+report:
   tap_counter++;
   bool differ = false;
   if ((differ = fy_node_compare(test->node, original_node))) {
-    fprintf(tap_file, "ok %d - %.*s\n", tap_counter, (int)IOVEC_STRLIT(ytest_name(test)));
+    if (is_todo) {
+      fprintf(tap_file, "ok %d - %.*s # TODO %*.s\n", tap_counter,
+              (int)IOVEC_STRLIT(ytest_name(test)), (int)IOVEC_STRLIT(todo_reason));
+    } else {
+      fprintf(tap_file, "ok %d - %.*s\n", tap_counter, (int)IOVEC_STRLIT(ytest_name(test)));
+    }
   } else {
-    fprintf(tap_file, "not ok %d - %.*s\n", tap_counter, (int)IOVEC_STRLIT(ytest_name(test)));
+    if (is_todo) {
+      fprintf(tap_file, "not ok %d - %.*s # TODO %*.s\n", tap_counter,
+              (int)IOVEC_STRLIT(ytest_name(test)), (int)IOVEC_STRLIT(todo_reason));
+    } else {
+      fprintf(tap_file, "not ok %d - %.*s\n", tap_counter, (int)IOVEC_STRLIT(ytest_name(test)));
+    }
     fprintf(tap_file, "  ---\n");
     struct fy_node *report = fy_node_create_mapping(fy_node_document(original_node));
     fy_node_mapping_append(report,
@@ -439,10 +472,14 @@ proceed:
   }
   fflush(tap_file);
 
-  return differ;
+  if (todo_allocated) {
+    free((void *)todo_reason.base);
+  }
+
+  return is_todo ? true : differ;
 }
 
-void ytest_run(ytest *test) { ytest_run_internal(NULL, test, false, NULL); }
+bool ytest_run(ytest *test) { return ytest_run_internal(NULL, test, false, NULL); }
 void ytest_run_without_transaction(ytest *test) { ytest_run_internal(NULL, test, true, NULL); }
 
 iovec_t ytest_name(ytest *test) {

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -297,3 +297,30 @@ tests:
   - table committed_step2_1
   # this will work because nested transactions commit everything
   - table committed_step2_2
+
+- name: skip
+  skip: reason
+  query: broken
+
+- name: skip (rich)
+  skip:
+    message: msg
+    details: details
+  query: broken
+
+- name: skip (bool)
+  skip: false
+  query: broken
+  success: false
+
+- name: skip (bool, true)
+  skip: true
+  query: broken
+
+- name: skip (without instruction)
+  skip: true
+
+- name: skip in steps
+  steps:
+  - skip: true
+  - select 1

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -324,3 +324,29 @@ tests:
   steps:
   - skip: true
   - select 1
+
+- name: todo
+  todo: true
+  query: broken
+
+- name: todo (reason)
+  todo: reason
+  query: broken
+
+- name: todo (bool)
+  todo: false
+  query: broken
+  success: false
+
+- name: todo (without instruction)
+  todo: true
+
+- name: todo (rich)
+  todo:
+    message: msg
+    details: details
+
+- name: todo in steps
+  steps:
+  - todo: true
+  - select 1


### PR DESCRIPTION
Developing tests is complicated. Sometimes tests fail for no apparent reason (but we want to write them down and have our reports indicate them) or being worked on.

Solution: introduce `skip` and `todo` directives with TAP support