### PR TITLE
Problem: omni_httpd's role.yml test is flaky

### DIFF
--- a/extensions/omni_httpd/event_loop.c
+++ b/extensions/omni_httpd/event_loop.c
@@ -198,12 +198,14 @@ static void on_message(h2o_multithread_receiver_t *receiver, h2o_linklist_t *mes
   }
 }
 
+void event_loop_register_receiver() {
+  h2o_multithread_register_receiver(event_loop_queue, &event_loop_receiver, on_message);
+}
+
 void *event_loop(void *arg) {
   assert(worker_event_loop != NULL);
   assert(handler_queue != NULL);
   assert(event_loop_queue != NULL);
-
-  h2o_multithread_register_receiver(event_loop_queue, &event_loop_receiver, on_message);
 
   bool running = atomic_load(&worker_running);
   bool reload = atomic_load(&worker_reload);

--- a/extensions/omni_httpd/event_loop.h
+++ b/extensions/omni_httpd/event_loop.h
@@ -121,4 +121,14 @@ void h2o_queue_abort(request_message_t *msg);
  */
 void h2o_queue_proxy(request_message_t *msg, char *url, bool preserve_host);
 
+/**
+ * Registers event loop receiver. Must be done prior to starting
+ * event loop's thread.
+ *
+ * An internal implementation detail.
+ *
+ * TODO: redesign event_loop <-> http_worker interaction to simplify this
+ */
+void event_loop_register_receiver();
+
 #endif // OMNI_HTTPD_EVENT_LOOP_H

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -127,6 +127,8 @@ void http_worker(Datum db_oid) {
   // configuration reloads and calling handlers.
   pthread_t event_loop_thread;
   event_loop_suspended = true;
+
+  event_loop_register_receiver(); // This MUST happen before starting event_loop
   pthread_create(&event_loop_thread, NULL, event_loop, NULL);
 
   // Connect worker to the database

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -147,9 +147,42 @@ void http_worker(Datum db_oid) {
       SetUserIdAndSecContext(TopUser, 0);
       CurrentHandlerUser = TopUser;
 
+      SetCurrentStatementStartTimestamp();
+      StartTransactionCommand();
+      PushActiveSnapshot(GetTransactionSnapshot());
+
+      SPI_connect();
+
+      // The idea here is that we get handlers sorted by listener id the same way they were
+      // sorted in the master worker (`by id asc`) and since they will arrive in the same order
+      // in the list of fds, we can simply get them by the index.
+      //
+      // This table is locked by the master worker and thus the order of listeners will not change
+
+      int handlers_query_rc = SPI_execute(
+          "select listeners.id, handlers.query, handlers.role_name "
+          "from omni_httpd.listeners "
+          "left join omni_httpd.listeners_handlers on listeners.id = "
+          "listeners_handlers.listener_id "
+          "left join omni_httpd.handlers handlers on handlers.id = listeners_handlers.handler_id "
+          "order by listeners.id asc",
+          false, 0);
+
+      // Now that we have this information, we can let the master worker commit its update and
+      // release the lock on the table.
+
       pg_atomic_add_fetch_u32(semaphore, 1);
 
+      // When all HTTP workers will do the same, the master worker will start serving the
+      // socket list.
+
       cvec_fd fds = accept_fds(MyBgworkerEntry->bgw_extra);
+      if (cvec_fd_empty(&fds)) {
+        SPI_finish();
+        PopActiveSnapshot();
+        AbortCurrentTransaction();
+        continue;
+      }
 
       // Disposing allocated listener/query pairs and their associated data
       // (such as sockets)
@@ -206,41 +239,40 @@ void http_worker(Datum db_oid) {
         }
       }
 
-      cvec_fd_drop(&fds);
+      // Now we're ready to work with the results of the query we made earlier:
+      if (handlers_query_rc == SPI_OK_SELECT) {
 
-      SetCurrentStatementStartTimestamp();
-      StartTransactionCommand();
-      PushActiveSnapshot(GetTransactionSnapshot());
+        // Here we have to track what was the last listener id
+        int last_id = 0;
+        // Here we have to track what was the last index
+        int index = -1;
 
-      SPI_connect();
-
-      int ret = SPI_execute(
-          "select listeners.address, listeners.effective_port, handlers.query, handlers.role_name "
-          "from "
-          "omni_httpd.listeners_handlers "
-          "inner join omni_httpd.listeners on listeners.id = listeners_handlers.listener_id "
-          "inner join omni_httpd.handlers handlers on handlers.id = listeners_handlers.handler_id",
-          false, 0);
-      if (ret == SPI_OK_SELECT) {
         TupleDesc tupdesc = SPI_tuptable->tupdesc;
         SPITupleTable *tuptable = SPI_tuptable;
         for (int i = 0; i < tuptable->numvals; i++) {
           HeapTuple tuple = tuptable->vals[i];
-          bool addr_is_null = false;
-          Datum addr = SPI_getbinval(tuple, tupdesc, 1, &addr_is_null);
-          bool port_is_null = false;
-          Datum port = SPI_getbinval(tuple, tupdesc, 2, &port_is_null);
-
-          int port_no = DatumGetInt32(port);
+          bool id_is_null = false;
+          Datum id = SPI_getbinval(tuple, tupdesc, 1, &id_is_null);
 
           bool query_is_null = false;
-          Datum query = SPI_getbinval(tuple, tupdesc, 3, &query_is_null);
+          Datum query = SPI_getbinval(tuple, tupdesc, 2, &query_is_null);
+
+          // Figure out socket index
+          if (last_id != DatumGetInt32(id)) {
+            last_id = DatumGetInt32(id);
+            index++;
+          }
+
+          // If no handler has matched, continue to the next row
+          if (query_is_null) {
+            continue;
+          }
 
           Oid role_id = InvalidOid;
           bool role_superuser = false;
           {
             bool role_name_is_null = false;
-            Datum role_name = SPI_getbinval(tuple, tupdesc, 4, &role_name_is_null);
+            Datum role_name = SPI_getbinval(tuple, tupdesc, 3, &role_name_is_null);
 
             HeapTuple roleTup = SearchSysCache1(AUTHNAME, role_name);
             if (!HeapTupleIsValid(roleTup)) {
@@ -254,131 +286,91 @@ void http_worker(Datum db_oid) {
             ReleaseSysCache(roleTup);
           }
 
-          c_FOREACH(iter, clist_listener_contexts, listener_contexts) {
-            int fd = iter.ref->fd;
-            struct sockaddr_in sin;
-            socklen_t len = sizeof(sin);
-            struct sockaddr_in6 sin6;
-            socklen_t len6 = sizeof(sin6);
-
-            socklen_t socklen;
-            void *sockaddr;
-
-            const char *fdaddr;
-
-            char _address[MAX_ADDRESS_SIZE];
-            char _address1[MAX_ADDRESS_SIZE];
-
-            int family = 0;
-            if (getsockname(fd, (struct sockaddr *)&sin, &len) == 0) {
-              family = sin.sin_family;
-            }
-
-            if (family == AF_INET) {
-              sockaddr = &sin;
-              socklen = len;
-            } else if (family == AF_INET6) {
-              sockaddr = &sin6;
-              socklen = len6;
-            } else {
-              continue;
-            }
-
-            int sock_port_no = 0;
-            if (getsockname(fd, (struct sockaddr *)sockaddr, &len) == 0) {
-              if (family == AF_INET) {
-                sock_port_no = ntohs(sin.sin_port);
-                fdaddr = inet_ntop(AF_INET, &sin.sin_addr, _address, sizeof(_address));
-              } else if (family == AF_INET6) {
-                sock_port_no = ntohs(sin6.sin6_port);
-                fdaddr = inet_ntop(AF_INET6, &sin6.sin6_addr, _address, sizeof(_address));
-              } else {
-                continue;
-              }
-            } else {
-              continue;
-            }
-
-            inet *inet_address = DatumGetInetPP(addr);
-            char *address = pg_inet_net_ntop(ip_family(inet_address), ip_addr(inet_address),
-                                             ip_bits(inet_address), _address1, sizeof(_address1));
-
-            if (strncmp(address, fdaddr, strlen(address)) == 0 && port_no == sock_port_no) {
-              // Found matching socket
-              char *query_string = text_to_cstring(DatumGetTextPP(query));
-              MemoryContext memory_context = CurrentMemoryContext;
-              char *request_cte = psprintf(
-                  // clang-format off
-                                  "select " "$" REQUEST_PLAN_PARAM(
-                                          REQUEST_PLAN_METHOD) "::text::omni_http.http_method AS method, "
-                                  "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_PATH) " as path, "
-                                  "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_QUERY_STRING) " as query_string, "
-                                  "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_BODY) " as body, "
-                                  "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_HEADERS) " as headers "
-                  // clang-format on
-              );
-
-              List *query_stmt = omni_sql_parse_statement(query_string);
-              if (omni_sql_is_parameterized(query_stmt)) {
-                ereport(WARNING, errmsg("Listener query is parameterized and is rejected:\n %s",
-                                        query_string));
-              } else {
-                List *request_cte_stmt = omni_sql_parse_statement(request_cte);
-                query_stmt = omni_sql_add_cte(query_stmt, "request", request_cte_stmt, false, true);
-
-                char *query = omni_sql_deparse_statement(query_stmt);
-                list_free_deep(request_cte_stmt);
-                list_free_deep(query_stmt);
-                PG_TRY();
-                {
-                  SPIPlanPtr plan =
-                      SPI_prepare(query, REQUEST_PLAN_PARAMS,
-                                  (Oid[REQUEST_PLAN_PARAMS]){
-                                      [REQUEST_PLAN_METHOD] = TEXTOID,
-                                      [REQUEST_PLAN_PATH] = TEXTOID,
-                                      [REQUEST_PLAN_QUERY_STRING] = TEXTOID,
-                                      [REQUEST_PLAN_BODY] = BYTEAOID,
-                                      [REQUEST_PLAN_HEADERS] = http_header_array_oid(),
-                                  });
-
-                  // Get role
-                  iter.ref->role_id = role_id;
-                  iter.ref->role_is_superuser = role_superuser;
-
-                  // We have to keep the plan as we're going to disconnect from SPI
-                  int keepret = SPI_keepplan(plan);
-                  if (keepret != 0) {
-                    ereport(WARNING,
-                            errmsg("Can't save plan: %s", SPI_result_code_string(keepret)));
-                    iter.ref->plan = NULL;
-                  } else {
-                    iter.ref->plan = plan;
-                  }
-                }
-                PG_CATCH();
-                {
-                  MemoryContextSwitchTo(memory_context);
-                  WITH_TEMP_MEMCXT {
-                    ErrorData *error = CopyErrorData();
-                    ereport(WARNING, errmsg("Error preparing query %s", query),
-                            errdetail("%s: %s", error->message, error->detail));
-                  }
-
-                  FlushErrorState();
-                }
-                PG_END_TRY();
-                pfree(query);
-              }
-              pfree(query_string);
+          const cvec_fd_value *fd = cvec_fd_at(&fds, index);
+          Assert(fd != NULL);
+          listener_ctx *listener_ctx = NULL;
+          c_foreach(iter, clist_listener_contexts, listener_contexts) {
+            if (iter.ref->fd == *fd) {
+              listener_ctx = iter.ref;
+              break;
             }
           }
+          Assert(listener_ctx != NULL);
+
+          char *query_string = text_to_cstring(DatumGetTextPP(query));
+          MemoryContext memory_context = CurrentMemoryContext;
+          char *request_cte = psprintf(
+              // clang-format off
+              "select " "$" REQUEST_PLAN_PARAM(
+                      REQUEST_PLAN_METHOD) "::text::omni_http.http_method AS method, "
+              "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_PATH) " as path, "
+              "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_QUERY_STRING) " as query_string, "
+              "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_BODY) " as body, "
+              "$" REQUEST_PLAN_PARAM(REQUEST_PLAN_HEADERS) " as headers "
+              // clang-format on
+          );
+
+          List *query_stmt = omni_sql_parse_statement(query_string);
+          if (omni_sql_is_parameterized(query_stmt)) {
+            ereport(WARNING,
+                    errmsg("Listener query is parameterized and is rejected:\n %s", query_string));
+          } else {
+            List *request_cte_stmt = omni_sql_parse_statement(request_cte);
+            query_stmt = omni_sql_add_cte(query_stmt, "request", request_cte_stmt, false, true);
+
+            char *query = omni_sql_deparse_statement(query_stmt);
+            list_free_deep(request_cte_stmt);
+            list_free_deep(query_stmt);
+            PG_TRY();
+            {
+              SPIPlanPtr plan = SPI_prepare(query, REQUEST_PLAN_PARAMS,
+                                            (Oid[REQUEST_PLAN_PARAMS]){
+                                                [REQUEST_PLAN_METHOD] = TEXTOID,
+                                                [REQUEST_PLAN_PATH] = TEXTOID,
+                                                [REQUEST_PLAN_QUERY_STRING] = TEXTOID,
+                                                [REQUEST_PLAN_BODY] = BYTEAOID,
+                                                [REQUEST_PLAN_HEADERS] = http_header_array_oid(),
+                                            });
+
+              Assert(plan != NULL);
+              // Get role
+              listener_ctx->role_id = role_id;
+              listener_ctx->role_is_superuser = role_superuser;
+
+              // We have to keep the plan as we're going to disconnect from SPI
+              int keepret = SPI_keepplan(plan);
+              if (keepret != 0) {
+                ereport(WARNING, errmsg("Can't save plan: %s", SPI_result_code_string(keepret)));
+                listener_ctx->plan = NULL;
+              } else {
+                listener_ctx->plan = plan;
+              }
+            }
+            PG_CATCH();
+            {
+              MemoryContextSwitchTo(memory_context);
+              WITH_TEMP_MEMCXT {
+                ErrorData *error = CopyErrorData();
+                ereport(WARNING, errmsg("Error preparing query %s", query),
+                        errdetail("%s: %s", error->message, error->detail));
+              }
+
+              FlushErrorState();
+            }
+            PG_END_TRY();
+            pfree(query);
+          }
+          pfree(query_string);
         }
       } else {
-        ereport(WARNING, errmsg("Error fetching configuration: %s", SPI_result_code_string(ret)));
+        ereport(WARNING, errmsg("Error fetching configuration: %s",
+                                SPI_result_code_string(handlers_query_rc)));
       }
 
       SPI_finish();
+      PopActiveSnapshot();
       AbortCurrentTransaction();
+      cvec_fd_drop(&fds);
     }
 
     event_loop_suspended = false;
@@ -555,6 +547,7 @@ try_connect:
   do {
     errno = 0;
     if (atomic_load(&worker_reload)) {
+      result = cvec_fd_init();
       break;
     }
     result = recv_fds(socket_fd);
@@ -580,7 +573,7 @@ static int handler(request_message_t *msg) {
 
   if (plan == NULL) {
     req->res.status = 500;
-    h2o_queue_send_inline(msg, H2O_STRLIT("Internal server error"));
+    h2o_queue_send_inline(msg, H2O_STRLIT("Internal server error!!"));
     goto release;
   }
 

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -117,10 +117,29 @@ create table configuration_reloads
 create procedure wait_for_configuration_reloads(n int) as
 $$
 declare
-    c int;
+    c  int = 0;
+    n_ int = n;
 begin
     loop
-        select count(*) into c from omni_httpd.configuration_reloads;
+        with
+            reloads as (select
+                            id
+                        from
+                            omni_httpd.configuration_reloads
+                        order by happened_at asc
+                        limit n_)
+        delete
+        from
+            omni_httpd.configuration_reloads
+        where
+            id in (select id from reloads);
+        declare
+            rowc int;
+        begin
+            get diagnostics rowc = row_count;
+            n_ = n_ - rowc;
+            c = c + rowc;
+        end;
         exit when c >= n;
     end loop;
 end;

--- a/extensions/omni_httpd/tests/role.yml
+++ b/extensions/omni_httpd/tests/role.yml
@@ -100,6 +100,9 @@ tests:
   success: false
   error: 'new row for relation "handlers" violates check constraint "handlers_role_name_check"'
 
+- query: delete from omni_httpd.configuration_reloads
+  commit: true
+
 - name: Can update it to a name that is not a current user if it is accessible
   query: update omni_httpd.handlers set role_name = 'test_user1' where role_name = 'test_user'
   commit: true
@@ -108,8 +111,15 @@ tests:
   query: set session role test_user1
   commit: true
 
+- query: call omni_httpd.wait_for_configuration_reloads(1)
+  commit: true
+
 - name: Can update it to a name that is a current user
   query: update omni_httpd.handlers set role_name = 'test_user1' where role_name = 'test_user'
+  commit: true
+
+- query: call omni_httpd.wait_for_configuration_reloads(1)
+  commit: true
 
 - name: After checking permissions, should not change to the new role
   steps:
@@ -120,11 +130,11 @@ tests:
 
 - name: Can't update it to a name that is not a current user if it is not accessible
   steps:
-    - reset role
-    - alter role current_user nosuperuser
-    - query: update omni_httpd.handlers set role_name = 'anotherrole' where role_name = 'test_user1'
-      success: false
-      error: 'new row for relation "handlers" violates check constraint "handlers_role_name_check"'
+  - reset role
+  - alter role current_user nosuperuser
+  - query: update omni_httpd.handlers set role_name = 'anotherrole' where role_name = 'test_user1'
+    success: false
+    error: 'new row for relation "handlers" violates check constraint "handlers_role_name_check"'
 
 - name: check current role through the service
   query: |

--- a/extensions/omni_httpd/tests/role.yml
+++ b/extensions/omni_httpd/tests/role.yml
@@ -6,6 +6,8 @@ instances:
     init:
     - set session omni_httpd.no_init = true
     - create extension omni_httpd cascade
+    - call omni_httpd.wait_for_configuration_reloads(1)
+    - delete from omni_httpd.configuration_reloads
     - create extension omni_httpc cascade
     - create role test_user inherit in role current_user
     - create role test_user1 inherit in role current_user
@@ -64,7 +66,6 @@ instances:
           return outcome;
       end;
       $$ language plpgsql
-    - delete from omni_httpd.configuration_reloads
     - |
       with
           listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 0) returning id),
@@ -92,8 +93,6 @@ instances:
           listener,
           handler
     - call omni_httpd.wait_for_configuration_reloads(1)
-    # FIXME: this shouldn't be here, but it doesn't work without it
-    - select pg_sleep(1)
 
 tests:
 - name: Can't update it to an arbitrary name


### PR DESCRIPTION
At times, HTTP connections are refused

Minor improvement: ensure we wait for the initial omni_httpd load

From https://github.com/omnigres/omnigres/issues/186#issuecomment-1570508233:

```
I think this is what is happening:

When omni_httpd is started with no_init (no default listener), upon
startup, the master worker reads the configuration, finds no listeners,
and proceeds to insert a record into configuration_reloads, which
indicates that a reload has happened. And in a sense, it has, however,
it is a "nil" configuration. We could make it conditional, saying
there won't be a reload notification if there are no listeners (or the
    listener configuration hasn't changed). However, this is
problematic:

We don't check the handlers and if their configuration changed (this is
currently the responsibility of http workers). We could, however,
try and do this.  It will have negative impact on interface
expectations. Let's say we issue an update to the configuration but
it doesn't change anything or deletes all listeners. Shouldn't there
 be a notification? Of course, there should be!

So, perhaps, with this in mind, the test scripts need to ensure they
wait for a configuration reload of the initial configuration. Or wait
for two reloads. This is not ideal, so I am still open to other ideas.
```

It has seemingly made the test less flaky but didn't seem to eliminate it altogether.

---

A better improvement is to omni_httpd master worker coordination:

It's a bit complicated: we have one transaction in which we start the
listener (picking a port, if necessary), then we commit it and notify
the HTTP workers that they can reload. We commit so that they can
read the effective port so that they can find the socket by address and
port.
    
The HTTP workers then notify the master worker that they are ready to
receive a list of sockets.
    
After this, we have a second transaction that signals that we're done
reloading the configuration so that user code can rely on that for
testing and other purposes.
    
Solution: change the socket lookup method
    
By sorting listeners by ID (ascending), we always get the same order of
IDs and, therefore, can use the vector of received sockets to get them by
index instead.
    
In order to guarantee that the order won't change, master worker locks
the `listeners` table before it reads it and other transactions can
only read from it but not modify it.
    
This simplifies the socket discovery and gives us a single transaction in the master worker.