### PR TITLE
Problem: trying to get non-existent header attribute

### DIFF
--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -731,14 +731,8 @@ static int handler(request_message_t *msg) {
                   size_t value_len = VARSIZE_ANY_EXHDR(value_text);
                   char *value_cstring = h2o_mem_alloc_pool(&req->pool, char *, value_len + 1);
                   text_to_cstring_buffer(value_text, value_cstring, value_len + 1);
-                  Datum append = GetAttributeByNum(header_tuple, 3, &isnull);
-                  if (isnull || !DatumGetBool(append)) {
-                    h2o_set_header_by_str(&req->pool, &req->res.headers, name_cstring, name_len, 0,
-                                          value_cstring, value_len, true);
-                  } else {
-                    h2o_add_header_by_str(&req->pool, &req->res.headers, name_cstring, name_len, 0,
-                                          NULL, value_cstring, value_len);
-                  }
+                  h2o_set_header_by_str(&req->pool, &req->res.headers, name_cstring, name_len, 0,
+                                        value_cstring, value_len, true);
                 }
               }
             }


### PR DESCRIPTION
Before acc3973d34b012d7ba988fa355344a69a70f1707, there was an `append` attribute in headers, but it is gone now. However, it was still being retrieved. Valgrind pointed that out.

Solution: make it always set headers

I am not sure why `append` was removed. Unfortunately, I didn't record this decision in the aforementioned change.