### PR TITLE
Problem: omni_httpd socket closing procedure

### DIFF
--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -170,10 +170,9 @@ void http_worker(Datum db_oid) {
 
           if (iter.ref->socket != NULL) {
             h2o_socket_t *socket = iter.ref->socket;
-            h2o_socket_read_stop(socket);
             h2o_socket_export_t info;
             h2o_socket_export(socket, &info);
-            close(info.fd);
+            h2o_socket_dispose_export(&info);
           }
           h2o_context_dispose(&iter.ref->context);
           MemoryContextDelete(iter.ref->memory_context);


### PR DESCRIPTION
Currently, it can lead to double free as it links the socket into the linked list by registering stoppage of reading and then registering a request to dispose it.

Solution: don't register the stoppage of reading

Also, while at it, properly cleanup the export.