### PR TITLE
Problem: listing files recursively in omni_vfs

### DIFF
--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -94,7 +94,7 @@ find_program(PGCLI pgcli)
 function(find_pg_yregress_tests dir)
     file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}_FindRegressTests.cmake"
             CONTENT "
-file(GLOB files RELATIVE ${CMAKE_CURRENT_LIST_DIR} ${dir}/*)
+file(GLOB_RECURSE files RELATIVE ${CMAKE_CURRENT_LIST_DIR} LIST_DIRECTORIES false ${dir}/*.yml ${dir}/*.yaml)
 list(SORT files)
 foreach(file \${files})
     add_test(\"${NAME}/\${file}\" \"$<TARGET_FILE:pg_yregress>\" \"${dir}/../\${file}\")

--- a/extensions/omni_vfs/docs/reference.md
+++ b/extensions/omni_vfs/docs/reference.md
@@ -54,6 +54,88 @@ Results in:
 | omni_vfs--0.1.sql | file | 3073 | 2023-06-08 17:10:55.278702 | 2023-06-08 17:11:04.599535 | 2023-06-08 17:10:55.278702 |
 | omni_vfs.c        | file |  347 | 2023-06-08 14:10:18.743496 | 2023-06-08 14:10:19.40728  | 2023-06-08 14:10:18.743496 |
 
+## API
+
+## `omni_vfs.file` type
+
+Describes a file entry.
+
+|    Field | Type                | Description                                   |
+|---------:|---------------------|-----------------------------------------------|
+| **name** | `text`              | File name                                     |
+| **kind** | `omni_vs.file_kind` | File kind (`file`, `dir`) [^other-file-types] |
+
+[^other-file-types]:
+Other file types (such as sockets) are not currently considered to be of practical use and will be reported as `file`. This may change in the future.
+
+## `omni_vs.file_info` type
+
+Describes file meta information.
+
+|           Field | Type        | Description                           |
+|----------------:|-------------|---------------------------------------|
+|        **size** | `bigint`    | File size                             |
+|  **created_at** | `timestamp` | File creation time (if available)     |
+| **accessed_at** | `timestamp` | File access time (if available)       |
+| **modified_at** | `timestamp` | File modification time (if available) |
+
+## `omni_vfs.list()`
+
+Lists a directory or a single file.
+
+|            Parameter | Type              | Description                                                       |
+|---------------------:|-------------------|-------------------------------------------------------------------|
+|               **fs** | _Filesystem type_ | Filesystem                                                        |
+|             **path** | `text`            | Path to list. If it is a single file, returns that file           |
+| **fail_unpermitted** | `bool`            | Raise an error if directory can't be open. `true` **by default**. |
+
+Returns a set of `omni_vfs.file` values.
+
+## `omni_vfs.list_recursively()`
+
+This is a helper function implemented for all backends that lists all files recursively.
+
+| Parameter | Type              | Description                                                        |
+|----------:|-------------------|--------------------------------------------------------------------|
+|    **fs** | _Filesystem type_ | Filesystem                                                         |
+|  **path** | `text`            | Path to list. If it is a single file, returns that file            |
+|   **max** | `bigint`          | Limit the number of files to be returned. No limit **by default**. |
+
+Returns a set of `omni_vfs.file`
+
+!!! warning "Use caution if the directory might contain a lot of files"
+
+    If there are a lot of files, this function will use a lot of memory and will take a long time. To safeguard
+    against this, use of `max` parameter is **strongly recommended**.
+
+    One of the reasons why this function has a long name is to force its users to use it carefully and sparingly.
+
+## `omni_vfs.file_info()`
+
+Provides file information (similar to POSIX `stat`)
+
+| Parameter | Type              | Description      |
+|----------:|-------------------|------------------|
+|    **fs** | _Filesystem type_ | Filesystem       |
+|  **path** | `text`            | Path to the file |
+
+Returns a value of the `omni_vfs.file_info` type.
+
+## `omni_vfs.read()`
+
+Reads a chunk of the file.
+
+|       Parameter | Type              | Description                                                                        |
+|----------------:|-------------------|------------------------------------------------------------------------------------|
+|          **fs** | _Filesystem type_ | Filesystem                                                                         |
+|        **path** | `text`            | Path to the file                                                                   |
+| **file_offset** | `bigint`          | Offset to read at. Defaults to `0`.                                                |
+|  **chunk_size** | `bigint`          | Number of bytes to read. By default, tries to read to the end [^chunk_size-limit]. |
+
+Returns a `bytea` value
+
+[^chunk_size-limit]: Chunk size is currently limited to 1GB.
+
 ## Backends
 
 Currently, omni_vfs provides the following backends:

--- a/extensions/omni_vfs/tests/local_fs.yml
+++ b/extensions/omni_vfs/tests/local_fs.yml
@@ -17,11 +17,45 @@ tests:
     results:
     - result: t
 
-- name: can list files
-  query: select * from omni_vfs.list(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), '')
+- name: can list files in a directory
+  query: |
+    select * from omni_vfs.list(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), '')
+    order by name
+  results:
+  - name: empty
+    kind: dir
+  - kind: file
+    name: local_fs.yml
+
+- name: can list a file
+  query: select * from omni_vfs.list(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), 'local_fs.yml')
   results:
   - kind: file
     name: local_fs.yml
+
+- name: list skips a non-existent file
+  query: select * from omni_vfs.list(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), 'local_fs_does_not_exist.yml')
+  results: [ ]
+
+- name: recursively list
+  query: |
+    select * from omni_vfs.list_recursively(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), '.')
+    order by name
+  results:
+  - name: empty
+    kind: dir
+  - name: empty/.keepme
+    kind: file
+  - kind: file
+    name: local_fs.yml
+
+- name: recursive listing respects path
+  query: |
+    select * from omni_vfs.list_recursively(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), 'empty')
+    order by name
+  results:
+  - name: .keepme
+    kind: file
 
 - name: can't list files outside of the mount point
   query: select * from omni_vfs.list(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), '..')


### PR DESCRIPTION
Currently, this requires one to write out a recursive query. At least that's the idea.

It's going to be very useful for facilitating smoother development environment experience (interacting with the working directory)

Solution: add `list_recursively()` function to make it reusable

While at it, document things.

Few fixes were made as well:

* `realpath()` was replaced with `make_absolute_path()` from Postgres to avoid symlink resolution.
* `chunk_size` is now `int` instead of `bigint` because there is a 1GB limit anyway (noticed during documenting)
* `omni_vfs.list()` got a new parameter of `fail_unpermitted`, primarily for the benefit of `list_recursively()` as it'd error out trying to list. It will make it a warning instead.