### PR TITLE
Problem: omni_vfs.local_fs() transfer of the result

### DIFF
--- a/extensions/omni_vfs/local_fs.c
+++ b/extensions/omni_vfs/local_fs.c
@@ -95,12 +95,7 @@ Datum local_fs(PG_FUNCTION_ARGS) {
   TupleDesc tupdesc = SPI_tuptable->tupdesc;
   HeapTuple tuple = SPI_tuptable->vals[0];
   bool isnull;
-  Datum local_fs = SPI_getbinval(tuple, tupdesc, 1, &isnull);
-
-  MemoryContext spi_context = CurrentMemoryContext;
-  MemoryContextSwitchTo(oldcontext);
-  SPI_datumTransfer(local_fs, false, -1);
-  MemoryContextSwitchTo(spi_context);
+  Datum local_fs = SPI_datumTransfer(SPI_getbinval(tuple, tupdesc, 1, &isnull), false, -1);
 
   SPI_finish();
 


### PR DESCRIPTION
It doesn't actually happen and manifests in other pieces of code getting garbage instead of proper data.

Solution: ensure we capture the result of `SPI_transferDatum`

Also, remove the unnecessary manipulations of the memory context as these are done by `SPI_transferDatum`. They are only necessary if we use `transferDatum`.