### PR TITLE
Problem: unused saved MemoryContext in omni_vfs

### DIFF
--- a/extensions/omni_vfs/local_fs.c
+++ b/extensions/omni_vfs/local_fs.c
@@ -64,8 +64,6 @@ Datum local_fs(PG_FUNCTION_ARGS) {
     ereport(ERROR, errmsg("must must not be NULL"));
   }
 
-  MemoryContext oldcontext = CurrentMemoryContext;
-
   text *absolute_mount = cstring_to_text(subpath(text_to_cstring(PG_GETARG_TEXT_PP(0)), "."));
 
   SPI_connect();


### PR DESCRIPTION
It's harmless, but there's no reason for it.

Solution: remove it