### PR TITLE
Problem: our build process only uses self-managed Postgres builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,3 +91,19 @@ jobs:
         find ${{github.workspace}}/build -name postmaster.log -exec echo "=== {}:" \; -exec cat {} \;
         echo "- initdb.log: "
         find ${{github.workspace}}/build -name initdb.log -exec echo "=== {}:" \; -exec cat {} \;
+
+  # Ensure it can be built against externally-supplied Postgres
+  build-external-pg:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install necessary dependencies
+      run: sudo apt install postgresql-server-dev-14
+
+    - name: Configure
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DPG_CONFIG=$(which pg_config)
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --parallel --config Release --target all --target package

--- a/cmake/FramaC.cmake
+++ b/cmake/FramaC.cmake
@@ -8,10 +8,10 @@ if(FRAMAC)
     # See https://git.frama-c.com/pub/frama-c/-/issues/2641
     #
     # The idea is that we undefine PG_INT128_TYPE if __FRAMAC_ is defined:
-    file(READ ${PostgreSQL_ROOT}/include/postgresql/server/pg_config_manual.h _pg_config_manual)
+    file(READ ${PostgreSQL_INCLUDE_DIRS}/postgresql/server/pg_config_manual.h _pg_config_manual)
 
     if(NOT _pg_config_manual MATCHES __FRAMAC__)
-        file(APPEND ${PostgreSQL_ROOT}/include/postgresql/server/pg_config_manual.h [=[
+        file(APPEND ${PostgreSQL_INCLUDE_DIRS}/postgresql/server/pg_config_manual.h [=[
  #ifdef __FRAMAC__
  #undef PG_INT128_TYPE
  #endif

--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -153,7 +153,7 @@ function(add_postgresql_extension NAME)
 
     set(_share_dir "${CMAKE_BINARY_DIR}/pg-share")
     if(_pg_sharedir)
-        file(COPY "${_pg_sharedir}/" DESTINATION "${_share_dir}")
+        file(COPY "${_pg_sharedir}/" DESTINATION "${_share_dir}" FOLLOW_SYMLINK_CHAIN)
     endif()
     set(_ext_dir "${_share_dir}/extension")
     file(MAKE_DIRECTORY ${_ext_dir})


### PR DESCRIPTION
This is problematic when we want to be able to build exensions against Postgres installed using system-wide package manager or any other method.

For example, this would be useful for building extensions for specific Linux distros.

Solution: allow this by taking `PG_CONFIG` variable to specify `pg_config`

The command would now look like:

```shell
cmake -DPG_CONFIG=/path/to/pg_config # for example, $(which pg_config)
```

We won't be able to run psql or test targets yet because of how we ship extensions using patched Postgres. Same applies to Frama-C tests. But I think that this is okay for the time being. If you want to develop and test, self-managed Postgres builds are okay. It would be great to improve this in the future, but not a huge priority at the moment.