### PR TITLE
Problem: pg_yregress uses Postgres notation for booleans

### DIFF
--- a/extensions/omni_httpd/tests/role.yml
+++ b/extensions/omni_httpd/tests/role.yml
@@ -149,7 +149,7 @@ tests:
 - name: Ensure 'anotherrole' is not a superuser (sanity check)
   query: select rolsuper from pg_roles where rolname = 'anotherrole'
   results:
-  - rolsuper: f
+  - rolsuper: false
 
 - name: set another role
   steps:

--- a/extensions/omni_mimetypes/tests/test.yml
+++ b/extensions/omni_mimetypes/tests/test.yml
@@ -8,12 +8,12 @@ tests:
 - name: presence of mime types
   query: select count(*) > 2000 as present from omni_mimetypes.mime_types
   results:
-  - present: t
+  - present: true
 
 - name: presence of file extensions
   query: select count(*) > 1000 as present from omni_mimetypes.mime_types
   results:
-  - present: t
+  - present: true
 
 - name: smoke test
   query: |

--- a/extensions/omni_schema/tests/test.yml
+++ b/extensions/omni_schema/tests/test.yml
@@ -29,7 +29,7 @@ tests:
     - load_from_fs: foo.sql
   - query: select foo()
     results:
-    - foo: f
+    - foo: false
   - name: 2
     query: |
       select
@@ -40,7 +40,7 @@ tests:
     - load_from_fs: foo_modified.sql
   - query: select foo()
     results:
-    - foo: t
+    - foo: true
   - name: 3
     query: |
       select
@@ -51,7 +51,7 @@ tests:
     - load_from_fs: foo_new_signature.sql
   - query: select foo(1)
     results:
-    - foo: t
+    - foo: true
   - query: select foo()
     success: false
     error: function foo() does not exist

--- a/extensions/omni_seq/tests/test.yml
+++ b/extensions/omni_seq/tests/test.yml
@@ -116,7 +116,7 @@ tests:
     select
     (omni_seq.system_identifier() = omni_seq.system_identifier() and omni_seq.system_identifier() is not null) as valid
   results:
-  - valid: t
+  - valid: true
 
 - name: smoke test
   steps:

--- a/extensions/omni_vfs/tests/local_fs.yml
+++ b/extensions/omni_vfs/tests/local_fs.yml
@@ -15,7 +15,7 @@ tests:
   - query: select omni_vfs.local_fs('.')
   - query: select true as result from seqval where currval = currval('omni_vfs.local_fs_mounts_id_seq')
     results:
-    - result: t
+    - result: true
 
 - name: can list files in a directory
   query: |
@@ -70,13 +70,13 @@ tests:
 - name: can get file info
   query: select size > 0 as non_zero, kind from omni_vfs.file_info(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), 'local_fs.yml')
   results:
-  - non_zero: t
+  - non_zero: true
     kind: file
 
 - name: can read file
   query: select length(convert_from(omni_vfs.read(omni_vfs.local_fs('../../../../extensions/omni_vfs'), 'tests/local_fs.yml'), 'utf8')) > 0 as result
   results:
-  - result: t
+  - result: true
 
 - name: mount point is recorded as an absolute path
   steps:
@@ -85,7 +85,7 @@ tests:
   - select omni_vfs.local_fs('.')
   - query: select length(mount) > length('.') as result from omni_vfs.local_fs_mounts
     results:
-    - result: t
+    - result: true
 
 - name: RLS is enforced (can't create a mount)
   steps:

--- a/extensions/omni_web/tests/query_string.yml
+++ b/extensions/omni_web/tests/query_string.yml
@@ -7,7 +7,7 @@ tests:
 
 - query: select omni_web.parse_query_string(null) is null as is_true
   results:
-   - is_true: t
+   - is_true: true
 
 - query: select omni_web.parse_query_string('')
   results:

--- a/pg_yregress/CMakeLists.txt
+++ b/pg_yregress/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(PostgreSQL REQUIRED)
 find_program(PG_CONFIG pg_config REQUIRED)
 
 include(CPM)
-CPMAddPackage(GITHUB_REPOSITORY "pantoniou/libfyaml" GIT_TAG "v0.8" EXCLUDE_FROM_ALL YES OPTIONS "BUILD_SHARED_LIBS OFF")
+CPMAddPackage(GITHUB_REPOSITORY "yrashk/libfyaml" GIT_TAG "4f1a4b1" VERSION "v0.8-4f1a4b1" EXCLUDE_FROM_ALL YES OPTIONS "BUILD_SHARED_LIBS OFF")
 
 include(CTest)
 

--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -290,7 +290,7 @@ tests:
   params:
   - 0x01
   results:
-  - value: t
+  - value: true
 ```
 
 [^send-recv]: The encoding that is used by `SEND` and `RECEIVE` functions of the type.

--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -159,6 +159,21 @@ error:
 
 In this form, both severity and message can be specified.
 
+## Negative tests
+
+A test can be marked negative when it should fail if the test itself passes. This is useful when testing scenarios where something specific should
+**not** happen.
+
+```yaml
+- name: 'string' should not be returned
+  query: select my_fun() as result
+  results:
+  - result: string
+  negative: true
+```
+
+The example is slightly contrived as we can test the assumption in the query itself, but at times it is easier or clearer to have this specified as such "negative test".
+
 ## Multi-step tests
 
 Some test inolve more than one query and we need to check for more than just the final result, so simply executing all statements and queries delimited by a semicolon wouldn't be great.

--- a/pg_yregress/instance.c
+++ b/pg_yregress/instance.c
@@ -113,6 +113,8 @@ static bool fetch_types(yinstance *instance) {
       instance->types.json = oid;
     } else if (strncmp(type_name, "jsonb", strlen(type_name)) == 0) {
       instance->types.jsonb = oid;
+    } else if (strncmp(type_name, "bool", strlen(type_name)) == 0) {
+      instance->types.boolean = oid;
     }
   }
   PQclear(result);

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -94,6 +94,7 @@ typedef struct {
   } info;
   struct fy_node *node;
   bool commit;
+  bool negative;
 } ytest;
 
 bool ytest_run(ytest *test);

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -44,6 +44,7 @@ typedef struct {
   struct {
     Oid json;
     Oid jsonb;
+    Oid boolean;
   } types;
 } yinstance;
 

--- a/pg_yregress/test.c
+++ b/pg_yregress/test.c
@@ -12,6 +12,9 @@ static void notice_receiver(struct fy_node *notices, const PGresult *result) {
 
 bool ytest_run_internal(PGconn *default_conn, ytest *test, bool in_transaction, int sub_test,
                         bool *errored) {
+  struct fy_node *true_scalar = fy_node_create_scalar(fy_node_document(test->node), STRLIT("true"));
+  struct fy_node *false_scalar =
+      fy_node_create_scalar(fy_node_document(test->node), STRLIT("false"));
 
 #define taprintf(str, ...) fprintf(tap_file, "%*s" str, sub_test * 4, "", ##__VA_ARGS__)
   // This will be used for TAP output
@@ -302,6 +305,8 @@ proceed:
               if (column_type == test->instance->types.json ||
                   column_type == test->instance->types.jsonb) {
                 value = fy_node_build_from_string(fy_node_document(test->node), STRLIT(str_value));
+              } else if (column_type == test->instance->types.boolean) {
+                value = strncmp(str_value, "t", 1) == 0 ? true_scalar : false_scalar;
               } else {
                 value = fy_node_create_scalar(fy_node_document(test->node), STRLIT(str_value));
               }

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -24,7 +24,7 @@ tests:
 - name: simple query
   query: select true as result
   results:
-  - result: t
+  - result: true
 
 - name: failure
   query: selec 1
@@ -64,7 +64,7 @@ tests:
 - name: the table should not exist
   query: select count(*) = 1 as exists from pg_class where relname = 'a'
   results:
-  - exists: f
+  - exists: false
 
 - name: save value as anchor
   query: select 1 as v
@@ -95,7 +95,7 @@ tests:
 - name: multistep's table should not exist
   query: select count(*) = 1 as exists from pg_class where relname = 'tab'
   results:
-  - exists: f
+  - exists: false
 
 - name: nested multistep
   steps:
@@ -103,7 +103,7 @@ tests:
     - query: create table nested_tab()
   - query: select count(*) = 1 as exists from pg_class where relname = 'nested_tab'
     results:
-    - exists: t
+    - exists: true
 
 - name: null
   query: select null::integer as result
@@ -181,7 +181,7 @@ tests:
   params:
   - 0x01
   results:
-  - value: t
+  - value: true
 
 - name: binary format for results
   query: select $1::bool as value

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -26,6 +26,18 @@ tests:
   results:
   - result: true
 
+- name: boolean scalar
+  query: select true as t, false as f from generate_series(1,4)
+  results:
+  - t: true
+    f: false
+  - t: True
+    f: False
+  - t: on
+    f: off
+  - t: y
+    f: n
+
 - name: failure
   query: selec 1
   success: false

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -26,6 +26,12 @@ tests:
   results:
   - result: true
 
+- name: negative test
+  negative: true
+  query: select 0 as result
+  results:
+  - result: 1
+
 - name: boolean scalar
   query: select true as t, false as f from generate_series(1,4)
   results:
@@ -37,6 +43,12 @@ tests:
     f: off
   - t: y
     f: n
+
+- name: string shouldn't be misinterpreted as a boolean scalar
+  query: select 'true' as t
+  negative: true
+  results:
+  - t: on
 
 - name: failure
   query: selec 1


### PR DESCRIPTION
That is, it will put `t` or `f` into results. However, this is inconsistent with the rest of the YAML file where booleans are denoted standard YAML scalars for booleans.

Solution: use `true` and `false` values for booleans

This solution is not yet perfect because the comparison will not work correctly for different variations of the boolean scalars in YAML. Fixing this will require implementing custom comparator and this hinges on being able to (ideally) reuse the standard comparison algorithms with boolean comparison on top of it. I've previously sent a PR: https://github.com/pantoniou/libfyaml/pull/85 but it wasn't merged yet.