### PR TITLE
Problem: omni_httpd tests fail sometimes

### DIFF
--- a/extensions/omni_httpd/tests/http.yml
+++ b/extensions/omni_httpd/tests/http.yml
@@ -20,7 +20,7 @@ instances:
     - set session omni_httpd.no_init = true
     - create extension omni_httpd cascade
     - create extension omni_httpc cascade
-    - delete from omni_httpd.configuration_reloads
+    - call omni_httpd.wait_for_configuration_reloads(1)
     - |
       with
        listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 0) returning id),

--- a/extensions/omni_httpd/tests/http2_reproxy.yml
+++ b/extensions/omni_httpd/tests/http2_reproxy.yml
@@ -8,7 +8,7 @@ instances:
     - set session omni_httpd.no_init = true
     - create extension omni_httpd cascade
     - create extension omni_httpc cascade
-    - delete from omni_httpd.configuration_reloads
+    - call omni_httpd.wait_for_configuration_reloads(1)
     - |
       with
         listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 0) returning id),

--- a/extensions/omni_httpd/tests/role.yml
+++ b/extensions/omni_httpd/tests/role.yml
@@ -7,7 +7,6 @@ instances:
     - set session omni_httpd.no_init = true
     - create extension omni_httpd cascade
     - call omni_httpd.wait_for_configuration_reloads(1)
-    - delete from omni_httpd.configuration_reloads
     - create extension omni_httpc cascade
     - create role test_user inherit in role current_user
     - create role test_user1 inherit in role current_user


### PR DESCRIPTION
The server is not ready to respond for the first request.

Solution: ensure we wait for the initial start of the server