### PR TITLE
Problem: GitHub Actions fails to do the homebrew step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,15 +37,18 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install necessary dependencies
-      # OpenSSL and `timeout` (from coreutils)
+      # OpenSSL
       if: matrix.os == 'macos-12'
       env:
         HOMEBREW_NO_AUTO_UPDATE: "1"
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
         HOMEBREW_NO_INSTALL_CLEANUP: "1"
+      # FIXME: untap step is as per https://github.com/Homebrew/brew/issues/15621#issuecomment-1619266788
+      # Should be fixed with https://github.com/Homebrew/brew/pull/15620
       run: |
+        brew untap -f homebrew/cask
         brew update
-        brew install openssl@3.0 coreutils
+        brew install openssl@3.0
 
     - name: Setup Docker on macOS using Colima, Lima-VM, and Homebrew.
       uses: douglascamata/setup-docker-macos-action@v1-alpha


### PR DESCRIPTION
The error looks like this:

```
  brew update
  brew install openssl@3.0 coreutils
  shell: /bin/bash -e {0}
error: Could not read ffac597fdb6ce8236b5e2da77ab6fbae3d9d9cb7
fatal: revision walk setup failed
error: https://github.com/Homebrew/homebrew-cask did not send all necessary objects
```

Solution: untap casks as per advice found in issues

Also, don't install coreutils anymore as we're not using `timeout` anymore (this was for when we were testing with `curl`)