### PR TITLE
Problem: pg_yregress includes instance initialization in TAP tests

### DIFF
--- a/pg_yregress/instance.c
+++ b/pg_yregress/instance.c
@@ -123,6 +123,7 @@ static bool fetch_types(yinstance *instance) {
 
 yinstance_connect_result yinstance_connect(yinstance *instance) {
   int init_step = 0;
+  int old_tap_counter = tap_counter;
 connect:
   instance->restarted = false;
   if (instance->conn != NULL && PQstatus(instance->conn) != CONNECTION_BAD) {
@@ -141,28 +142,42 @@ connect:
         struct fy_node *init = fy_node_mapping_lookup_by_string(instance->node, STRLIT("init"));
         if (init != NULL) {
           assert(fy_node_is_sequence(init));
-          {
-            int cur_step = 0;
-            void *iter = NULL;
-            struct fy_node *step;
-            while ((step = fy_node_sequence_iterate(init, &iter)) != NULL) {
-              if (cur_step >= init_step) {
-                // We want to keep the effects of these steps and therefore we don't
-                // wrap them into a rolled back transaction.
-                ytest_run_without_transaction((ytest *)fy_node_get_meta(step));
-                if (instance->restarted) {
-                  init_step = cur_step + 1;
-                  goto connect;
-                }
-              }
-              cur_step++;
+          int init_steps = fy_node_sequence_item_count(init);
+          if (init_steps > 0) {
+            // if we are following a restart, don't report the subtest again
+            if (init_step == 0) {
+              fprintf(tap_file, "# Subtest: initialize instance `%.*s`\n",
+                      (int)IOVEC_STRLIT(yinstance_name(instance)));
+              fprintf(tap_file, "    1..%d\n", init_steps);
+              tap_counter = 0;
             }
+            {
+              int cur_step = 0;
+              void *iter = NULL;
+              struct fy_node *step;
+              while ((step = fy_node_sequence_iterate(init, &iter)) != NULL) {
+                if (cur_step >= init_step) {
+                  // We want to keep the effects of these steps and therefore we don't
+                  // wrap them into a rolled back transaction.
+                  ytest_run_without_transaction((ytest *)fy_node_get_meta(step));
+                  if (instance->restarted) {
+                    init_step = cur_step + 1;
+                    goto connect;
+                  }
+                }
+                cur_step++;
+              }
+            }
+            tap_counter = old_tap_counter;
           }
         }
+        tap_counter++;
+        fprintf(tap_file, "ok %d - initialize instance `%.*s`\n", tap_counter,
+                (int)IOVEC_STRLIT(yinstance_name(instance)));
       }
-    }
 
-    return fetch_types(instance) ? yinstance_connect_success : yinstance_connect_error;
+      return fetch_types(instance) ? yinstance_connect_success : yinstance_connect_error;
+    }
   }
 
   return yinstance_connect_failure;
@@ -274,7 +289,7 @@ void instances_cleanup() {
       struct fy_node *instance = fy_node_pair_value(instance_pair);
       yinstance *y_instance = (yinstance *)fy_node_get_meta(instance);
 
-      if (y_instance->ready) {
+      if (y_instance != NULL && y_instance->ready) {
         if (y_instance->managed) {
           char *stop_command;
           asprintf(&stop_command, "%s/pg_ctl stop -D %.*s -m immediate -s", bindir,

--- a/pg_yregress/pg_yregress.c
+++ b/pg_yregress/pg_yregress.c
@@ -367,6 +367,8 @@ static int execute_document(struct fy_document *fyd, FILE *out) {
         // If instance is still not ready, it means there was a recoverable error
         if (!y_instance->ready) {
           // We can't do much about it, bail.
+          fprintf(tap_file, "Bail out! Can't connect to instance `%.*s`",
+                  (int)IOVEC_STRLIT(y_instance->name));
           return false;
         }
         yinstance_connect(y_instance);

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -41,6 +41,7 @@ typedef struct {
   struct fy_node *node;
   bool is_default;
   bool restarted;
+  bool used;
   struct {
     Oid json;
     Oid jsonb;

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -99,7 +99,7 @@ typedef struct {
 } ytest;
 
 bool ytest_run(ytest *test);
-void ytest_run_without_transaction(ytest *test);
+bool ytest_run_without_transaction(ytest *test);
 
 iovec_t ytest_name(ytest *test);
 

--- a/pg_yregress/test.c
+++ b/pg_yregress/test.c
@@ -557,11 +557,11 @@ report:
 }
 
 bool ytest_run(ytest *test) { return ytest_run_internal(NULL, test, false, 0, NULL); }
-void ytest_run_without_transaction(ytest *test) {
+bool ytest_run_without_transaction(ytest *test) {
   // FIXME: this is only used for initializing instances and those create subtests,
   // that's why we use subtest indentation of 1. But the name of the function doesn't really reflect
   // any of this
-  ytest_run_internal(NULL, test, true, 1, NULL);
+  return ytest_run_internal(NULL, test, true, 1, NULL);
 }
 
 iovec_t ytest_name(ytest *test) {


### PR DESCRIPTION
However, they aren't really tests, and they are executed on demand when an instance is initialized.

Solution: make used instance initialization run as proper tests

Closes #197