### PR TITLE
Problem: YAML output of pg_yregress

### DIFF
--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -24,15 +24,25 @@ _managed instance_[^managed] of Postgres.
 
 [^managed]: Postgres instance that is provisioned and deprovisioned by `pg_yregress` tool without any user involvement.
 
-Running `pg_yregress` against this file will output the updated specification.
+Running `pg_yregress` against this file will produce output adhering to [TAP](https://testanything.org), Test Anything Protocol for human or machine consumption.
+
+It is also possible to get the effective YAML of the result of the execution (with results matching actual outcomes as opposed to expectations). It is currently
+_hidden_ in an output to file descriptor 1001 (if one is defined), and if you want to collect or print it, simply pipe that out to a program processing it.
+
+```shell
+$ pg_yregress test.yml 1001>out.yaml
+```
+
+As a result, `out.yaml` should contian something like this:
 
 ```shell
 $ pg_yregress test.yaml
-...
 tests:
 - name: simple
   query: select 1 as value
 ```
+
+As the tool will evolve, we might add other ways to get this information.
 
 ??? tip "The above test can be further simplified"
 
@@ -363,19 +373,3 @@ All test suites receive an implicit `env` mapping at the root that contains a ma
   results:
   - user: */env/USER
 ```
-
-## TAP output
-
-`pg_yregress` can also provide a [TAP](https://testanything.org), Test Anything Protocol for human or machine consumption.
-
-It is currently
-_hidden_ in an output to file descriptor 1001 (if one is defined), and if you want to collect or print it, simply pipe that out to a program processing it (like `tapview'):
-
-```shell
-# Bash
-$ pg_yregress test.yml 1001> >(tapview) 1>/dev/null 2>/dev/null
-# Fish
-$ pg_yregress test.yml 1>/dev/null 2>/dev/null 1001>|tapview
-```
-
-As the tool will evolve, there will likely be another way to activate this.

--- a/pg_yregress/instance.c
+++ b/pg_yregress/instance.c
@@ -240,8 +240,11 @@ void yinstance_start(yinstance *instance) {
     instance->info.managed.port = get_available_inet_port();
 
     char *start_command;
-    asprintf(&start_command, "%s/pg_ctl start -o '-c port=%d' -D %s -s", bindir,
-             instance->info.managed.port, datadir);
+    asprintf(&start_command,
+             "%s/pg_ctl start -o '-c port=%d -c log_destination=stderr -c logging_collector=on -c "
+             "log_filename=postgresql.log' -D "
+             "%s -s >/dev/null",
+             bindir, instance->info.managed.port, datadir);
     system(start_command);
 
     // Create the database
@@ -321,8 +324,12 @@ void register_instances_cleanup() { atexit(instances_cleanup); }
 void restart_instance(yinstance *instance) {
   if (instance->managed) {
     char *restart_command;
-    asprintf(&restart_command, "%s/pg_ctl restart -o '-c port=%d' -D %.*s -s", bindir,
-             instance->info.managed.port, (int)IOVEC_STRLIT(instance->info.managed.datadir));
+    asprintf(&restart_command,
+             "%s/pg_ctl restart -o '-c port=%d -c log_destination=stderr -c logging_collector=on "
+             "-c log_filename=postgresql.log' "
+             "-D %.*s -s >/dev/null",
+             bindir, instance->info.managed.port,
+             (int)IOVEC_STRLIT(instance->info.managed.datadir));
     system(restart_command);
     // Capture new PID
     retrieve_postmaster_pid(instance);


### PR DESCRIPTION
When trying to find an error, it's not very helpful as it requires comparing with the original document. And it can't be compared properly at the moment due to the use of references and some other artifacts.

Solution: make TAP the primary output

And make the original output optional. Make sure postgres logs are collected and not printed out together with the TAP output.