### PR TITLE
Problem: writing non-SQL code in SQL files

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -93,8 +93,21 @@ if(NOT DEFINED PG_CONFIG)
         message(STATUS "Extracting PostgreSQL ${PGVER}")
         file(ARCHIVE_EXTRACT INPUT "${PGDIR}/postgresql-${PGVER_ALIAS}.tar.bz2" DESTINATION ${PGDIR_VERSION})
 
+        # We use this to test multi-language features
+        set(BUILD_POSTGRES_WITH_PYTHON ON)
+
+        if(BUILD_POSTGRES_WITH_PYTHON)
+            find_package(Python COMPONENTS Development)
+            if(Python_FOUND)
+                set(extra_configure_args --with-python)
+            else()
+                message(WARNING "Can't find Python, disabling its support in Postgres. Some tests may fail")
+            endif()
+        endif()
+
         execute_process(
                 COMMAND ./configure --enable-debug --prefix "${PGDIR_VERSION}/build"
+                ${extra_configure_args}
                 WORKING_DIRECTORY "${PGDIR_VERSION}/postgresql-${PGVER_ALIAS}"
                 RESULT_VARIABLE pg_configure_result)
 

--- a/extensions/omni_schema/docs/reference.md
+++ b/extensions/omni_schema/docs/reference.md
@@ -102,10 +102,10 @@ There are two components to this:
 * `omni_schema.languages` tables that defines mapping of languages
 
 The directive part is pretty simple: anywhere in the file, typically a comment
-you can put a __single__ line that looks like this:
+you can put a snippet that looks like this, enclosed within `SQL[[...]]`:
 
 ```python title='times_ten.py'
-# SQL: create function times_ten(a integer) returns integer
+# SQL[[create function times_ten(a integer) returns integer]]
 return a * 10
 ```
 

--- a/extensions/omni_schema/docs/reference.md
+++ b/extensions/omni_schema/docs/reference.md
@@ -47,12 +47,111 @@ The types supported are:
 * **policies**
 * **views**
 
-This extension provides `load_from_fs` function that will reload all such objects from a local on a file system (provided by the `omni_vfs` extension), similar to `migrate_from_fs`:
+This extension provides `load_from_fs` function that will reload all such
+objects from a local on a file system (provided by the `omni_vfs` extension),
+similar to `migrate_from_fs`:
 
 ```postgresql
 select *
 from
-    omni_schema.load_from_fs(omni_vfs.local_fs('/path/to/project/migrations'))
+  omni_schema.load_from_fs(omni_vfs.local_fs('/path/to/project/migrations'))
 ```
 
-Its return type and parameters are currently identical to those of `migrate_from_fs`.
+Its return type and parameters are currently identical to those
+of `migrate_from_fs`.
+
+## Multi-language functions
+
+Object reloading functionality allows one to load functions from '.sql' files
+which can contain SQL or PL/pgSQL functions defined verbatim:
+
+```postgresql title='test_function.sql'
+create function test_function(a integer) returns integer
+  language sql
+as
+$$
+select a > 1
+$$;
+
+create function test_function(a integer) returns integer
+  language plpgsql
+as
+$$
+begin
+  return a > 1;
+end
+$$;
+```
+
+Such files can contain multiple function definitions.
+
+One can note, however, that SQL or PL/pgSQL is not always the best fit for a
+particular problem. This is reflected in the fact that Postgres has an ecosystem
+of other programming languages. However, writing code in those languages inside
+of SQL files is a sub-par development experience: syntax highlighting,
+auto-completion may not work; external tools that work with this languages are
+unaware of this embedding technique.
+
+To address this, this extension provides extensible support for custom
+languages.
+
+There are two components to this:
+
+* in-file function signature directive (conceptually similar to [shebang]
+  (https://en.wikipedia.org/wiki/Shebang_(Unix)))
+* `omni_schema.languages` tables that defines mapping of languages
+
+The directive part is pretty simple: anywhere in the file, typically a comment
+you can put a __single__ line that looks like this:
+
+```python title='times_ten.py'
+# SQL: create function times_ten(a integer) returns integer
+return a * 10
+```
+
+The extension is syntax-agnostic, so it'll look for this type of line anywhere,
+comments, or code. It will then match the extension of the file to the language
+and append the given `create function` line with an
+appropriate `language ... as` construct and pass the contents of the entire file
+to it
+[^single-function-per-file].
+
+!!! tip "Future vision"
+
+    In the future, we want to be able to provide a more sophisticated 
+    functionality to supported languages, like allowing to define _multiple 
+    functions per file_, use native language annotation/type systems to 
+    _infer the SQL function signature_ or detect language when file extensions
+    are ambiguous (like `.pl` for Perl and Prolog).
+
+[^single-function-per-file]: This means you can only define one function per
+file at the moment.
+
+Currently supported languages:
+
+* SQL and PL/pgSQL (`.sql`) [^sql-languages-table]
+* Python (`.py`)
+* Perl (`.pl`, `.trusted.pl`)
+* Tcl (`.tcl`, `.trusted.tcl`)
+* Rust (`.rs`)
+
+If an extension required for the support of a language is not installed, files
+in that language will be skipped and a notice will be given, similar to this
+one:
+
+```
+Extension pltclu required for language pltclu (required for foo.tcl)
+is not installed
+```
+
+The support for languages is configurable through `omni_schema.languages` table:
+
+|             Column | Type        | Description                                                                            |
+|-------------------:|-------------|----------------------------------------------------------------------------------------|
+| **file_extension** | varchar(32) | Filename extension without the preceding <br/>dot. _Examples: `py`, `trusted.pl`, `rs` |
+|       **language** | name        | Language identifier to be used `create function ... language`                          |
+|      **extension** | name        | Extension that implements the language, if required                                    |
+
+[^sql-languages-table]: SQL language is always supported, even if corresponding
+entry is removed from `omni_schema.languages`. This behavior may change in the
+future.

--- a/extensions/omni_schema/omni_schema--0.1.sql
+++ b/extensions/omni_schema/omni_schema--0.1.sql
@@ -1,3 +1,25 @@
+create table languages
+(
+    id             integer primary key generated always as identity,
+    file_extension varchar(32) not null unique,
+    language       name        not null,
+    extension      name
+);
+
+insert
+into
+    languages (file_extension, language, extension)
+values
+    ('sql', 'sql', null),
+    ('pl', 'plperlu', 'plperlu'),
+    ('trusted.pl', 'plperl', 'plperl'),
+    ('py', 'plpython3u', 'plpython3u'),
+    ('tcl', 'pltclu', 'pltclu'),
+    ('trusted.tcl', 'pltcl', 'pltcl'),
+    ('rs', 'plrust', 'plrust');
+
+select pg_catalog.pg_extension_config_dump('languages', '');
+
 create table procs as
     select *
     from
@@ -24,16 +46,32 @@ declare
     rec record;
 begin
     -- Procs
-    create temporary table if not exists _omni_schema_pg_proc on commit drop as
-        select * from pg_proc;
+    if not exists(select
+                  from
+                      pg_class
+                  where
+                      relname = '_omni_schema_pg_proc' and
+                      relkind = 'r' and
+                      relpersistence = 't') then
+        create temporary table if not exists _omni_schema_pg_proc on commit drop as
+            select * from pg_proc;
+    end if;
     for rec in select * from omni_schema.procs
         loop
             execute format('drop function if exists %s', rec.oid::regprocedure);
         end loop;
     delete from omni_schema.procs;
     -- Policies
-    create temporary table if not exists _omni_schema_pg_policy on commit drop as
-        select * from pg_policy;
+    if not exists(select
+                  from
+                      pg_class
+                  where
+                      relname = '_omni_schema_pg_policy' and
+                      relkind = 'r' and
+                      relpersistence = 't') then
+        create temporary table if not exists _omni_schema_pg_policy on commit drop as
+            select * from pg_policy;
+    end if;
     for rec in select
                    policies.*,
                    pg_class.relname
@@ -45,8 +83,16 @@ begin
         end loop;
     delete from omni_schema.policies;
     -- Supported relations
-    create temporary table if not exists _omni_schema_pg_class on commit drop as
-        select * from pg_class;
+    if not exists(select
+                  from
+                      pg_class
+                  where
+                      relname = '_omni_schema_pg_class' and
+                      relkind = 'r' and
+                      relpersistence = 't') then
+        create temporary table if not exists _omni_schema_pg_class on commit drop as
+            select * from pg_class;
+    end if;
     for rec in select
                    class.*,
                    pg_namespace.nspname
@@ -62,13 +108,35 @@ begin
     -- Execute
     for rec in select
                    case when path = '' then '' else path || '/' end || name      as name,
-                   convert_from(omni_vfs.read(fs, path || '/' || name), 'utf-8') as code
+                   convert_from(omni_vfs.read(fs, path || '/' || name), 'utf-8') as code,
+                   language,
+                   extension
                from
-                   omni_vfs.list_recursively(fs, path, max => 10000)
-               where
-                   name like '%.sql'
+                   omni_vfs.list_recursively(fs, path, max => 10000) files
+                   join omni_schema.languages on files.name like concat('%', languages.file_extension)
         loop
-            execute rec.code;
+            if rec.language = 'sql' then
+                execute rec.code;
+            else
+                -- Check if the language is available
+                if not exists(select from pg_extension where extname = rec.extension) then
+                    raise notice 'Extension % required for language % (required for %) is not installed', rec.extension, rec.language, rec.name;
+                    -- Don't include it in the list of loaded files
+                    continue;
+                else
+                    -- Prepare and execute the SQL create function construct
+                    declare
+                        sql_snippet text;
+                    begin
+                        if rec.code ~ 'SQL:(.*\n)' then
+                            sql_snippet := format('%s language %I as %L',
+                                                  substring(rec.code from 'SQL:(.*\n)'), rec.language,
+                                                  rec.code);
+                            execute sql_snippet;
+                        end if;
+                    end;
+                end if;
+            end if;
             return next rec.name;
         end loop;
     -- New procs

--- a/extensions/omni_schema/omni_schema--0.1.sql
+++ b/extensions/omni_schema/omni_schema--0.1.sql
@@ -128,9 +128,9 @@ begin
                     declare
                         sql_snippet text;
                     begin
-                        if rec.code ~ 'SQL:(.*\n)' then
+                        if rec.code ~ 'SQL\[\[.*\]\]' then
                             sql_snippet := format('%s language %I as %L',
-                                                  substring(rec.code from 'SQL:(.*\n)'), rec.language,
+                                                  substring(rec.code from 'SQL\[\[(.*?)\]\]'), rec.language,
                                                   rec.code);
                             execute sql_snippet;
                         end if;

--- a/extensions/omni_schema/tests/fixture/function/4/foo.py
+++ b/extensions/omni_schema/tests/fixture/function/4/foo.py
@@ -1,0 +1,2 @@
+# SQL: create function foo(a integer) returns bool
+return a > 2

--- a/extensions/omni_schema/tests/fixture/function/4/foo.py
+++ b/extensions/omni_schema/tests/fixture/function/4/foo.py
@@ -1,2 +1,2 @@
-# SQL: create function foo(a integer) returns bool
+# SQL[[create function foo(a integer) returns bool]]
 return a > 2

--- a/extensions/omni_schema/tests/fixture/function/unavailable/foo.tcl
+++ b/extensions/omni_schema/tests/fixture/function/unavailable/foo.tcl
@@ -1,2 +1,2 @@
-# SQL: create function foo(a integer) returns bool
+# SQL[[create function foo(a integer) returns bool]]
 return [expr {$1 > 2}]

--- a/extensions/omni_schema/tests/fixture/function/unavailable/foo.tcl
+++ b/extensions/omni_schema/tests/fixture/function/unavailable/foo.tcl
@@ -1,0 +1,2 @@
+# SQL: create function foo(a integer) returns bool
+return [expr {$1 > 2}]

--- a/extensions/omni_schema/tests/test.yml
+++ b/extensions/omni_schema/tests/test.yml
@@ -2,6 +2,7 @@ instances:
   default:
     init:
     - create extension omni_schema cascade
+    - create extension plpython3u
 
 tests:
 
@@ -12,6 +13,8 @@ tests:
     inner join pg_class on pg_class.oid = un.extconfig where extname = 'omni_schema'
     order by relname
   results:
+  - relname: languages
+    extcondition:
   - relname: migrations
     extcondition:
   - relname: migrations_id_seq
@@ -55,7 +58,27 @@ tests:
   - query: select foo()
     success: false
     error: function foo() does not exist
-
+  - name: 4 (language support)
+    query: |
+      select
+        *
+      from
+        omni_schema.load_from_fs(omni_vfs.local_fs('../../../../extensions/omni_schema/tests/fixture/function/4'))
+    results:
+    - load_from_fs: foo.py
+  - query: select foo(1) as f1, foo(3) as f3
+    results:
+    - f1: false # implementation is different
+      f3: true
+  - name: unavailable (language is available but not supproted)
+    query: |
+      select
+       *
+      from
+       omni_schema.load_from_fs(omni_vfs.local_fs('../../../../extensions/omni_schema/tests/fixture/function/unavailable'))
+    notices:
+    - Extension pltclu required for language pltclu (required for foo.tcl) is not installed
+    results: [ ]
 - name: view
   steps:
   - name: 1


### PR DESCRIPTION
Writing code in languages that are not SQL inside of SQL iles is a sub-par development experience: syntax highlighting, auto-completion may not work; external tools that work with this languages are unaware of this embedding technique.

It looks like this:

```sql
create function test(a integer) returns bool language plpython3u as $$
return a > 1
$$
```

Solution: allow writing in native language files

omni_schema will find these files and extract SQL function signature in
them and provision these functions from the files, resulting in a proper
development workflow.