### PR TITLE
Problem: using an older version of libh2o

### DIFF
--- a/cmake/FindH2O.cmake
+++ b/cmake/FindH2O.cmake
@@ -6,6 +6,6 @@ list(APPEND _h2o_options "WITH_MRUBY OFF")
 list(APPEND _h2o_options "DISABLE_LIBUV ON")
 
 cmake_policy(SET CMP0042 NEW)
-CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG 489165c VERSION 2.3.0-489165c OPTIONS "${_h2o_options}")
+CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG 398ea25 VERSION 2.3.0-398ea25 OPTIONS "${_h2o_options}")
 set_property(TARGET libh2o PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET libh2o-evloop PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
There have been some fixes applied to libh2o in the past weeks.

Solution: upgrade to 398ea25