### PR TITLE
Problem: omni_vfs method dispatch

### DIFF
--- a/extensions/omni_vfs/CMakeLists.txt
+++ b/extensions/omni_vfs/CMakeLists.txt
@@ -12,11 +12,20 @@ enable_testing()
 find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
+        omni_vfs_api
+        VERSION 0.1
+        SCHEMA omni_vfs_api
+        RELOCATABLE false
+        TESTS OFF
+        SCRIPTS omni_vfs_api--0.1.sql)
+
+add_postgresql_extension(
         omni_vfs
         VERSION 0.1
         SCHEMA omni_vfs
         RELOCATABLE false
         DEPENDS_ON libpgaug
+        REQUIRES omni_vfs_api
         SCRIPTS omni_vfs--0.1.sql
         SOURCES omni_vfs.c local_fs.c pg_path_v15.c)
 

--- a/extensions/omni_vfs/docs/reference.md
+++ b/extensions/omni_vfs/docs/reference.md
@@ -56,26 +56,26 @@ Results in:
 
 ## API
 
-## `omni_vfs.file` type
+## `omni_vfs_api.file` type
 
 Describes a file entry.
 
-|    Field | Type                 | Description                                   |
-|---------:|----------------------|-----------------------------------------------|
-| **name** | `text`               | File name                                     |
-| **kind** | `omni_vfs.file_kind` | File kind (`file`, `dir`) [^other-file-types] |
+|    Field | Type                     | Description                                   |
+|---------:|--------------------------|-----------------------------------------------|
+| **name** | `text`                   | File name                                     |
+| **kind** | `omni_vfs_api.file_kind` | File kind (`file`, `dir`) [^other-file-types] |
 
-## `omni_vs.file_info` type
+## `omni_vs_api.file_info` type
 
 Describes file meta information.
 
-|           Field | Type                 | Description                                   |
-|----------------:|----------------------|-----------------------------------------------|
-|        **size** | `bigint`             | File size                                     |
-|  **created_at** | `timestamp`          | File creation time (if available)             |
-| **accessed_at** | `timestamp`          | File access time (if available)               |
-| **modified_at** | `timestamp`          | File modification time (if available)         |
-|        **kind** | `omni_vfs.file_kind` | File kind (`file`, `dir`) [^other-file-types] |
+|           Field | Type                     | Description                                   |
+|----------------:|--------------------------|-----------------------------------------------|
+|        **size** | `bigint`                 | File size                                     |
+|  **created_at** | `timestamp`              | File creation time (if available)             |
+| **accessed_at** | `timestamp`              | File access time (if available)               |
+| **modified_at** | `timestamp`              | File modification time (if available)         |
+|        **kind** | `omni_vfs_api.file_kind` | File kind (`file`, `dir`) [^other-file-types] |
 
 ## `omni_vfs.list()`
 
@@ -87,7 +87,7 @@ Lists a directory or a single file.
 |             **path** | `text`            | Path to list. If it is a single file, returns that file           |
 | **fail_unpermitted** | `bool`            | Raise an error if directory can't be open. `true` **by default**. |
 
-Returns a set of `omni_vfs.file` values.
+Returns a set of `omni_vfs_api.file` values.
 
 ## `omni_vfs.list_recursively()`
 
@@ -99,7 +99,7 @@ This is a helper function implemented for all backends that lists all files recu
 |  **path** | `text`            | Path to list. If it is a single file, returns that file            |
 |   **max** | `bigint`          | Limit the number of files to be returned. No limit **by default**. |
 
-Returns a set of `omni_vfs.file`
+Returns a set of `omni_vfs_api.file`
 
 !!! warning "Use caution if the directory might contain a lot of files"
 
@@ -117,7 +117,7 @@ Provides file information (similar to POSIX `stat`)
 |    **fs** | _Filesystem type_ | Filesystem       |
 |  **path** | `text`            | Path to the file |
 
-Returns a value of the `omni_vfs.file_info` type.
+Returns a value of the `omni_vfs_api.file_info` type.
 
 ## `omni_vfs.read()`
 

--- a/extensions/omni_vfs/omni_vfs--0.1.sql
+++ b/extensions/omni_vfs/omni_vfs--0.1.sql
@@ -1,78 +1,3 @@
---- API surface
-create type file_kind as enum ('dir', 'file');
-
-create type file as
-(
-    name text,
-    kind file_kind
-);
-
-create type file_info as
-(
-    size        bigint,
-    created_at  timestamp,
-    accessed_at timestamp,
-    modified_at timestamp,
-    kind        file_kind
-);
-
-create function is_valid_fs(type regtype) returns boolean
-as
-$$
-declare
-    result record;
-begin
-    select into result
-    from
-        pg_proc
-        inner join pg_namespace on pg_namespace.nspname = 'omni_vfs' and pg_proc.pronamespace = pg_namespace.oid
-    where
-        pg_proc.proname = 'list' and
-        pg_proc.proargtypes[0] = type::oid and
-        pg_proc.proargtypes[1] = 'text'::regtype and
-        pg_proc.proargtypes[2] = 'bool'::regtype and
-        pg_proc.proretset and
-        pg_proc.prorettype = 'omni_vfs.file'::regtype;
-    if not found then
-        raise warning '%s does not define valid `omni_vfs.list` function', type::text;
-        return false;
-    end if;
-
-    select into result
-    from
-        pg_proc
-        inner join pg_namespace on pg_namespace.nspname = 'omni_vfs' and pg_proc.pronamespace = pg_namespace.oid
-    where
-        pg_proc.proname = 'file_info' and
-        pg_proc.proargtypes[0] = type::oid and
-        pg_proc.proargtypes[1] = 'text'::regtype and
-        not pg_proc.proretset and
-        pg_proc.prorettype = 'omni_vfs.file_info'::regtype;
-    if not found then
-        raise warning '%s does not define valid `omni_vfs.file_info` function', type::text;
-        return false;
-    end if;
-
-    select into result
-    from
-        pg_proc
-        inner join pg_namespace on pg_namespace.nspname = 'omni_vfs' and pg_proc.pronamespace = pg_namespace.oid
-    where
-        pg_proc.proname = 'read' and
-        pg_proc.proargtypes[0] = type::oid and
-        pg_proc.proargtypes[1] = 'text'::regtype and
-        pg_proc.proargtypes[2] = 'bigint'::regtype and
-        pg_proc.proargtypes[3] = 'int'::regtype and
-        not pg_proc.proretset and
-        pg_proc.prorettype = 'bytea'::regtype;
-    if not found then
-        raise warning '%s does not define valid `omni_vfs.read` function', type::text;
-        return false;
-    end if;
-    return true;
-end;
-$$ language plpgsql;
-
 --- local_fs
 create table local_fs_mounts
 (
@@ -91,11 +16,11 @@ create type local_fs as
 create function local_fs(mount text) returns local_fs as
 'MODULE_PATHNAME' language c;
 
-create function list(fs local_fs, path text, fail_unpermitted boolean default true) returns setof file as
+create function list(fs local_fs, path text, fail_unpermitted boolean default true) returns setof omni_vfs_api.file as
 'MODULE_PATHNAME',
 'local_fs_list' language c;
 
-create function file_info(fs local_fs, path text) returns file_info as
+create function file_info(fs local_fs, path text) returns omni_vfs_api.file_info as
 'MODULE_PATHNAME',
 'local_fs_file_info' language c;
 
@@ -106,7 +31,7 @@ create function read(fs local_fs, path text, file_offset bigint default 0,
 
 -- Helpers
 
-create function list_recursively(fs anyelement, path text, max bigint default null) returns setof file as
+create function list_recursively(fs anyelement, path text, max bigint default null) returns setof omni_vfs_api.file as
 $$
 with
     recursive
@@ -117,7 +42,7 @@ with
                        union all
                        select
                            row ((directory_tree.file).name || '/' || sub_file.name,
-                               sub_file.kind)::omni_vfs.file
+                               sub_file.kind)::omni_vfs_api.file
                        from
                            directory_tree,
                            lateral omni_vfs.list(fs, (directory_tree.file).name, fail_unpermitted => false) as sub_file
@@ -135,7 +60,7 @@ $$
 do
 $$
     begin
-        if not is_valid_fs('local_fs') then
+        if not omni_vfs_api.is_valid_fs('local_fs') then
             raise exception 'local_fs is not a valid vfs';
         end if;
     end;

--- a/extensions/omni_vfs/omni_vfs.c
+++ b/extensions/omni_vfs/omni_vfs.c
@@ -15,7 +15,7 @@ PG_MODULE_MAGIC;
 
 #include "libpgaug.h"
 
-CACHED_OID(file_kind);
-CACHED_OID(file_info);
+CACHED_OID(omni_vfs_api, file_kind);
+CACHED_OID(omni_vfs_api, file_info);
 CACHED_ENUM_OID(file_kind, file)
 CACHED_ENUM_OID(file_kind, dir)

--- a/extensions/omni_vfs/omni_vfs_api--0.1.sql
+++ b/extensions/omni_vfs/omni_vfs_api--0.1.sql
@@ -1,0 +1,73 @@
+create type file_kind as enum ('dir', 'file');
+
+create type file as
+(
+    name text,
+    kind file_kind
+);
+
+create type file_info as
+(
+    size        bigint,
+    created_at  timestamp,
+    accessed_at timestamp,
+    modified_at timestamp,
+    kind        file_kind
+);
+
+create function is_valid_fs(type regtype) returns boolean
+as
+$$
+declare
+    result record;
+begin
+    select into result
+    from
+        pg_proc
+        inner join pg_namespace on pg_namespace.nspname = 'omni_vfs' and pg_proc.pronamespace = pg_namespace.oid
+    where
+        pg_proc.proname = 'list' and
+        pg_proc.proargtypes[0] = type::oid and
+        pg_proc.proargtypes[1] = 'text'::regtype and
+        pg_proc.proargtypes[2] = 'bool'::regtype and
+        pg_proc.proretset and
+        pg_proc.prorettype = 'omni_vfs_api.file'::regtype;
+    if not found then
+        raise warning '%s does not define valid `omni_vfs.list` function', type::text;
+        return false;
+    end if;
+
+    select into result
+    from
+        pg_proc
+        inner join pg_namespace on pg_namespace.nspname = 'omni_vfs' and pg_proc.pronamespace = pg_namespace.oid
+    where
+        pg_proc.proname = 'file_info' and
+        pg_proc.proargtypes[0] = type::oid and
+        pg_proc.proargtypes[1] = 'text'::regtype and
+        not pg_proc.proretset and
+        pg_proc.prorettype = 'omni_vfs_api.file_info'::regtype;
+    if not found then
+        raise warning '%s does not define valid `omni_vfs.file_info` function', type::text;
+        return false;
+    end if;
+
+    select into result
+    from
+        pg_proc
+        inner join pg_namespace on pg_namespace.nspname = 'omni_vfs' and pg_proc.pronamespace = pg_namespace.oid
+    where
+        pg_proc.proname = 'read' and
+        pg_proc.proargtypes[0] = type::oid and
+        pg_proc.proargtypes[1] = 'text'::regtype and
+        pg_proc.proargtypes[2] = 'bigint'::regtype and
+        pg_proc.proargtypes[3] = 'int'::regtype and
+        not pg_proc.proretset and
+        pg_proc.prorettype = 'bytea'::regtype;
+    if not found then
+        raise warning '%s does not define valid `omni_vfs.read` function', type::text;
+        return false;
+    end if;
+    return true;
+end;
+$$ language plpgsql;

--- a/extensions/omni_vfs/tests/local_fs.yml
+++ b/extensions/omni_vfs/tests/local_fs.yml
@@ -1,7 +1,7 @@
 instances:
   default:
     init:
-    - create extension omni_vfs
+    - create extension omni_vfs cascade
 
 tests:
 


### PR DESCRIPTION
omni_vfs uses a technique where we dispatch all FS-specific calls to omni_vfs.method. The problem is that since some of these functions may use types defined in the same schema by the omni_vfs extension, one can't drop the extension without dropping these functions altogether, which may not be a great DX in the sense that if we had to drop/create omni_vfs, we would have to re-create these functions.

Solution: extract omni_vfs types into omni_vfs_api extension

This is not ideal (one more extension) but it does accomplish the job to a degree.

Addresses #219