### PR TITLE
Problem: omni_vfs.file_info errors on file not found

### DIFF
--- a/extensions/omni_vfs/docs/reference.md
+++ b/extensions/omni_vfs/docs/reference.md
@@ -119,6 +119,9 @@ Provides file information (similar to POSIX `stat`)
 
 Returns a value of the `omni_vfs_api.file_info` type.
 
+If file does not exist, returns `null` as there no information to be retrieved
+about it. In all other cases expected to raise an exception.
+
 ## `omni_vfs.read()`
 
 Reads a chunk of the file.

--- a/extensions/omni_vfs/local_fs.c
+++ b/extensions/omni_vfs/local_fs.c
@@ -289,8 +289,12 @@ Datum local_fs_file_info(PG_FUNCTION_ARGS) {
   int err = stat(fullpath, &file_stat);
   if (err != 0) {
     int e = errno;
-    ereport(ERROR, errmsg("can't get file information for %s", fullpath),
-            errdetail("%s", strerror(e)));
+    if (e != ENOENT) {
+      ereport(ERROR, errmsg("can't get file information for %s", fullpath),
+              errdetail("%s", strerror(e)));
+    } else {
+      PG_RETURN_NULL();
+    }
   }
 
   TupleDesc header_tupledesc = TypeGetTupleDesc(file_info_oid(), NULL);

--- a/extensions/omni_vfs/tests/local_fs.yml
+++ b/extensions/omni_vfs/tests/local_fs.yml
@@ -73,6 +73,11 @@ tests:
   - non_zero: true
     kind: file
 
+- name: file info on a non-existent file
+  query: select omni_vfs.file_info(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), 'does not exist')
+  results:
+  - file_info: null
+
 - name: can read file
   query: select length(convert_from(omni_vfs.read(omni_vfs.local_fs('../../../../extensions/omni_vfs'), 'tests/local_fs.yml'), 'utf8')) > 0 as result
   results:


### PR DESCRIPTION
This is difficult to deal with when writing a static HTTP handler because it requires exception handling which is only available in PL/pgSQL or other languages, but not SQL.

Solution: make it return NULL instead

May be not a perfect solution but makes sense for now. May consider a more sophisticated type for it later.