### PR TITLE
Problem: debugging errors in pg_yregress

### DIFF
--- a/extensions/omni_containers/tests/container.yml
+++ b/extensions/omni_containers/tests/container.yml
@@ -52,7 +52,6 @@ tests:
 
 - name: Creating a container that can't be found
   query: select true from omni_containers.docker_container_create('cannotbefound')
-  success: false
   error:
     severity: ERROR
     message: Docker image not found

--- a/extensions/omni_httpd/tests/handler_validity.yml
+++ b/extensions/omni_httpd/tests/handler_validity.yml
@@ -9,27 +9,23 @@ instances:
 tests:
   - query: insert into omni_httpd.handlers (query) values ($$select * from no_such_table$$)
     commit: true # only enforced at the transaction
-    success: false
     error:
       severity: ERROR
       message: invalid query
       detail: relation "no_such_table" does not exist
   - query: insert into omni_httpd.handlers (query) values ($$select request.pth from request$$)
     commit: true # only enforced at the transaction
-    success: false
     error:
       severity: ERROR
       message: invalid query
       detail: column request.pth does not exist
   - query: insert into omni_httpd.handlers (query) values ($$$$)
     commit: true # only enforced at the transaction
-    success: false
     error:
       severity: ERROR
       message: query can only contain one statement
   - query: insert into omni_httpd.handlers (query) values ($$select; select$$);
     commit: true # only enforced at the transaction
-    success: false
     error:
       severity: ERROR
       message: query can only contain one statement

--- a/extensions/omni_httpd/tests/role.yml
+++ b/extensions/omni_httpd/tests/role.yml
@@ -96,7 +96,6 @@ instances:
 tests:
 - name: Can't update it to an arbitrary name
   query: update omni_httpd.handlers set role_name = 'some_role' where role_name = 'test_user'
-  success: false
   error: 'new row for relation "handlers" violates check constraint "handlers_role_name_check"'
 
 - query: delete from omni_httpd.configuration_reloads
@@ -132,7 +131,6 @@ tests:
   - reset role
   - alter role current_user nosuperuser
   - query: update omni_httpd.handlers set role_name = 'anotherrole' where role_name = 'test_user1'
-    success: false
     error: 'new row for relation "handlers" violates check constraint "handlers_role_name_check"'
 
 - name: check current role through the service

--- a/extensions/omni_schema/tests/test.yml
+++ b/extensions/omni_schema/tests/test.yml
@@ -56,7 +56,6 @@ tests:
     results:
     - foo: true
   - query: select foo()
-    success: false
     error: function foo() does not exist
   - name: 4 (language support)
     query: |
@@ -112,7 +111,6 @@ tests:
         omni_schema.load_from_fs(omni_vfs.local_fs('../../../../extensions/omni_schema/tests/fixture/view/3'))
     results: [ ]
   - query: select * from my_view
-    success: false
     error: relation "my_view" does not exist
 
 - name: policy

--- a/extensions/omni_seq/tests/test.yml
+++ b/extensions/omni_seq/tests/test.yml
@@ -55,7 +55,7 @@ tests:
     binary: params
     params:
     - 0x00
-    success: false
+    error: true
   - query: select $1::omni_seq.id_int16 as decoding
     binary: params
     params:

--- a/extensions/omni_vfs/tests/local_fs.yml
+++ b/extensions/omni_vfs/tests/local_fs.yml
@@ -60,12 +60,10 @@ tests:
 - name: can't list files outside of the mount point
   query: select * from omni_vfs.list(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), '..')
   error: requested path is outside of the mount point
-  success: false
 
 - name: can't list files outside of the mount point (matching length)
   query: select * from omni_vfs.list(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), '../../omni_seq/tests')
   error: requested path is outside of the mount point
-  success: false
 
 - name: can get file info
   query: select size > 0 as non_zero, kind from omni_vfs.file_info(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), 'local_fs.yml')
@@ -100,5 +98,4 @@ tests:
   - grant usage on schema omni_vfs to another_user
   - set role another_user
   - query: select omni_vfs.local_fs('.')
-    success: false
     error: new row violates row-level security policy for table "local_fs_mounts"

--- a/extensions/omni_web/tests/params.yml
+++ b/extensions/omni_web/tests/params.yml
@@ -12,7 +12,6 @@ tests:
 
 - name: invalid params should fail
   query: select array ['key']::omni_web.params
-  success: false
   error: value for domain omni_web.params violates check constraint "params_check"
 
 - query: select omni_web.param_get(omni_web.parse_query_string('a=1&a=2'), 'a')

--- a/extensions/omni_web/tests/query_string.yml
+++ b/extensions/omni_web/tests/query_string.yml
@@ -40,5 +40,4 @@ tests:
 
 - name: Ensure it fails with an arbitrary binary
   query: select omni_web.parse_query_string(E'\x0000'::bytea)
-  success: false
   error: 'invalid byte sequence for encoding "UTF8": 0x00'

--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -128,13 +128,13 @@ You can simply test that a certain query will fail:
 tests:
 - name: error
   query: selec 1 as value
-  success: false
+  error: true
 ```
 
-The above will succeed, since we have set `success` to
-`false`.
+The above will succeed, since we have set `error` to `true`.
 
-But how we can test against specific error message? This can be done by adding `error` property:
+But how we can test against specific error message? This can be done by
+setting `error` to a more specific value:
 
 ```yaml
 tests:

--- a/pg_yregress/pg_yregress.c
+++ b/pg_yregress/pg_yregress.c
@@ -62,7 +62,7 @@ static bool populate_ytest_from_fy_node(struct fy_document *fyd, struct fy_node 
                 fy_emit_node_to_string(negative, FYECF_DEFAULT));
         return false;
       }
-      y_test->negative = fy_node_get_boolean(commit);
+      y_test->negative = fy_node_get_boolean(negative);
     }
 
     // Determine the instance to run

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -10,7 +10,7 @@ instances:
     init:
     # Test that we can init using usual test
     - query: select tru
-      success: false
+      error: true
     config: |
       shared_buffers = '194MB'
       log_connections = yes
@@ -56,18 +56,16 @@ tests:
 
 - name: failure
   query: selec 1
-  success: false
+  error: true
 
 - name: error
   query: selec 1
-  success: false
   error:
     severity: ERROR
     message: syntax error at or near "selec"
 
 - name: error message literal
   query: selec 1
-  success: false
   error: syntax error at or near "selec"
 
 - name: error message detail
@@ -77,7 +75,6 @@ tests:
       raise exception 'custom error' using detail = 'custom detail';
     end;
     $$
-  success: false
   error:
     severity: ERROR
     message: custom error
@@ -319,7 +316,7 @@ tests:
   steps:
   - table committed_step1
   - query: table committed_step2
-    success: false
+    error: true
   - table committed_step1_1
   - table committed_step1_2
   - table committed_step2_1
@@ -339,7 +336,7 @@ tests:
 - name: skip (bool)
   skip: false
   query: broken
-  success: false
+  error: true
 
 - name: skip (bool, true)
   skip: true
@@ -364,7 +361,7 @@ tests:
 - name: todo (bool)
   todo: false
   query: broken
-  success: false
+  error: true
 
 - name: todo (without instruction)
   todo: true

--- a/pg_yregress/yaml.c
+++ b/pg_yregress/yaml.c
@@ -7,7 +7,7 @@ bool fy_node_is_boolean(struct fy_node *node) {
   size_t sz;
   const char *val = fy_node_get_scalar(node, &sz);
 #define match(pat)                                                                                 \
-  if (strncmp(val, pat, sz) == 0) {                                                                \
+  if (sz == sizeof(pat) - 1 && strncmp(val, pat, sz) == 0) {                                       \
     return true;                                                                                   \
   }
   // clang-format off
@@ -25,7 +25,7 @@ bool fy_node_is_boolean(struct fy_node *node) {
 bool fy_node_get_boolean(struct fy_node *node) {
   size_t sz;
   const char *val = fy_node_get_scalar(node, &sz);
-#define match(pat) strncmp(val, pat, sz) == 0
+#define match(pat) (sizeof(pat) - 1 == sz) && strncmp(val, pat, sz) == 0
   return (match("y") || match("Y") || match("yes") || match("Yes") || match("YES") ||
           match("true") || match("True") || match("TRUE") || match("on") || match("On") ||
           match("ON"));


### PR DESCRIPTION
When we're writing a test and it fails, the resulting output is not very useful. We get `success` set to `false` but it doesn't really give us much. This requires one to go back to the test definition, add an empty `error` key and re-run the test to get the actual error. After figuring the issue out, this change needs to be reverted

This is hardly practical and is annoying. Not to mention that it is confusing that the single concept of failing is managed by two different keys.

Solution: drop `success` altogether

This is achieved by allowing `error` to be set as a boolean if details of the error are not of interest. Thus, one can set `error` to `true` instead of `success` being set to `false`. When `error` is not set, it will be populated with the scalar representation of the error.

During this implementation, two important bugs were fixed:

* `negative` flag was never set correctly
* matching boolean scalars was failing to do a correct job to ensure full equality of strings, thus "f" was always matching "false" and so on, and that was unintentional.