### PR TITLE
Problem: GitHub Actions fails on macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         brew install openssl@3.0 lima
 
     - name: Setup Docker on macOS using Colima, Lima-VM, and Homebrew.
-      uses: douglascamata/setup-docker-macos-action@v1-alpha.6
+      uses: yrashk/setup-docker-macos-action@brew-edit-fix
       if: matrix.os == 'macos-13' # No need to check on Linux, it's there
 
     - name: Configure Docker host on macOS


### PR DESCRIPTION
```
cat: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/colima.rb: No such file or directory
Error: Process completed with exit code 1.
```

Solution: upgrade to a newer GitHub action to setup Docker