### PR TITLE
Problem: lack of logical grouping of tests in pg_yregress

### DIFF
--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -209,18 +209,48 @@ tests:
     every item is not wrapped into a transaction and the results of each step are visible 
     in the next step.
 
-## Committing Tests
+## Grouping tests
 
-By default, all tests are rolled back to ensure clean environment. However, in some cases, tests need to commit (for example, to test deferred constraints).
+There are cases when a number of tests that don't need to be executed in the
+same transaction (like multi-step) but they do form a logical group
+nevertheless. For example, testing different aspects of a feature, or different
+inputs on the same function.
 
-When this is necessary, the `commit` property of a test should be set to `false`:
+For this, one can use `tests`:
+
+```yaml
+tests:
+- name: fib
+  tests:
+  - query: select fib(0)
+    results:
+    - fib: 0
+  - query: select fib(1)
+    results:
+    - fib: 1
+  - query: select fib(2)
+    results:
+    - fib: 1
+  - query: select fib(3)
+    results:
+    - fib: 2
+```
+
+## Committing tests
+
+By default, all tests are rolled back to ensure clean environment. However, in
+some cases, tests need to commit (for example, to test deferred constraints).
+
+When this is necessary, the `commit` property of a test should be set
+to `false`:
 
 ```yaml
 - query: insert into table values (...)
   commit: true
 ```
 
-This can be also used for multi-step tests. If any of the steps is committed but the multi-step test itself isn't, it'll roll back the uncommitted steps.
+This can be also used for multi-step tests. If any of the steps is committed but
+the multi-step test itself isn't, it'll roll back the uncommitted steps.
 
 ## Notices
 

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -81,7 +81,13 @@ extern struct fy_node *instances;
  */
 void instances_cleanup();
 
-typedef enum { ytest_kind_none, ytest_kind_query, ytest_kind_steps, ytest_kind_restart } ytest_kind;
+typedef enum {
+  ytest_kind_none,
+  ytest_kind_query,
+  ytest_kind_steps,
+  ytest_kind_tests,
+  ytest_kind_restart
+} ytest_kind;
 
 typedef struct {
   iovec_t name;

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -108,6 +108,15 @@ tests:
   results:
   - v: *p
 
+- name: subtests
+  tests:
+  - create table subtests_table ()
+  - query: select * from subtests_table
+    error: relation "subtests_table" does not exist
+  - query: create table subtests_table ()
+    commit: true
+  - select * from subtests_table
+
 - name: multistep
   steps:
   - name: create table


### PR DESCRIPTION
Sometimes test organization can be improved if it was easy to group them, without grouping them into a transaction using steps. Otherwise, the structure of the file becomes very flat and it is hard to find different sections.

Solution: introduce test grouping with `tests` test kind

Closes #236