### PR TITLE
Problem: tedious to configure single instance in pg_yregress

### DIFF
--- a/dynpgext/test/tests/loader_present.yml
+++ b/dynpgext/test/tests/loader_present.yml
@@ -1,7 +1,6 @@
-instances:
-  default:
-    init:
-    - create extension dynpgext_test
+instance:
+  init:
+  - create extension dynpgext_test
 
 tests:
 - name: There should be no loader

--- a/extensions/omni_containers/tests/container.yml
+++ b/extensions/omni_containers/tests/container.yml
@@ -1,12 +1,11 @@
-instances:
-  default:
-    hba: |
-      local all all trust
-      host all all all trust
-    config:
-      listen_addresses: 0.0.0.0
-    init:
-    - create extension omni_containers
+instance:
+  hba: |
+    local all all trust
+    host all all all trust
+  config:
+    listen_addresses: 0.0.0.0
+  init:
+  - create extension omni_containers
 
 tests:
 - name: calling a container with connection information

--- a/extensions/omni_containers/tests/images.yml
+++ b/extensions/omni_containers/tests/images.yml
@@ -1,12 +1,11 @@
-instances:
-  default:
-    hba: |
-      local all all trust
-      host all all all trust
-    config:
-      listen_addresses: 0.0.0.0
-    init:
-    - create extension omni_containers
+instance:
+  hba: |
+    local all all trust
+    host all all all trust
+  config:
+    listen_addresses: 0.0.0.0
+  init:
+  - create extension omni_containers
 
 tests:
 - name: Ensure we pull an image

--- a/extensions/omni_http/tests/test.yml
+++ b/extensions/omni_http/tests/test.yml
@@ -1,7 +1,6 @@
-instances:
-  default:
-    init:
-    - create extension omni_http cascade
+instance:
+  init:
+  - create extension omni_http cascade
 
 tests:
 - name: get header

--- a/extensions/omni_httpc/tests/test.yml
+++ b/extensions/omni_httpc/tests/test.yml
@@ -1,14 +1,14 @@
-instances:
-  default:
-    config:
-      shared_preload_libraries: */env/OMNI_EXT_SO
-      max_worker_processes: 64
-    init:
-    - set session omni_httpd.init_port = 0
-    - create extension omni_httpd cascade
-    - create extension omni_httpc cascade
-    - delete from omni_httpd.configuration_reloads
-    - update omni_httpd.handlers set query = $$
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+    max_worker_processes: 64
+  init:
+  - set session omni_httpd.init_port = 0
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - delete from omni_httpd.configuration_reloads
+  - |
+    update omni_httpd.handlers set query = $$
       select omni_httpd.http_response(json_build_object(
       'method', request.method,
       'path', request.path,
@@ -16,8 +16,8 @@ instances:
       'headers', request.headers::text,
       'body', convert_from(request.body, 'utf-8')
       )) from request
-      $$
-    - call omni_httpd.wait_for_configuration_reloads(1)
+    $$
+  - call omni_httpd.wait_for_configuration_reloads(1)
 
 tests:
 - name: default GET request

--- a/extensions/omni_httpd/tests/cascading_query.yml
+++ b/extensions/omni_httpd/tests/cascading_query.yml
@@ -1,25 +1,24 @@
-instances:
-  default:
-    config:
-      shared_preload_libraries: */env/OMNI_EXT_SO
-      max_worker_processes: 64
-    init:
-    - create extension omni_httpd cascade
-    - create extension omni_httpc cascade
-    - |
-      create table routes
-      (
-          name     text not null,
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+    max_worker_processes: 64
+  init:
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - |
+    create table routes
+    (
+        name     text not null,
           query    text not null,
           priority int  not null
       )
-    - |
-      insert
-      into
-          routes (name, query, priority)
-      values
-          ('test', $$SELECT omni_httpd.http_response(body => 'test') FROM request WHERE request.path = '/test'$$, 1),
-          ('ping', $$SELECT omni_httpd.http_response(body => 'pong') FROM request WHERE request.path = '/ping'$$, 1);
+  - |
+    insert
+    into
+        routes (name, query, priority)
+    values
+        ('test', $$SELECT omni_httpd.http_response(body => 'test') FROM request WHERE request.path = '/test'$$, 1),
+        ('ping', $$SELECT omni_httpd.http_response(body => 'pong') FROM request WHERE request.path = '/ping'$$, 1);
 
 
 tests:

--- a/extensions/omni_httpd/tests/handler_validity.yml
+++ b/extensions/omni_httpd/tests/handler_validity.yml
@@ -1,10 +1,9 @@
-instances:
-  default:
-    config:
-      shared_preload_libraries: */env/OMNI_EXT_SO
-      max_worker_processes: 64
-    init:
-    - create extension omni_httpd cascade
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+    max_worker_processes: 64
+  init:
+  - create extension omni_httpd cascade
 
 tests:
   - query: insert into omni_httpd.handlers (query) values ($$select * from no_such_table$$)

--- a/extensions/omni_httpd/tests/http.yml
+++ b/extensions/omni_httpd/tests/http.yml
@@ -1,68 +1,67 @@
-instances:
-  default:
-    config:
-      shared_preload_libraries: */env/OMNI_EXT_SO
-      max_worker_processes: 64
-    init:
-    - |
-      create table users
-      (
-          id     integer primary key generated always as identity,
-          handle text,
-          name   text
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+    max_worker_processes: 64
+  init:
+  - |
+    create table users
+    (
+        id     integer primary key generated always as identity,
+        handle text,
+        name   text
       )
-    - |
-      insert
-      into
-          users (handle, name)
-      values
-          ('johndoe', 'John')
-    - set session omni_httpd.no_init = true
-    - create extension omni_httpd cascade
-    - create extension omni_httpc cascade
-    - call omni_httpd.wait_for_configuration_reloads(1)
-    - |
-      with
-       listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 0) returning id),
-       handler as (insert into omni_httpd.handlers (query)
-           select
-               omni_httpd.cascading_query(name, query order by priority desc nulls last)
-           from
-               (values
-                    ('hello',
-                     $$SELECT omni_httpd.http_response(headers => array[omni_http.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!')
-          FROM request
-          INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
-         $$, 1),
-                    ('abort', $$select omni_httpd.abort() from request where request.path = '/abort'$$, 1),
-                    ('headers',
-                     $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$,
-                     1),
-                    ('echo',
-                     $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$,
-                     1),
-                    -- proxy proxies to /
-                    ('proxy',
-                     $$select omni_httpd.http_proxy('http://127.0.0.1:' || (select effective_port from omni_httpd.listeners where port = 0)) from request where request.path = '/proxy'$$,
-                     1),
-                    -- This validates that `request CTE` can be casted to http_request
-                    ('http_request',
-                     $$SELECT omni_httpd.http_response(body => request.*::omni_httpd.http_request::text) FROM request WHERE request.path = '/http_request'$$,
-                     1),
-                    ('not_found',
-                     $$SELECT omni_httpd.http_response(status => 404, body => json_build_object('method', request.method, 'path', request.path, 'query_string', request.query_string))
-          FROM request$$, 0)) as routes(name, query, priority)
-           returning id)
-      insert
-      into
-       omni_httpd.listeners_handlers (listener_id, handler_id)
-      select
-       listener.id,
-       handler.id
-      from
-       listener,
-       handler
-    - call omni_httpd.wait_for_configuration_reloads(1)
+  - |
+    insert
+    into
+        users (handle, name)
+    values
+        ('johndoe', 'John')
+  - set session omni_httpd.no_init = true
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - call omni_httpd.wait_for_configuration_reloads(1)
+  - |
+    with
+     listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 0) returning id),
+     handler as (insert into omni_httpd.handlers (query)
+         select
+             omni_httpd.cascading_query(name, query order by priority desc nulls last)
+         from
+             (values
+                  ('hello',
+                   $$SELECT omni_httpd.http_response(headers => array[omni_http.http_header('content-type', 'text/html')], body => 'Hello, <b>' || users.name || '</b>!')
+        FROM request
+        INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
+       $$, 1),
+                  ('abort', $$select omni_httpd.abort() from request where request.path = '/abort'$$, 1),
+                  ('headers',
+                   $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$,
+                   1),
+                  ('echo',
+                   $$SELECT omni_httpd.http_response(body => request.body) FROM request WHERE request.path = '/echo'$$,
+                   1),
+                  -- proxy proxies to /
+                  ('proxy',
+                   $$select omni_httpd.http_proxy('http://127.0.0.1:' || (select effective_port from omni_httpd.listeners where port = 0)) from request where request.path = '/proxy'$$,
+                   1),
+                  -- This validates that `request CTE` can be casted to http_request
+                  ('http_request',
+                   $$SELECT omni_httpd.http_response(body => request.*::omni_httpd.http_request::text) FROM request WHERE request.path = '/http_request'$$,
+                   1),
+                  ('not_found',
+                   $$SELECT omni_httpd.http_response(status => 404, body => json_build_object('method', request.method, 'path', request.path, 'query_string', request.query_string))
+        FROM request$$, 0)) as routes(name, query, priority)
+         returning id)
+    insert
+    into
+     omni_httpd.listeners_handlers (listener_id, handler_id)
+    select
+     listener.id,
+     handler.id
+    from
+     listener,
+     handler
+  - call omni_httpd.wait_for_configuration_reloads(1)
 
 tests:
 - name: query dump

--- a/extensions/omni_httpd/tests/http2_reproxy.yml
+++ b/extensions/omni_httpd/tests/http2_reproxy.yml
@@ -1,25 +1,24 @@
-instances:
-  default:
-    config:
-      shared_preload_libraries: */env/OMNI_EXT_SO
-      max_worker_processes: 64
-      omni_httpd.http_workers: 2
-    init:
-    - set session omni_httpd.no_init = true
-    - create extension omni_httpd cascade
-    - create extension omni_httpc cascade
-    - call omni_httpd.wait_for_configuration_reloads(1)
-    - |
-      with
-        listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 0) returning id),
-        handler as (insert into omni_httpd.handlers (query)
-                    select
-                      omni_httpd.cascading_query(name, query order by priority desc nulls last)
-                    from
-                      (values
-                      ('sleep',
-                      $$select omni_httpd.http_response(pg_backend_pid()::text || pg_sleep(2)::text) from request where request.path = '/sleep'$$, 1),
-                      ('other',
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+    max_worker_processes: 64
+    omni_httpd.http_workers: 2
+  init:
+  - set session omni_httpd.no_init = true
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - call omni_httpd.wait_for_configuration_reloads(1)
+  - |
+    with
+      listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 0) returning id),
+      handler as (insert into omni_httpd.handlers (query)
+                  select
+                    omni_httpd.cascading_query(name, query order by priority desc nulls last)
+                  from
+                    (values
+                    ('sleep',
+                    $$select omni_httpd.http_response(pg_backend_pid()::text || pg_sleep(2)::text) from request where request.path = '/sleep'$$, 1),
+                    ('other',
                       $$select omni_httpd.http_response(pg_backend_pid()::text)$$,
                       1)) as routes(name, query, priority)
                       returning id)
@@ -31,7 +30,7 @@ instances:
       from
         listener,
         handler
-    - call omni_httpd.wait_for_configuration_reloads(1)
+  - call omni_httpd.wait_for_configuration_reloads(1)
 
 tests:
   - steps:

--- a/extensions/omni_httpd/tests/http_response.yml
+++ b/extensions/omni_httpd/tests/http_response.yml
@@ -1,10 +1,9 @@
-instances:
-  default:
-    config:
-      shared_preload_libraries: */env/OMNI_EXT_SO
-      max_worker_processes: 64
-    init:
-    - create extension omni_httpd cascade
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+    max_worker_processes: 64
+  init:
+  - create extension omni_httpd cascade
 
 tests:
 - name: NULL status

--- a/extensions/omni_httpd/tests/role.yml
+++ b/extensions/omni_httpd/tests/role.yml
@@ -1,97 +1,96 @@
-instances:
-  default:
-    config:
-      shared_preload_libraries: */env/OMNI_EXT_SO
-      max_worker_processes: 64
-    init:
-    - set session omni_httpd.no_init = true
-    - create extension omni_httpd cascade
-    - call omni_httpd.wait_for_configuration_reloads(1)
-    - create extension omni_httpc cascade
-    - create role test_user inherit in role current_user
-    - create role test_user1 inherit in role current_user
-    - create role anotherrole inherit in role current_user
-    - alter role anotherrole nosuperuser
-    - create role another_superuser superuser
-    - set role test_user
-    - |
-      create function reset_role() returns omni_httpd.http_outcome
-      as
-      $$
-       declare
-           outcome omni_httpd.http_outcome;
-       begin
-           begin
-               reset role;
-               select omni_httpd.http_response('ok') into outcome;
-           exception
-               when others then
-                   select omni_httpd.http_response('failed resetting') into outcome;
-           end;
-           return outcome;
-       end;
-       $$ language plpgsql
-    - |
-      create function set_role_none() returns omni_httpd.http_outcome
-      as
-      $$
-      declare
-          outcome omni_httpd.http_outcome;
-      begin
-          begin
-              set role none;
-              select omni_httpd.http_response('ok') into outcome;
-          exception
-              when others then
-                  select omni_httpd.http_response('failed setting to none') into outcome;
-          end;
-          return outcome;
-      end;
-      $$ language plpgsql
-    - |
-      create function set_superuser_role() returns omni_httpd.http_outcome
-      as
-      $$
-      declare
-          outcome omni_httpd.http_outcome;
-      begin
-          begin
-              set role another_superuser;
-              select omni_httpd.http_response('ok') into outcome;
-          exception
-              when others then
-                  select omni_httpd.http_response('failed setting superuser role') into outcome;
-          end;
-          return outcome;
-      end;
-      $$ language plpgsql
-    - |
-      with
-          listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 0) returning id),
-          handler as (insert into omni_httpd.handlers (query)
-              values
-                  ($$select
-                           (case
-                             when request.path = '/' then
-                               omni_httpd.http_response(body => current_user::text)
-                             when request.path = '/reset-role' then
-                               reset_role()
-                             when request.path = '/set-role-none' then
-                               set_role_none()
-                             when request.path = '/superuser-role' then
-                               set_superuser_role()
-                            end)
-                          from request$$) returning id)
-      insert
-      into
-          omni_httpd.listeners_handlers (listener_id, handler_id)
-      select
-          listener.id,
-          handler.id
-      from
-          listener,
-          handler
-    - call omni_httpd.wait_for_configuration_reloads(1)
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+    max_worker_processes: 64
+  init:
+  - set session omni_httpd.no_init = true
+  - create extension omni_httpd cascade
+  - call omni_httpd.wait_for_configuration_reloads(1)
+  - create extension omni_httpc cascade
+  - create role test_user inherit in role current_user
+  - create role test_user1 inherit in role current_user
+  - create role anotherrole inherit in role current_user
+  - alter role anotherrole nosuperuser
+  - create role another_superuser superuser
+  - set role test_user
+  - |
+    create function reset_role() returns omni_httpd.http_outcome
+    as
+    $$
+     declare
+         outcome omni_httpd.http_outcome;
+     begin
+         begin
+             reset role;
+             select omni_httpd.http_response('ok') into outcome;
+         exception
+             when others then
+                 select omni_httpd.http_response('failed resetting') into outcome;
+         end;
+         return outcome;
+     end;
+     $$ language plpgsql
+  - |
+    create function set_role_none() returns omni_httpd.http_outcome
+    as
+    $$
+    declare
+        outcome omni_httpd.http_outcome;
+    begin
+        begin
+            set role none;
+            select omni_httpd.http_response('ok') into outcome;
+        exception
+            when others then
+                select omni_httpd.http_response('failed setting to none') into outcome;
+        end;
+        return outcome;
+    end;
+    $$ language plpgsql
+  - |
+    create function set_superuser_role() returns omni_httpd.http_outcome
+    as
+    $$
+    declare
+        outcome omni_httpd.http_outcome;
+    begin
+        begin
+            set role another_superuser;
+            select omni_httpd.http_response('ok') into outcome;
+        exception
+            when others then
+                select omni_httpd.http_response('failed setting superuser role') into outcome;
+        end;
+        return outcome;
+    end;
+    $$ language plpgsql
+  - |
+    with
+        listener as (insert into omni_httpd.listeners (address, port) values ('127.0.0.1', 0) returning id),
+        handler as (insert into omni_httpd.handlers (query)
+            values
+                ($$select
+                         (case
+                           when request.path = '/' then
+                             omni_httpd.http_response(body => current_user::text)
+                           when request.path = '/reset-role' then
+                             reset_role()
+                           when request.path = '/set-role-none' then
+                             set_role_none()
+                           when request.path = '/superuser-role' then
+                             set_superuser_role()
+                          end)
+                        from request$$) returning id)
+    insert
+    into
+        omni_httpd.listeners_handlers (listener_id, handler_id)
+    select
+        listener.id,
+        handler.id
+    from
+        listener,
+        handler
+  - call omni_httpd.wait_for_configuration_reloads(1)
 
 tests:
 - name: Can't update it to an arbitrary name

--- a/extensions/omni_mimetypes/tests/test.yml
+++ b/extensions/omni_mimetypes/tests/test.yml
@@ -1,7 +1,6 @@
-instances:
-  default:
-    init:
-    - create extension omni_mimetypes
+instance:
+  init:
+  - create extension omni_mimetypes
 
 tests:
 

--- a/extensions/omni_schema/tests/test.yml
+++ b/extensions/omni_schema/tests/test.yml
@@ -1,8 +1,7 @@
-instances:
-  default:
-    init:
-    - create extension omni_schema cascade
-    - create extension plpython3u
+instance:
+  init:
+  - create extension omni_schema cascade
+  - create extension plpython3u
 
 tests:
 

--- a/extensions/omni_seq/tests/test.yml
+++ b/extensions/omni_seq/tests/test.yml
@@ -1,7 +1,6 @@
-instances:
-  default:
-    init:
-    - create extension omni_seq
+instance:
+  init:
+  - create extension omni_seq
 
 tests:
 - name: creating a distributed ID

--- a/extensions/omni_vfs/tests/local_fs.yml
+++ b/extensions/omni_vfs/tests/local_fs.yml
@@ -1,7 +1,6 @@
-instances:
-  default:
-    init:
-    - create extension omni_vfs cascade
+instance:
+  init:
+  - create extension omni_vfs cascade
 
 tests:
 

--- a/extensions/omni_web/tests/params.yml
+++ b/extensions/omni_web/tests/params.yml
@@ -1,7 +1,6 @@
-instances:
- default:
-  init:
-  - create extension omni_web
+instance:
+ init:
+ - create extension omni_web
 
 tests:
 

--- a/extensions/omni_web/tests/query_string.yml
+++ b/extensions/omni_web/tests/query_string.yml
@@ -1,7 +1,6 @@
-instances:
- default:
-  init:
-  - create extension omni_web
+instance:
+ init:
+ - create extension omni_web
 
 tests:
 

--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -403,6 +403,18 @@ instances:
 
 This is useful when tests impose special authentication requirements.
 
+### Single instance configuration
+
+In case when only one instance is necessary but it needs to be configured,
+instead of using `instances` and naming the default instance, one can use
+`instance` key instead:
+
+```yaml
+instance:
+  init:
+  - create extension ltree
+```
+
 ## Configuring test suite
 
 In certain cases, it may be useful to pass some configuration information to the


### PR DESCRIPTION
This is because we have to name the instance and we get a whole new level of nesting for it.

Solution: allow single instances to be conigured with `instance`