### PR TITLE
Problem: limiting file name extension to 32 characters

### DIFF
--- a/extensions/omni_schema/docs/reference.md
+++ b/extensions/omni_schema/docs/reference.md
@@ -146,11 +146,11 @@ is not installed
 
 The support for languages is configurable through `omni_schema.languages` table:
 
-|             Column | Type        | Description                                                                            |
-|-------------------:|-------------|----------------------------------------------------------------------------------------|
-| **file_extension** | varchar(32) | Filename extension without the preceding <br/>dot. _Examples: `py`, `trusted.pl`, `rs` |
-|       **language** | name        | Language identifier to be used `create function ... language`                          |
-|      **extension** | name        | Extension that implements the language, if required                                    |
+|             Column | Type | Description                                                                            |
+|-------------------:|------|----------------------------------------------------------------------------------------|
+| **file_extension** | text | Filename extension without the preceding <br/>dot. _Examples: `py`, `trusted.pl`, `rs` |
+|       **language** | name | Language identifier to be used `create function ... language`                          |
+|      **extension** | name | Extension that implements the language, if required                                    |
 
 [^sql-languages-table]: SQL language is always supported, even if corresponding
 entry is removed from `omni_schema.languages`. This behavior may change in the

--- a/extensions/omni_schema/omni_schema--0.1.sql
+++ b/extensions/omni_schema/omni_schema--0.1.sql
@@ -1,7 +1,7 @@
 create table languages
 (
     id             integer primary key generated always as identity,
-    file_extension varchar(32) not null unique,
+    file_extension text not null unique,
     language       name        not null,
     extension      name
 );


### PR DESCRIPTION
It's kind of pointless. Why? It is not going to affect its storage layout.

Solution: switch it to `text`