### PR TITLE
Problem: macos builds on GitHub Actions fail again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         brew install openssl@3.0 lima
 
     - name: Setup Docker on macOS using Colima, Lima-VM, and Homebrew.
-      uses: yrashk/setup-docker-macos-action@brew-edit-fix
+      uses: douglascamata/setup-docker-macos-action@v1-alpha.9
       if: matrix.os == 'macos-13' # No need to check on Linux, it's there
 
     - name: Configure Docker host on macOS


### PR DESCRIPTION
```
time="2023-08-23T15:04:26Z" level=warning msg="QEMU binary
\"/Users/runner/.colima/_wrapper/4e1b408f843d1c63afbbdcf80c40e4c88d33509f/bin/qemu-system-x86_64\"
is not properly signed with the \"com.apple.security.hypervisor\"
entitlement"
```

Solution: try upgrading to the latest GitHub Action for setting up Colima