### PR TITLE
Problem: subtests with a failing scalar test loop indefnitely

### DIFF
--- a/pg_yregress/test.c
+++ b/pg_yregress/test.c
@@ -426,6 +426,15 @@ proceed:
         // Stop proceeding further if the step has failed
         if (!step_success) {
           step_failed = true;
+          // TODO: improve this
+          // This is a compensation mechanism for the following behavior:
+          // When a scalar test fails, it's replaced by a mapping with an error
+          // However, because it does remove/insert for this replacement
+          // (see https://github.com/pantoniou/libfyaml/issues/84)
+          // `iter` still points to the removed node but not the new one
+          // However, the code doing this updates `y_test->node`, so we'll use
+          // that to ensure we're on the right element of the sequence.
+          iter = (void *)y_test->node;
         } else {
           if (errored) {
             // Reset the transaction
@@ -446,6 +455,7 @@ proceed:
           }
         }
       } else {
+        // Skip tests after a failure
         tap_counter++;
         taprintf("ok %d - %.*s # SKIP\n", tap_counter, (int)IOVEC_STRLIT(ytest_name(y_test)));
       }


### PR DESCRIPTION
This happens if we have something like this:

```yaml
- tests:
  - slect
```

Solution: ensure to mitigate lack of node replacement

Currently, because of lack of node replacement
(https://github.com/pantoniou/libfyaml/issues/84), when scalar nodes are replaced with mapping (containing the error), they are actually removed and a new node is inserted. However, this came into conflict with subtest iteration.