### PR TITLE
Problem: process group stuff in pg_yregress

### DIFF
--- a/pg_yregress/instance.c
+++ b/pg_yregress/instance.c
@@ -295,9 +295,6 @@ void yinstance_start(yinstance *instance) {
     // Get postmaster PID
     retrieve_postmaster_pid(instance);
 
-    // Link postmaster into our process group
-    setpgid(instance->pid, pgid);
-
     instance->ready = true;
   }
 }
@@ -346,9 +343,6 @@ void restart_instance(yinstance *instance) {
     system(restart_command);
     // Capture new PID
     retrieve_postmaster_pid(instance);
-
-    // Link new postmaster into our process group
-    setpgid(instance->pid, pgid);
   }
   instance->restarted = true;
 }

--- a/pg_yregress/pg_yregress.c
+++ b/pg_yregress/pg_yregress.c
@@ -508,8 +508,6 @@ static void get_path_from_popen(char *cmd, char *path) {
   }
 }
 
-pid_t pgid;
-
 extern char **environ;
 
 int main(int argc, char **argv) {
@@ -519,10 +517,7 @@ int main(int argc, char **argv) {
     // Before starting, we try to open special FD for tap file
     tap_file = stdout;
 
-    // Get a process group
-    pgid = getpgrp();
-
-    // Hanle signals for cleanup, etc.
+    // Handle signals for cleanup, etc.
     register_sighandler();
 
     // Retrieve hard-coded Postgres configuration

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -6,11 +6,6 @@
 #include <libfyaml.h>
 #include <libpq-fe.h>
 
-/**
- * pg_yregress' process group
- */
-extern pid_t pgid;
-
 typedef struct {
   const char *base;
   size_t len;


### PR DESCRIPTION
It is currently ineffective at solving the problem we have in the test setup. If ctest is killed with SIGINT, the children don't catch that, and cleanup is not performed.

Solution: remove this to prevent confusion