### PR TITLE
Problem: omni_vfs_api naming

### DIFF
--- a/extensions/omni_vfs/CMakeLists.txt
+++ b/extensions/omni_vfs/CMakeLists.txt
@@ -12,12 +12,12 @@ enable_testing()
 find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
-        omni_vfs_api
+        omni_vfs_types_v1
         VERSION 0.1
-        SCHEMA omni_vfs_api
+        SCHEMA omni_vfs_types_v1
         RELOCATABLE false
         TESTS OFF
-        SCRIPTS omni_vfs_api--0.1.sql)
+        SCRIPTS omni_vfs_types_v1--0.1.sql)
 
 add_postgresql_extension(
         omni_vfs
@@ -25,7 +25,7 @@ add_postgresql_extension(
         SCHEMA omni_vfs
         RELOCATABLE false
         DEPENDS_ON libpgaug
-        REQUIRES omni_vfs_api
+        REQUIRES omni_vfs_types_v1
         SCRIPTS omni_vfs--0.1.sql
         SOURCES omni_vfs.c local_fs.c pg_path_v15.c)
 

--- a/extensions/omni_vfs/docs/reference.md
+++ b/extensions/omni_vfs/docs/reference.md
@@ -56,14 +56,14 @@ Results in:
 
 ## API
 
-## `omni_vfs_api.file` type
+## `omni_vfs_types_v1.file` type
 
 Describes a file entry.
 
 |    Field | Type                     | Description                                   |
 |---------:|--------------------------|-----------------------------------------------|
 | **name** | `text`                   | File name                                     |
-| **kind** | `omni_vfs_api.file_kind` | File kind (`file`, `dir`) [^other-file-types] |
+| **kind** | `omni_vfs_types_v1.file_kind` | File kind (`file`, `dir`) [^other-file-types] |
 
 ## `omni_vs_api.file_info` type
 
@@ -75,7 +75,7 @@ Describes file meta information.
 |  **created_at** | `timestamp`              | File creation time (if available)             |
 | **accessed_at** | `timestamp`              | File access time (if available)               |
 | **modified_at** | `timestamp`              | File modification time (if available)         |
-|        **kind** | `omni_vfs_api.file_kind` | File kind (`file`, `dir`) [^other-file-types] |
+|        **kind** | `omni_vfs_types_v1.file_kind` | File kind (`file`, `dir`) [^other-file-types] |
 
 ## `omni_vfs.list()`
 
@@ -87,7 +87,7 @@ Lists a directory or a single file.
 |             **path** | `text`            | Path to list. If it is a single file, returns that file           |
 | **fail_unpermitted** | `bool`            | Raise an error if directory can't be open. `true` **by default**. |
 
-Returns a set of `omni_vfs_api.file` values.
+Returns a set of `omni_vfs_types_v1.file` values.
 
 ## `omni_vfs.list_recursively()`
 
@@ -99,7 +99,7 @@ This is a helper function implemented for all backends that lists all files recu
 |  **path** | `text`            | Path to list. If it is a single file, returns that file            |
 |   **max** | `bigint`          | Limit the number of files to be returned. No limit **by default**. |
 
-Returns a set of `omni_vfs_api.file`
+Returns a set of `omni_vfs_types_v1.file`
 
 !!! warning "Use caution if the directory might contain a lot of files"
 
@@ -117,7 +117,7 @@ Provides file information (similar to POSIX `stat`)
 |    **fs** | _Filesystem type_ | Filesystem       |
 |  **path** | `text`            | Path to the file |
 
-Returns a value of the `omni_vfs_api.file_info` type.
+Returns a value of the `omni_vfs_types_v1.file_info` type.
 
 If file does not exist, returns `null` as there no information to be retrieved
 about it. In all other cases expected to raise an exception.

--- a/extensions/omni_vfs/omni_vfs--0.1.sql
+++ b/extensions/omni_vfs/omni_vfs--0.1.sql
@@ -16,11 +16,11 @@ create type local_fs as
 create function local_fs(mount text) returns local_fs as
 'MODULE_PATHNAME' language c;
 
-create function list(fs local_fs, path text, fail_unpermitted boolean default true) returns setof omni_vfs_api.file as
+create function list(fs local_fs, path text, fail_unpermitted boolean default true) returns setof omni_vfs_types_v1.file as
 'MODULE_PATHNAME',
 'local_fs_list' language c;
 
-create function file_info(fs local_fs, path text) returns omni_vfs_api.file_info as
+create function file_info(fs local_fs, path text) returns omni_vfs_types_v1.file_info as
 'MODULE_PATHNAME',
 'local_fs_file_info' language c;
 
@@ -31,7 +31,7 @@ create function read(fs local_fs, path text, file_offset bigint default 0,
 
 -- Helpers
 
-create function list_recursively(fs anyelement, path text, max bigint default null) returns setof omni_vfs_api.file as
+create function list_recursively(fs anyelement, path text, max bigint default null) returns setof omni_vfs_types_v1.file as
 $$
 with
     recursive
@@ -42,7 +42,7 @@ with
                        union all
                        select
                            row ((directory_tree.file).name || '/' || sub_file.name,
-                               sub_file.kind)::omni_vfs_api.file
+                               sub_file.kind)::omni_vfs_types_v1.file
                        from
                            directory_tree,
                            lateral omni_vfs.list(fs, (directory_tree.file).name, fail_unpermitted => false) as sub_file
@@ -60,7 +60,7 @@ $$
 do
 $$
     begin
-        if not omni_vfs_api.is_valid_fs('local_fs') then
+        if not omni_vfs_types_v1.is_valid_fs('local_fs') then
             raise exception 'local_fs is not a valid vfs';
         end if;
     end;

--- a/extensions/omni_vfs/omni_vfs.c
+++ b/extensions/omni_vfs/omni_vfs.c
@@ -15,7 +15,7 @@ PG_MODULE_MAGIC;
 
 #include "libpgaug.h"
 
-CACHED_OID(omni_vfs_api, file_kind);
-CACHED_OID(omni_vfs_api, file_info);
+CACHED_OID(omni_vfs_types_v1, file_kind);
+CACHED_OID(omni_vfs_types_v1, file_info);
 CACHED_ENUM_OID(file_kind, file)
 CACHED_ENUM_OID(file_kind, dir)

--- a/extensions/omni_vfs/omni_vfs_types_v1--0.1.sql
+++ b/extensions/omni_vfs/omni_vfs_types_v1--0.1.sql
@@ -31,7 +31,7 @@ begin
         pg_proc.proargtypes[1] = 'text'::regtype and
         pg_proc.proargtypes[2] = 'bool'::regtype and
         pg_proc.proretset and
-        pg_proc.prorettype = 'omni_vfs_api.file'::regtype;
+        pg_proc.prorettype = 'omni_vfs_types_v1.file'::regtype;
     if not found then
         raise warning '%s does not define valid `omni_vfs.list` function', type::text;
         return false;
@@ -46,7 +46,7 @@ begin
         pg_proc.proargtypes[0] = type::oid and
         pg_proc.proargtypes[1] = 'text'::regtype and
         not pg_proc.proretset and
-        pg_proc.prorettype = 'omni_vfs_api.file_info'::regtype;
+        pg_proc.prorettype = 'omni_vfs_types_v1.file_info'::regtype;
     if not found then
         raise warning '%s does not define valid `omni_vfs.file_info` function', type::text;
         return false;


### PR DESCRIPTION
There are two problems with it:

1. It implies a set of functions for VFS yet doesn't have them
2. Since Postgres schemas are not versioned, it's impossible to depend on diferent versions of VFS types when the ecosystem of filesystem will grow

Solution: rename to omni_vfs_types_v1

`types`, while not perfect, captures the essence of the extension better and versioning the name allows versioned schema for types so that different extensions can depend on different versions if needed.