### PR TITLE
Problem: omni_httpc compile-time warning

### DIFF
--- a/extensions/omni_httpc/omni_httpc.c
+++ b/extensions/omni_httpc/omni_httpc.c
@@ -225,7 +225,8 @@ struct request {
 };
 
 // Called when response body chunk is being received
-static int on_body(h2o_httpclient_t *client, const char *errstr) {
+static int on_body(h2o_httpclient_t *client, const char *errstr, h2o_header_t *trailers,
+                   size_t num_trailers) {
   struct request *req = (struct request *)client->data;
 
   // If there's an error, report it


### PR DESCRIPTION
```
extensions/omni_httpc/omni_httpc.c:292:10:
warning: incompatible function pointer types
returning 'int (h2o_httpclient_t *, const char *)'
(aka 'int (struct st_h2o_httpclient_t *, const char *)')
from a function with result type 'h2o_httpclient_body_cb'
(aka 'int (*)(struct st_h2o_httpclient_t *, const char *, struct st_h2o_header_t *, unsigned long)') [-Wincompatible-function-pointer-types]
  return on_body;
```

Solution: use the most recently introduced signature for `on_body`

One of the recent changes to h2o changed it:
https://github.com/h2o/h2o/commit/a9487cbde08163e540cffcea94c90243c57857a7