### PR TITLE
Problem: omni_http.http_request and http_response types

### DIFF
--- a/extensions/omni_http/omni_http--0.1.sql
+++ b/extensions/omni_http/omni_http--0.1.sql
@@ -39,20 +39,3 @@ limit 1
 $$
     set search_path to '@extschema@'
     language sql;
-
-create type http_request as
-(
-    method       http_method,
-    path         text,
-    query_string text,
-    body         bytea,
-    headers      http_headers
-);
-
-
-create type http_response as
-(
-    body    bytea,
-    status  smallint,
-    headers http_headers
-);


### PR DESCRIPTION
These types are currently unusued and httpd/httpc use their own types. Presence of these types is confusing.

Solution: remove them for the time being
and figure out if we can unite httpd/httpc types later.