### PR TITLE
Problem: difficult to test request handling

### DIFF
--- a/extensions/omni_httpd/docs/intro.md
+++ b/extensions/omni_httpd/docs/intro.md
@@ -128,3 +128,25 @@ headers omni_http.http_header[]
     that's because it is still work in progress. Please consider contributing if you feel up to it.
 
     Also, [omni_web](/omni_web/intro) provides complementary higher-level functionality.
+
+In order to test your request handlers without having to run actual HTTP
+requests against it, one can use `omni_httpd.http_request` function to compose
+requests:
+
+```postgresql
+with
+    request as (select (omni_httpd.http_request('/')).*)
+select
+    omni_httpd.http_response(request.path)
+from
+    request
+```
+
+|        Parameter | Type                   | Description                | Default     |
+|-----------------:|------------------------|----------------------------|-------------|
+|         **path** | text                   | Path                       | None        | 
+|       **method** | omni_http.http_method  | HTTP method [^http-method] | `GET`       | 
+| **query_string** | text                   | Query string               | `NULL`      | 
+|      **headers** | omni_http.http_headers | An array of HTTP headers   | empty array |
+|         **body** | bytea                  | Request body               | `NULL`      |
+ 

--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -9,6 +9,15 @@ create type http_request as
     headers      http_headers
 );
 
+create function http_request(path text, method omni_http.http_method default 'GET', query_string text default null,
+                             body bytea default null,
+                             headers http_headers default array []::http_headers)
+    returns http_request
+    language sql
+as
+$$
+select row (method, path, query_string, body, headers)
+$$;
 
 create type http_response as
 (

--- a/extensions/omni_httpd/tests/http_request.yml
+++ b/extensions/omni_httpd/tests/http_request.yml
@@ -1,0 +1,24 @@
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+    max_worker_processes: 64
+  init:
+  - create extension omni_httpd cascade
+
+tests:
+- name: fits `request` CTE
+  query: |
+    with
+      request as (select (omni_httpd.http_request('/')).*)
+    select
+      convert_from(response.body, 'utf-8') as body,
+      response.status,
+     (select json_agg(json_build_object(h.name, h.value)) from unnest(response.headers) h) as headers
+    from
+      request,
+      lateral (select (omni_httpd.http_response(request.path)::omni_httpd.http_response).*) response
+  results:
+    - body: /
+      status: 200
+      headers:
+      - content-type: text/plain; charset=utf-8


### PR DESCRIPTION
This requires manually creating `http_request` composite type values.

Solution: introduce `omni_httpd.http_request` function that simplifies this type of testing.