### PR TITLE
Problem: no cookie parser for HTTP handlers

### DIFF
--- a/extensions/omni_web/docs/cookies.md
+++ b/extensions/omni_web/docs/cookies.md
@@ -1,0 +1,17 @@
+# Cookies
+
+## Getting cookies
+
+One can use `omni_web.cookies(text)` to convert a `Cookie` header string 
+into a table of key/value pairs of cookies.
+
+
+```postgresql
+omni_web=# select * from omni_web.cookies('PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1'::text);
+   name    |      value      
+-----------+-----------------
+ PHPSESSID | 298zf09hf012fh2
+ csrftoken | u32t4o3tb3gg43
+ _gat      | 1
+(3 rows)
+```

--- a/extensions/omni_web/omni_web--0.1.sql
+++ b/extensions/omni_web/omni_web--0.1.sql
@@ -72,3 +72,19 @@ $$
 select omni_web.param_get(omni_web.parse_query_string(convert_from(params, 'UTF8')), param);
 $$
     language sql;
+
+create function cookies(cookies text)
+    returns table
+            (
+                name  text,
+                value text
+            )
+    language sql
+as
+$$
+select
+    split_part(cookie, '=', 1),
+    split_part(cookie, '=', 2)
+from
+    unnest(string_to_array(cookies, '; ')) cookies_arr(cookie);
+$$;

--- a/extensions/omni_web/tests/cookies.yml
+++ b/extensions/omni_web/tests/cookies.yml
@@ -1,0 +1,15 @@
+instance:
+  init:
+  - create extension omni_web
+
+tests:
+
+- name: getting a cookie
+  query: select * from omni_web.cookies('PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1'::text)
+  results:
+  - name: PHPSESSID
+    value: 298zf09hf012fh2
+  - name: csrftoken
+    value: u32t4o3tb3gg43
+  - name: _gat
+    value: 1


### PR DESCRIPTION
Cookies are important for session management and doing this manually is not fun.

Solution: provide a basic implementation of the cookie parser

It's probably not the most efficient way to do this, but good enough for start.