### PR TITLE
Problem: omni_httpc request header value is name

### DIFF
--- a/extensions/omni_httpc/omni_httpc.c
+++ b/extensions/omni_httpc/omni_httpc.c
@@ -460,7 +460,7 @@ Datum http_execute(PG_FUNCTION_ARGS) {
           Datum name = GetAttributeByNum(tuple, 1, &isnull);
           if (!isnull) {
             text *name_str = DatumGetTextPP(name);
-            Datum value = GetAttributeByNum(tuple, 1, &isnull);
+            Datum value = GetAttributeByNum(tuple, 2, &isnull);
             if (!isnull) {
               text *value_str = DatumGetTextPP(value);
               h2o_add_header_by_str(pool, headers_vec, VARDATA_ANY(name_str),

--- a/extensions/omni_httpc/tests/test.yml
+++ b/extensions/omni_httpc/tests/test.yml
@@ -88,12 +88,12 @@ tests:
       from response
   results:
   - status: 200
-    headers: '{"(connection,keep-alive)","(content-length,132)","(server,omni_httpd-0.1)","(content-type,application/json)"}'
+    headers: '{"(connection,keep-alive)","(content-length,127)","(server,omni_httpd-0.1)","(content-type,application/json)"}'
     body:
       method: GET
       path: /test
       qs: q=1
-      headers: '{"(x-test,x-test)","(user-agent,omni_httpc/0.1)"}'
+      headers: '{"(x-test,1)","(user-agent,omni_httpc/0.1)"}'
       body: ""
 
 - name: sending body


### PR DESCRIPTION
If we specify `Content-Type: application/json`, we get `Content-Type: Content-Type`

Solution: make sure we send the value, not the name

There was a test covering this functionality but the test was obviously incorrect. Need more eyes!