### PR TITLE
Problem: OpenSSL deprecated API warnigns during h2o compile

### DIFF
--- a/cmake/FindH2O.cmake
+++ b/cmake/FindH2O.cmake
@@ -6,6 +6,6 @@ list(APPEND _h2o_options "WITH_MRUBY OFF")
 list(APPEND _h2o_options "DISABLE_LIBUV ON")
 
 cmake_policy(SET CMP0042 NEW)
-CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG d5b5721 VERSION 2.3.0-d5b5721 OPTIONS "${_h2o_options}")
+CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG 4c84bfa VERSION 2.3.0-4c84bfa OPTIONS "${_h2o_options}")
 set_property(TARGET libh2o PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET libh2o-evloop PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Not a big problem, but a nuisance.

Solution: upgrade to the latest version of h2o

See https://github.com/h2o/h2o/pull/3286