### PR TITLE
Problem: python file loading is cumbersome

### DIFF
--- a/extensions/omni_python/omni_python--0.1.sql
+++ b/extensions/omni_python/omni_python--0.1.sql
@@ -76,7 +76,6 @@ $$
                 return 'unknown'
 
     def process_argument(function, arg):
-        import ast
         type = function.__annotations__[arg]
         if hasattr(type, '__pg_type_hint__') and callable(type.__pg_type_hint__):
             type.__pg_type_hint__.__globals__.update(code_locals)

--- a/extensions/omni_python/omni_python--0.1.sql
+++ b/extensions/omni_python/omni_python--0.1.sql
@@ -10,6 +10,8 @@ create function functions(code text, filename text default null)
     language plpython3u
 as
 $$
+    code_globals = globals()
+
     import os
     import ast
     import decimal
@@ -26,13 +28,10 @@ $$
         plpy.execute(plpy.prepare("select current_setting('omni_python.site_packages', true)"))[0][
             'current_setting'] or "~/.omni_python/default")
 
-    import sys
     sys.path.insert(0, site_packages)
-    del sys
     import omni_python
 
     code_locals = {}
-    code_globals = globals()
 
     try:
         exec(compile(code, filename or 'unnamed.py', 'exec'), code_globals, code_locals)

--- a/extensions/omni_python/omni_python--0.1.sql
+++ b/extensions/omni_python/omni_python--0.1.sql
@@ -51,7 +51,7 @@ $$
     def resolve_type(function, arg):
         type = function.__annotations__[arg]
         if hasattr(type, '__pg_type_hint__') and callable(type.__pg_type_hint__):
-            # FIXME: can't use outer scope imports
+            type.__pg_type_hint__.__globals__.update(code_locals)
             type = type.__pg_type_hint__()
         if type is None:
             return 'unknown'
@@ -79,7 +79,7 @@ $$
         import ast
         type = function.__annotations__[arg]
         if hasattr(type, '__pg_type_hint__') and callable(type.__pg_type_hint__):
-            # FIXME: can't use outer scope imports
+            type.__pg_type_hint__.__globals__.update(code_locals)
             type = type.__pg_type_hint__()
         if (type.__class__ == typing.Annotated[int, 0].__class__ and isinstance(type.__metadata__[0],
                                                                                 omni_python.pgtype) and

--- a/extensions/omni_python/tests/functions.yml
+++ b/extensions/omni_python/tests/functions.yml
@@ -35,6 +35,21 @@ tests:
     import thisdoesnotexist
   error: "ModuleNotFoundError: No module named 'thisdoesnotexist'"
 
+- name: imperative loading
+  steps:
+  - query: select * from omni_python.create_functions($1)
+    params:
+    - |
+      from omni_python import pg
+      def my_fun(f):
+        return f
+      @my_fun
+      @pg
+      def fun1(v: str) -> int:
+        return len(v)
+    results:
+    - create_functions: fun1(text)
+
 - name: create multiple @pg functions
   steps:
   - query: select * from omni_python.create_functions($1)

--- a/extensions/omni_python/tests/functions.yml
+++ b/extensions/omni_python/tests/functions.yml
@@ -195,3 +195,22 @@ tests:
     query: select fun1(0)
     results:
     - fun1: 0
+
+- name: executing function doesn't re-execute the whole file
+  steps:
+  - name: create
+    query: select * from omni_python.create_functions($1)
+    notices:
+    - executed
+    params:
+    - |
+      from omni_python import pg, log
+      log.notice('executed')
+      @pg
+      def fun1(v: str) -> int:
+        return len(v)
+    results:
+    - create_functions: fun1(text)
+  - name: execute it
+    query: select fun1('test')
+    notices: [ ]

--- a/extensions/omni_python/tests/types.yml
+++ b/extensions/omni_python/tests/types.yml
@@ -152,7 +152,7 @@ tests:
       select omni_python.create_functions($1)
     params:
     - |
-      from omni_python import pg
+      from omni_python import pg, Composite
       from dataclasses import dataclass
       
       @dataclass
@@ -163,7 +163,6 @@ tests:
       
           @classmethod
           def __pg_type_hint__(cls):
-              from omni_python import Composite
               return Composite(cls, "employee")
       
       @pg


### PR DESCRIPTION
We can't really set any values to be used during construction:

```python
def my_fun(f):
    return f

@my_fun
def ...
```

`my_fun` won't resolve

Solution: execute the whole module on processing

This simplifies things a lot.