### PR TITLE
Problem: omni_httpd producing duplicate `content-length`

### DIFF
--- a/extensions/omni_httpd/tests/http.yml
+++ b/extensions/omni_httpd/tests/http.yml
@@ -34,6 +34,9 @@ instance:
         INNER JOIN users ON string_to_array(request.path,'/', '') = array[NULL, 'users', users.handle]
        $$, 1),
                   ('abort', $$select omni_httpd.abort() from request where request.path = '/abort'$$, 1),
+                  ('custom-content-length',
+                   $$select omni_httpd.http_response(headers => array[omni_http.http_header('content-length', '10')], body => '0123456789')
+                   from request where request.path = '/custom-content-length'$$, 1),
                   ('headers',
                    $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$,
                    1),
@@ -122,6 +125,20 @@ tests:
   results:
   - status: 200
     body: '{"(user-agent,omni_httpc/0.1)"}'
+- name: should not duplicate content-length if it is set
+  query: |
+    with response as (select * from omni_httpc.http_execute(
+      omni_httpc.http_request('http://127.0.0.1:' ||
+      (select effective_port from omni_httpd.listeners where port = 0) || '/custom-content-length')))
+    select
+    response.status,
+    headers,
+    convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    headers: '{"(connection,keep-alive)","(content-length,10)","(server,omni_httpd-0.1)","(content-type,\"text/plain; charset=utf-8\")"}'
+    body: 0123456789
 - name: proxy
   query: |
     with response as (select * from omni_httpc.http_execute(

--- a/extensions/omni_httpd/tests/http.yml
+++ b/extensions/omni_httpd/tests/http.yml
@@ -37,6 +37,9 @@ instance:
                   ('custom-content-length',
                    $$select omni_httpd.http_response(headers => array[omni_http.http_header('content-length', '10')], body => '0123456789')
                    from request where request.path = '/custom-content-length'$$, 1),
+                  ('custom-content-length-1',
+                   $$select omni_httpd.http_response(headers => array[omni_http.http_header('content-length', '3')], body => '0123456789')
+                   from request where request.path = '/custom-content-length-1'$$, 1),
                   ('headers',
                    $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$,
                    1),
@@ -139,6 +142,18 @@ tests:
   - status: 200
     headers: '{"(connection,keep-alive)","(content-length,10)","(server,omni_httpd-0.1)","(content-type,\"text/plain; charset=utf-8\")"}'
     body: 0123456789
+- name: should resize the content if content-length is set low
+  query: |
+    with response as (select * from omni_httpc.http_execute(
+      omni_httpc.http_request('http://127.0.0.1:' ||
+      (select effective_port from omni_httpd.listeners where port = 0) || '/custom-content-length-1')))
+    select
+    response.status,
+    convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    body: 012
 - name: proxy
   query: |
     with response as (select * from omni_httpc.http_execute(


### PR DESCRIPTION
If HTTP handler has produced `content-length` header, omni_httpd will add its own based on the size of the response. This creates duplicate headers.

Solution: check for `content-length` in the response

If the size specified is smaller, cut the response body to fit into it to avoid overflow. If the specified size is too large, send a warning but let omni_httpd calculate the right size.

In the end, continue letting h2o handle the header.