### PR TITLE
Problem: omni_httpd may be vulnerable to the Rapid Reset attack

### DIFF
--- a/cmake/FindH2O.cmake
+++ b/cmake/FindH2O.cmake
@@ -6,6 +6,6 @@ list(APPEND _h2o_options "WITH_MRUBY OFF")
 list(APPEND _h2o_options "DISABLE_LIBUV ON")
 
 cmake_policy(SET CMP0042 NEW)
-CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG 4c84bfa VERSION 2.3.0-4c84bfa OPTIONS "${_h2o_options}")
+CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG b311c04 VERSION 2.3.0-b311c04 OPTIONS "${_h2o_options}")
 set_property(TARGET libh2o PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET libh2o-evloop PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
https://blog.cloudflare.com/zero-day-rapid-reset-http2-record-breaking-ddos-attack/

Solution: update h2o that includes mitigation support

We use `h2o_config_init` so we get the default value of 100ms DoS delay. However, in the future, this parameter should become configurable.