### PR TITLE
Problem: can't use pg_yregress against running databases

### DIFF
--- a/pg_yregress/CHANGELOG.md
+++ b/pg_yregress/CHANGELOG.md
@@ -8,6 +8,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+* Support for unmanaged (external) instances
+
 ## [0.1.0] - 2023-08-25
 
 Initial release following a few months of iterative development.

--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -409,6 +409,41 @@ instance:
   - create extension ltree
 ```
 
+## Unmanaged instances
+
+By default, `pg_yregress` manages Postgres instances itself: provisions the
+database and its configuration, starts and stops processes. However, it can also
+be used to run tests against other instances of Postgres operated outside of its
+own workflow. This can be used for testing functionality or data patterns in an
+existing database.
+
+In order to use it, one has to pass one of the following options:
+
+| Option        | Short | Description                                                                                           |
+|---------------|-------|-------------------------------------------------------------------------------------------------------|
+| --host        | -h    | Host to connect to. Defaults to `127.0.0.1` if other options are selected.                            |
+| --port        | -p    | Port to connect to. Default to `5432` if not specified.                                               |
+| --username    | -U    | Username. Defaults to current username.                                                               |
+| --dbname      | -d    | Database name. Defaults to username.                                                                  |
+| --password    | -W    | Force to prompt for a password before connecting to the database.                                     |
+| --no-password | -w    | Never issue a password prompt. Will attempt to get a password from `PGPASSWORD` environment variable. |
+
+For example, this will attempt to connect to a local Postgres instance on port
+5432 using `omnigres` as a database name and a username, prompting for a
+password:
+
+```shell
+pg_yregress -U omnigres -W tests.yml
+```
+
+!!! tip "Caveats"
+
+    The following options are not available for unmanaged instances and will
+    make pg_yregress terminate early with a corresponding error message.
+
+    * `instance` and `instances` configuration keys
+    * `restart` tests
+
 ## Configuring test suite
 
 In certain cases, it may be useful to pass some configuration information to the

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -28,7 +28,11 @@ typedef struct {
       uint16_t port;
     } managed;
     struct {
-      // TODO
+      char *host;
+      char *username;
+      char *dbname;
+      int port;
+      char *password;
     } unmanaged;
   } info;
   PGconn *conn;


### PR DESCRIPTION
pg_yregress always manages Postgres databases itself.

Solution: allow pg_yregress to be directed against a running instance