### PR TITLE
Problem: pgcrypto is not available in the dev build of Postgres

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -110,7 +110,6 @@ if(NOT DEFINED PG_CONFIG)
 
         # Ensure the right OpenSSL gets configured
         if(DEFINED OPENSSL_ROOT_DIR)
-            message(WARNING "ok ${OPENSSL_ROOT_DIR}")
             set(OLD_CFLAGS "$ENV{CFLAGS}")
             set(OLD_LDFLAGS "$ENV{LDFLAGS}")
             set(ENV{CFLAGS} "${OLD_CFLAGS} -I ${OPENSSL_ROOT_DIR}/include")

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -51,6 +51,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+include(${CMAKE_SOURCE_DIR}/cmake/OpenSSL.cmake)
+
 if(NOT DEFINED PG_CONFIG)
 
     # Use latest known version if PGVER is not set
@@ -106,8 +108,18 @@ if(NOT DEFINED PG_CONFIG)
             endif()
         endif()
 
+        # Ensure the right OpenSSL gets configured
+        if(DEFINED OPENSSL_ROOT_DIR)
+            message(WARNING "ok ${OPENSSL_ROOT_DIR}")
+            set(OLD_CFLAGS "$ENV{CFLAGS}")
+            set(OLD_LDFLAGS "$ENV{LDFLAGS}")
+            set(ENV{CFLAGS} "${OLD_CFLAGS} -I ${OPENSSL_ROOT_DIR}/include")
+            set(ENV{LDFLAGS} "${OLD_LDLAGS} -L ${OPENSSL_ROOT_DIR}/lib")
+        endif()
+
         execute_process(
                 COMMAND ./configure --enable-debug --prefix "${PGDIR_VERSION}/build" --without-icu
+                --with-ssl=openssl
                 ${extra_configure_args}
                 WORKING_DIRECTORY "${PGDIR_VERSION}/postgresql-${PGVER_ALIAS}"
                 RESULT_VARIABLE pg_configure_result)
@@ -154,6 +166,11 @@ if(NOT DEFINED PG_CONFIG)
 
         if(NOT pg_build_result EQUAL 0)
             message(FATAL_ERROR "Can't build Postgres contribs, aborting.")
+        endif()
+
+        if(DEFINED OPENSSL_ROOT_DIR)
+            set(ENV{CFLAGS} "${OLD_CFLAGS}")
+            set(ENV{LDFLAGS} "${OLD_LDLAGS}")
         endif()
 
     endif()

--- a/cmake/OpenSSL.cmake
+++ b/cmake/OpenSSL.cmake
@@ -1,20 +1,21 @@
-if(APPLE)
-    # TODO: reassess pinning to 3.0 as this is a temporary workaround for this issue:
-    # https://github.com/openssl/openssl/issues/20753
+if(NOT DEFINED OPENSSL_CONFIGURED)
+    if(APPLE)
+        execute_process(COMMAND brew --prefix openssl@3.1
+                OUTPUT_VARIABLE OPENSSL_PREIX RESULT_VARIABLE OPENSSL_RC
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-    execute_process(COMMAND brew --prefix openssl@3.0
-        OUTPUT_VARIABLE OPENSSL_PREIX RESULT_VARIABLE OPENSSL_RC
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
+        if(NOT OPENSSL_RC EQUAL 0)
+            message(FATAL_ERROR "No OpenSSL found, use homebrew to install one")
+        endif()
 
-    if(NOT OPENSSL_RC EQUAL 0)
-        message(FATAL_ERROR "No OpenSSL found, use homebrew to install one")
+        message(STATUS "Found OpenSSL at ${OPENSSL_PREIX}")
+        set(OPENSSL_ROOT_DIR ${OPENSSL_PREIX} CACHE INTERNAL "OpenSSL")
+    elseif(UNIX)
+        find_package(PkgConfig)
+        pkg_check_modules(_OPENSSL openssl)
     endif()
 
-    message(STATUS "Found OpenSSL at ${OPENSSL_PREIX}")
-    set(OPENSSL_ROOT_DIR ${OPENSSL_PREIX} CACHE INTERNAL "OpenSSL")
-elseif(UNIX)
-    find_package(PkgConfig)
-    pkg_check_modules(_OPENSSL openssl)
-endif()
+    set(OPENSSL_USE_STATIC_LIBS ON)
+    set(OPENSSL_CONFIGURED TRUE CACHE INTERNAL "OpenSSL")
 
-set(OPENSSL_USE_STATIC_LIBS ON)
+endif()


### PR DESCRIPTION
Solution: ensure we configure it with the right OpenSSL

On macOS, we end up using Homebrew-supplied version of OpenSSL, so lets make Postgres use it.