### PR TITLE
Problem: omni_httpc may receive an initialized buffer

### DIFF
--- a/extensions/omni_httpc/omni_httpc.c
+++ b/extensions/omni_httpc/omni_httpc.c
@@ -238,9 +238,12 @@ static int on_body(h2o_httpclient_t *client, const char *errstr, h2o_header_t *t
     }
   }
 
-  // Append the body
-  appendBinaryStringInfo(&req->body, (*client->buf)->bytes, (*client->buf)->size);
-  h2o_buffer_consume(&(*client->buf), (*client->buf)->size);
+  // Append the body if there's a body to consume
+  h2o_buffer_t *buf = *client->buf;
+  if (buf != NULL && buf->size > 0) {
+    appendBinaryStringInfo(&req->body, buf->bytes, buf->size);
+    h2o_buffer_consume(&buf, buf->size);
+  }
 
   // End of stream, complete the request
   if (errstr == h2o_httpclient_error_is_eos) {


### PR DESCRIPTION
I am yet to confirm this in practice, but it is not inconceivable that the buffer will not be initialized when trying to copy from it.

This may result in a segmentation fault.

Solution: guard against this possibility