### PR TITLE
Problem: unclear how omni_httpc would handle nulls in headers

### DIFF
--- a/extensions/omni_httpc/omni_httpc.c
+++ b/extensions/omni_httpc/omni_httpc.c
@@ -469,6 +469,9 @@ Datum http_execute(PG_FUNCTION_ARGS) {
               h2o_add_header_by_str(pool, headers_vec, VARDATA_ANY(name_str),
                                     VARSIZE_ANY_EXHDR(name_str), 1, NULL, VARDATA_ANY(value_str),
                                     VARSIZE_ANY_EXHDR(value_str));
+            } else {
+              h2o_add_header_by_str(pool, headers_vec, VARDATA_ANY(name_str),
+                                    VARSIZE_ANY_EXHDR(name_str), 1, NULL, "", 0);
             }
           }
         }

--- a/extensions/omni_httpc/tests/test.yml
+++ b/extensions/omni_httpc/tests/test.yml
@@ -97,6 +97,58 @@ tests:
       headers: '{"(x-test,1)","(user-agent,omni_httpc/0.1)"}'
       body: ""
 
+- name: null header name
+  query: |
+    with
+        response as (select *
+                     from
+                         omni_httpc.http_execute(
+                                 omni_httpc.http_request('http://127.0.0.1:' ||
+                                                         (select effective_port from omni_httpd.listeners) ||
+                                                         '/test?q=1', headers =>
+                                                             array [omni_http.http_header(null, null)])))
+    select
+        response.status,
+        response.headers,
+        convert_from(response.body, 'utf-8')::json as body
+    from
+        response
+  results:
+  - status: 200
+    headers: '{"(connection,keep-alive)","(content-length,112)","(server,omni_httpd-0.1)","(content-type,application/json)"}'
+    body:
+      method: GET
+      path: /test
+      qs: q=1
+      headers: "{\"(user-agent,omni_httpc/0.1)\"}"
+      body: ""
+
+- name: null header value
+  query: |
+    with
+        response as (select *
+                     from
+                         omni_httpc.http_execute(
+                                 omni_httpc.http_request('http://127.0.0.1:' ||
+                                                         (select effective_port from omni_httpd.listeners) ||
+                                                         '/test?q=1', headers =>
+                                                             array [omni_http.http_header('x-test', null)])))
+    select
+        response.status,
+        response.headers,
+        convert_from(response.body, 'utf-8')::json as body
+    from
+        response
+  results:
+  - status: 200
+    headers: '{"(connection,keep-alive)","(content-length,134)","(server,omni_httpd-0.1)","(content-type,application/json)"}'
+    body:
+      method: GET
+      path: /test
+      qs: q=1
+      headers: "{\"(x-test,\\\"\\\")\",\"(user-agent,omni_httpc/0.1)\"}"
+      body: ""
+
 - name: sending body
   query: |
     with response as (select * from omni_httpc.http_execute(


### PR DESCRIPTION
Solution: write a test and document it

While at it, change the behavior to make null header value an empty string instead of skipping the entire header.