### PR TITLE
Doc: fix tiny markdown syntax in Omnigres docs home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,7 @@ Omnigres makes PostgreSQL a complete application platform. You can deploy a sing
 * **Deployment** provisioning (**Git**, **Docker**, etc.)
 * Database instance serves **HTTP**, **WebSocket** and other protocols
 * In-memory and volatile on-disk **caching**
-* Routine application building blocks (**authentication**, **authorization**, *
-  *payments**, etc.)
+* Routine application building blocks (**authentication**, **authorization**, **payments**, etc.)
 * Database-modeled application logic via **reactive** queries
 * Automagic remote **APIs** and **form** handling
 * **Live** data updates


### PR DESCRIPTION
- Tiny markdown syntax fix on docs main page: https://docs.omnigres.org/ 
![image](https://github.com/omnigres/omnigres/assets/38150419/e49be0a1-bbaa-46d8-855c-6acbe7039502)
