### PR TITLE
Problem: omni_python silently fails on syntax errors

### DIFF
--- a/extensions/omni_python/tests/functions.yml
+++ b/extensions/omni_python/tests/functions.yml
@@ -37,6 +37,22 @@ tests:
     import thisdoesnotexist
   error: "ModuleNotFoundError: No module named 'thisdoesnotexist'"
 
+- name: fails on syntax errors
+  query: select *
+         from
+             omni_python.create_functions($1)
+  params:
+  #language=Python
+  - |
+    from omni_python import pg
+    from a import c.b
+    
+    
+    @pg
+    def fun() -> int:
+        pass
+  error: "SyntaxError: invalid syntax (unnamed.py, line 2)"
+
 - name: imperative loading
   steps:
   - query: select * from omni_python.create_functions($1)


### PR DESCRIPTION
If there is a file we're loading and there's a syntax error, it will not do anything but silently accept it.

Solution: throw a syntax error when syntax is invalid

The reason for the original erroneous behavior lies in handling "enriched" and "legacy" approaches to defining stored functions.

In the legacy approach, plpython3u expects a body of the function, which can be syntactically incorrect on its own (like using `return` outside function).

To accommodate that, omni_python was swallowing SyntaxError to let the legacy handler pick the file up.

However, it's obvious that this won't work well when there is a legitimate syntax error.

Now omni_python, if it encounters a syntax error, tries to re-evaluate the code with a function wrapped around it. If it succeeds, we assume that this is a legacy function. Otherwise, throw the original error.