### PR TITLE
Problem: omni_httpd fallback strategy is flawed

### DIFF
--- a/extensions/omni_httpd/master_worker.c
+++ b/extensions/omni_httpd/master_worker.c
@@ -315,9 +315,11 @@ void master_worker(Datum db_oid) {
                                              try_port_no, address_str, &effective_port);
               if (sock == -1) {
                 if (errno == EADDRINUSE) {
-                  // If there is a current effective port,
+                  // If there is a current effective port that is not the same as the one we're
+                  // trying,
                   int effective_port_no = DatumGetInt32(current_effective_port);
-                  if (!current_effective_port_is_null && effective_port_no != 0) {
+                  if (!current_effective_port_is_null && effective_port_no != 0 &&
+                      effective_port_no != try_port_no) {
                     // If it is an active listener,
                     portsock = cmap_portsock_get(&portsocks, effective_port_no);
                     if (portsock != NULL) {


### PR DESCRIPTION
It will attempt to fall back to effective port even if it is the same port as we just tried to listen at and failed.

Solution: ensure these ports aren't the same

If they are the same, try picking a new port.

(I wonder if we can come up with a good way to test behavior of this?)