### PR TITLE
Problem: Python DX rough edges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,10 +92,11 @@ ENV POSTGRES_DB=omnigres
 ENV POSTGRES_USER=omnigres
 ENV POSTGRES_PASSWORD=omnigres
 COPY --from=build /build/packaged /omni
+COPY --from=build /build/python-index /python-packages
 COPY docker/initdb-slim/* /docker-entrypoint-initdb.d/
 RUN cp -R /omni/extension $(pg_config --sharedir)/ && cp -R /omni/*.so $(pg_config --pkglibdir)/ && rm -rf /omni
 RUN apt update && apt -y install libtclcl1 libpython3.9 libperl5.32
-RUN PG_VER=${PG%.*} && apt update && apt -y install postgresql-pltcl-${PG_VER} postgresql-plperl-${PG_VER} postgresql-plpython3-${PG_VER}
+RUN PG_VER=${PG%.*} && apt update && apt -y install postgresql-pltcl-${PG_VER} postgresql-plperl-${PG_VER} postgresql-plpython3-${PG_VER} python3-dev python3-venv python3-pip
 EXPOSE 8080
 EXPOSE 5432
 

--- a/languages/python/omni_http/src/omni_http/omni_httpd/__init__.py
+++ b/languages/python/omni_http/src/omni_http/omni_httpd/__init__.py
@@ -1,7 +1,7 @@
 import json
 from omni_python import Composite, Custom
 from ..omni_http import HttpHeader
-from typing import TypedDict, Optional, Any, Self
+from typing import TypedDict, Optional, Any
 from dataclasses import dataclass
 
 import sys
@@ -35,7 +35,7 @@ class HTTPResponse:
     body: bytes = b""
     status: int = 200
 
-    def outcome(self: Self) -> HTTPOutcome:
+    def outcome(self) -> HTTPOutcome:
       __plpy = sys.modules['__main__'].plpy
       return __plpy.execute(__plpy.prepare("select omni_httpd.http_response(body => $1, status => $2, headers => $3) as result",
                                            ["bytea", "int","omni_http.http_headers"]), [self.body, self.status, self.headers])[0]["result"]


### PR DESCRIPTION
1. `omni_http` package won't load in Python 3.9
2. Can't use Python packages when using Omnigres in a provided container image

Solution: address both issues (see merge commits)