### PR TITLE
Problem: notices on files omni_schema doesn't understand

### DIFF
--- a/extensions/omni_schema/omni_schema--0.1.sql
+++ b/extensions/omni_schema/omni_schema--0.1.sql
@@ -151,6 +151,10 @@ begin
             if rec.language = 'sql' then
                 execute rec.code;
             else
+                if rec.language is null then
+                    -- Ignore file
+                    continue;
+                end if;
                 -- Check if the language is available
                 if not exists(select from pg_extension where extname = rec.extension) then
                     raise notice 'Extension % required for language % (required for %) is not installed', rec.extension, rec.language, rec.name;


### PR DESCRIPTION
For example, if I have `test.http` file, it will make this notice:

```
NOTICE:  Extension <NULL> required for language <NULL> (required for test.http) is not installed
```

Solution: ignore files for which language can't be found