### PR TITLE
Problem: omni_schema.load_from_fs is too eager

### DIFF
--- a/extensions/omni_schema/docs/reference.md
+++ b/extensions/omni_schema/docs/reference.md
@@ -60,6 +60,12 @@ from
 Its return type and parameters are currently identical to those
 of `migrate_from_fs`.
 
+!!! tip "Ignoring files"
+
+    In order to avoid loading particular files that match a language or a tool
+    filename pattern, one can put `omni_schema[[ignore]]` somewhere inside such
+    file (for example, in a comment) and `omni_schema` will not load it.
+
 ## Multi-language functions
 
 Object reloading functionality allows one to load functions from '.sql' files

--- a/extensions/omni_schema/omni_schema--0.1.sql
+++ b/extensions/omni_schema/omni_schema--0.1.sql
@@ -148,6 +148,10 @@ begin
                 end if;
                 continue;
             end if;
+            if rec.code ~ 'omni_schema\[\[ignore\]\]' then
+                -- Ignore the file
+                continue;
+            end if;
             if rec.language = 'sql' then
                 execute rec.code;
             else

--- a/extensions/omni_schema/tests/fixture/function/1/ignore.sql
+++ b/extensions/omni_schema/tests/fixture/function/1/ignore.sql
@@ -1,0 +1,1 @@
+-- omni_schema[[ignore]]


### PR DESCRIPTION
It will ingest all files that match a file name pattern.

Solution: provide a way to ignore files

By placing `omni_schema[[ignore]]` somewhere in the file, the file will be ignored.