### PR TITLE
Problem: omni_httpd.no_init still creates handlers/listeners

### DIFF
--- a/extensions/omni_httpd/omni_httpd--0.1.sql
+++ b/extensions/omni_httpd/omni_httpd--0.1.sql
@@ -289,10 +289,17 @@ with
              coalesce(current_setting('omni_httpd.init_listen_address', true),
                       '0.0.0.0')::inet                                                 as init_listen_address,
              coalesce(current_setting('omni_httpd.init_port', true)::port, 8080::port) as init_port),
-    listener as (insert into listeners (address, port) select init_listen_address, init_port from config returning id),
-    handler as (insert into handlers (query) values
+    listener
+        as (insert into listeners (address, port) select init_listen_address, init_port from config where should_init returning id),
+    handler as (insert into handlers (query) (select
+                                                  query
+                                              from
+                                                  (values
                                                  ($$
-       SELECT omni_httpd.default_page(request.*::omni_httpd.http_request) FROM request $$) returning id)
+       SELECT omni_httpd.default_page(request.*::omni_httpd.http_request) FROM request $$)) v(query),
+                                                                                            config
+                                              where
+                                                  should_init) returning id)
 insert
 into
     listeners_handlers (listener_id, handler_id)

--- a/extensions/omni_httpd/tests/no_init.yml
+++ b/extensions/omni_httpd/tests/no_init.yml
@@ -1,0 +1,20 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+    max_worker_processes: 64
+  init:
+  - set session omni_httpd.no_init = true
+  - create extension omni_httpd cascade
+
+tests:
+
+- name: should not have any listeners
+  query: select count(*) from omni_httpd.listeners
+  results:
+  - count: 0
+
+- name: should not have any handlers
+  query: select count(*) from omni_httpd.handlers
+  results:
+  - count: 0


### PR DESCRIPTION
These shouldn't be created in this case.

Solution: ensure they aren't