### PR TITLE
Problem: some test suites' purpose is unclear

### DIFF
--- a/pg_yregress/CHANGELOG.md
+++ b/pg_yregress/CHANGELOG.md
@@ -8,6 +8,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+* Test suites (YAML files) can now be named using optional `name` property.
+
 ## [0.2.0]
 
 ### Added

--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -462,3 +462,15 @@ retrieve configuration specified through environment variables:
   results:
   - user: */env/USER
 ```
+
+### Named test suites
+
+A test suite (the YAML file) can be given a human-readable name using
+optional `name` property:
+
+```yaml
+name: Core tests
+
+tests:
+...
+```

--- a/pg_yregress/pg_yregress.c
+++ b/pg_yregress/pg_yregress.c
@@ -429,6 +429,13 @@ static int execute_document(struct fy_document *fyd, bool managed, char *host, i
   int test_count = 1 + fy_node_sequence_item_count(tests) + used_instances;
   fprintf(tap_file, "TAP version 14\n");
   fprintf(tap_file, "1..%d\n", test_count);
+  {
+    size_t name_len;
+    const char *name = fy_node_mapping_lookup_scalar_by_simple_key(root, &name_len, STRLIT("name"));
+    if (name != NULL) {
+      fprintf(tap_file, "# Test suite: %.*s\n", (int)name_len, name);
+    }
+  }
 
   // Initialize used instances
   {

--- a/pg_yregress/schema.json
+++ b/pg_yregress/schema.json
@@ -12,6 +12,10 @@
         "$ref": "#/definitions/instance"
       }
     },
+    "name": {
+      "type": "string",
+      "description": "Test suite name"
+    },
     "tests": {
       "type": "array",
       "items": {

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -1,4 +1,7 @@
 $schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+
+name: pg_yregress
+
 instances:
   main:
     default: true


### PR DESCRIPTION
Solution: allow to give test suites a name

This is marginally better than comments and gets printed out in the output.