### PR TITLE
Problem:  errors during omni_httpd restart post-crash

### DIFF
--- a/dynpgext/docs/usage.md
+++ b/dynpgext/docs/usage.md
@@ -46,3 +46,10 @@ handle->register_bgworker(handle, &bgw, NULL, NULL,
 ```
 
 Just like shared memory allocations, background workers can be either global or provisioned per database.
+
+!!! tip "Caveat: bgw_restart_time is always BGW_NEVER_RESTART"
+
+    Since omni_ext manages the startup of the background workers, 
+    `BackgroundWorker.bgw_restart_time` value is ignored and is always 
+    effectively set to `BGW_NEVER_RESTART` so that Postgres never attempts
+    to restart them itself.

--- a/extensions/omni_ext/workers.c
+++ b/extensions/omni_ext/workers.c
@@ -91,7 +91,7 @@ void master_worker(Datum main_arg) {
                                        BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION,
                                    .bgw_main_arg = ObjectIdGetDatum(db->oid),
                                    .bgw_start_time = BgWorkerStart_RecoveryFinished,
-                                   .bgw_restart_time = 0,
+                                   .bgw_restart_time = BGW_NEVER_RESTART,
                                    .bgw_function_name = "database_worker",
                                    .bgw_notify_pid = MyProcPid};
         strncpy(worker.bgw_library_name, get_library_name(), BGW_MAXLEN);
@@ -248,6 +248,7 @@ void database_worker(Datum db_oid) {
             if (!global_background_worker) {
               bgw.ref->bgw.bgw_main_arg = db_oid;
             }
+            bgw.ref->bgw.bgw_restart_time = BGW_NEVER_RESTART;
             RegisterDynamicBackgroundWorker(&bgw.ref->bgw, &handle);
             if (bgw.ref->callback) {
               bgw.ref->callback(handle, bgw.ref->data);

--- a/extensions/omni_httpd/master_worker.c
+++ b/extensions/omni_httpd/master_worker.c
@@ -475,6 +475,7 @@ void master_worker(Datum db_oid) {
                                  .bgw_function_name = "http_worker",
                                  .bgw_notify_pid = getpid(),
                                  .bgw_main_arg = db_oid,
+                                 .bgw_restart_time = BGW_NEVER_RESTART,
                                  .bgw_flags =
                                      BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION,
                                  .bgw_start_time = BgWorkerStart_RecoveryFinished};


### PR DESCRIPTION
It seemingly attempts to bind the port multiple times and is having difficulties with that.

Solution: ensure it is only omni_ext that manages the lifecycle of omni_httpd and other Dynpgext-registered background workers

Importantly, we do the same for omni_httpd-controlled http_workers as well, otherwise, it exhibits the same problem which manifests in postgres having trouble terminating cleanly afterwards.
