### PR TITLE
Problem: omni_python configs don't survive the restart

### DIFF
--- a/extensions/omni_python/tests/functions.yml
+++ b/extensions/omni_python/tests/functions.yml
@@ -23,8 +23,12 @@ instance:
       omni_httpd.cascading_query(name, query order by priority desc nulls last)
       from (select * from omni_httpd.static_file_handlers('pypi', 0, listing => true)) routes)
   - call omni_httpd.wait_for_configuration_reloads(1)
-  - select set_config('omni_python.extra_pip_index_url','http://localhost:'  || (select effective_port from omni_httpd.listeners), false)
-  - select set_config('omni_python.site_packages','omni_python_test_functions', false)
+  - insert
+    into
+        omni_python.config (name, value)
+    values
+        ('extra_pip_index_url', 'http://localhost:' || (select effective_port from omni_httpd.listeners)),
+        ('site_packages', 'omni_python_test_functions')
   - select omni_python.install_requirements('omni_python')
 
 tests:

--- a/extensions/omni_python/tests/omni_python.yml
+++ b/extensions/omni_python/tests/omni_python.yml
@@ -23,8 +23,12 @@ instance:
       omni_httpd.cascading_query(name, query order by priority desc nulls last)
       from (select * from omni_httpd.static_file_handlers('pypi', 0, listing => true)) routes)
   - call omni_httpd.wait_for_configuration_reloads(1)
-  - select set_config('omni_python.extra_pip_index_url','http://localhost:'  || (select effective_port from omni_httpd.listeners), false)
-  - select set_config('omni_python.site_packages','omni_python_test_functions', false)
+  - insert
+    into
+        omni_python.config (name, value)
+    values
+        ('extra_pip_index_url', 'http://localhost:' || (select effective_port from omni_httpd.listeners)),
+        ('site_packages', 'omni_python_test_functions')
   - select omni_python.install_requirements('omni_python')
 
 tests:

--- a/extensions/omni_python/tests/types.yml
+++ b/extensions/omni_python/tests/types.yml
@@ -23,8 +23,12 @@ instance:
       omni_httpd.cascading_query(name, query order by priority desc nulls last)
       from (select * from omni_httpd.static_file_handlers('pypi', 0, listing => true)) routes)
   - call omni_httpd.wait_for_configuration_reloads(1)
-  - select set_config('omni_python.extra_pip_index_url','http://localhost:'  || (select effective_port from omni_httpd.listeners), false)
-  - select set_config('omni_python.site_packages','omni_python_test_types', false)
+  - insert
+    into
+        omni_python.config (name, value)
+    values
+        ('extra_pip_index_url', 'http://localhost:' || (select effective_port from omni_httpd.listeners)),
+        ('site_packages', 'omni_python_test_types')
   - select omni_python.install_requirements('omni_python')
   - |
     create function identity(type text, preamble text default '') returns text language sql

--- a/extensions/omni_schema/tests/omni_python.yml
+++ b/extensions/omni_schema/tests/omni_python.yml
@@ -23,8 +23,12 @@ instance:
       omni_httpd.cascading_query(name, query order by priority desc nulls last)
       from (select * from omni_httpd.static_file_handlers('pypi', 0, listing => true)) routes)
   - call omni_httpd.wait_for_configuration_reloads(1)
-  - select set_config('omni_python.extra_pip_index_url','http://localhost:'  || (select effective_port from omni_httpd.listeners), false)
-  - select set_config('omni_python.site_packages','omni_schema_test', false)
+  - insert
+    into
+        omni_python.config (name, value)
+    values
+        ('extra_pip_index_url', 'http://localhost:' || (select effective_port from omni_httpd.listeners)),
+        ('site_packages', 'omni_schema_test')
   - select omni_python.install_requirements('omni_python')
   - create extension omni_schema cascade
 


### PR DESCRIPTION
That's because they are set using `set_config`

Solution: persist configuration in omni_python.config

Also, make site_packages default to `data_dir/.omni_python/default` instead of the user's home directory. This way we're not polluting where we shouldn't and when used with Docker, it'll survive in the data volume.