### PR TITLE
Problem: impossible to rename @pg-decorated Python functions

### DIFF
--- a/extensions/omni_python/omni_python--0.1.sql
+++ b/extensions/omni_python/omni_python--0.1.sql
@@ -69,7 +69,7 @@ $$
     for name, value in code_locals.items():
         if callable(value):
             if hasattr(value, '__pg_stored_procedure__'):
-                pg_functions.append((name, value))
+                pg_functions.append((name, value, value.__pg_stored_procedure__))
 
     __types__ = {str: 'text', bool: 'boolean', bytes: 'bytea', int: 'int',
                  decimal.Decimal: 'numeric', float: 'double precision'}
@@ -130,7 +130,7 @@ $$
 
     from textwrap import dedent
 
-    return [(name,
+    return [(pgargs.get('name', name),
              [a for a in inspect.getfullargspec(f).args],
              [resolve_type(f, a) for a in inspect.getfullargspec(f).args], resolve_type(f, 'return'),
              dedent("""
@@ -150,7 +150,7 @@ $$
                          args=', '.join(
                              [process_argument(f, a) for a in
                               inspect.getfullargspec(f).args])))
-            for name, f in pg_functions]
+            for name, f, pgargs in pg_functions]
 $$;
 
 create function create_functions(code text, filename text default null, replace boolean default false) returns setof regprocedure

--- a/extensions/omni_python/tests/functions.yml
+++ b/extensions/omni_python/tests/functions.yml
@@ -96,6 +96,26 @@ tests:
     results:
     - fun2: tset
 
+- name: override @pg name
+  steps:
+  - query: select *
+           from
+               omni_python.create_functions($1)
+    params:
+    #language=Python
+    - |
+      from omni_python import pg
+      
+      
+      @pg(name="fun")
+      def fun1(v: str) -> int:
+          return len(v)
+    results:
+    - create_functions: fun(text)
+  - query: select fun('test')
+    results:
+    - fun: 4
+
 - name: ignores non-@pg functions
   steps:
   - query: select * from omni_python.create_functions($1)

--- a/languages/python/omni_python/src/omni_python/__init__.py
+++ b/languages/python/omni_python/src/omni_python/__init__.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Any
+from typing import Any, TypedDict, Optional
 from dataclasses import dataclass
 
 
@@ -28,13 +28,23 @@ def Custom(klass: Any, name: str):
     return typing.Annotated[klass, pgtype(name)]
 
 
-def pg(fun):
+class PgAttributes(TypedDict, total=False):
+    name: Optional[str]
+
+
+def pg(*args, **attrs: PgAttributes):
     """
     Decorator that annotates the function to be available as a Postgres stored procedure
 
-    :param fun: Function to be decorated
-    :return: same function
+    :param attrs: Function attributes
+    :return: decorator
     """
 
-    fun.__pg_stored_procedure__ = True
-    return fun
+    def pg_fun(fun):
+        fun.__pg_stored_procedure__ = attrs
+        return fun
+
+    if len(args) == 1 and callable(args[0]) and not attrs:
+        return pg_fun(args[0])
+    else:
+        return pg_fun


### PR DESCRIPTION
Sometimes, we need to rename to avoid clashing or otherwise invalid names.

Solution: allow overriding the name using `@pg(name="new_name")`