### PR TITLE
Problem: HTTP endpoint to serve local Python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,7 @@ ENV POSTGRES_USER=omnigres
 ENV POSTGRES_PASSWORD=omnigres
 COPY --from=build /build/packaged /omni
 COPY --from=build /build/python-index /python-packages
+COPY --from=build /build/python-wheels /python-wheels
 COPY docker/initdb-slim/* /docker-entrypoint-initdb.d/
 RUN cp -R /omni/extension $(pg_config --sharedir)/ && cp -R /omni/*.so $(pg_config --pkglibdir)/ && rm -rf /omni
 RUN apt update && apt -y install libtclcl1 libpython3.9 libperl5.32

--- a/extensions/omni_python/.psqlrc
+++ b/extensions/omni_python/.psqlrc
@@ -5,28 +5,13 @@ select pg_reload_conf();
 
 -- Extensions
 create extension omni_python cascade;
-create extension omni_httpd cascade;
-call omni_httpd.wait_for_configuration_reloads(1);
-create extension if not exists omni_vfs cascade;
-create extension if not exists omni_mimetypes cascade;
 
--- Index VFS
-create or replace function pypi() returns omni_vfs.local_fs language sql
-as $$
-select omni_vfs.local_fs(current_setting('omni_python.cmake_binary_dir') || '/python-index')
-$$;
-
---- Configure the index server
-update omni_httpd.handlers
-set
-query = (select
-omni_httpd.cascading_query(name, query order by priority desc nulls last)
-from (select * from omni_httpd.static_file_handlers('pypi', 0, listing => true)) routes);
-
-call omni_httpd.wait_for_configuration_reloads(1);
-
--- Configure the index
-select set_config('omni_python.extra_pip_index_url','http://localhost:'  || (select effective_port from omni_httpd.listeners), false);
+-- Configure the wheels
+insert
+into
+    omni_python.config (name, value)
+values
+    ('pip_find_links', current_setting('omni_python.cmake_binary_dir') || '/python-wheels');
 
 -- Get omni_python in
 select omni_python.install_requirements('omni_python');

--- a/extensions/omni_schema/.psqlrc
+++ b/extensions/omni_schema/.psqlrc
@@ -6,28 +6,13 @@ select pg_reload_conf();
 -- Extensions
 create extension omni_schema cascade;
 create extension omni_python cascade;
-create extension omni_httpd cascade;
-call omni_httpd.wait_for_configuration_reloads(1);
-create extension if not exists omni_vfs cascade;
-create extension if not exists omni_mimetypes cascade;
 
--- Index VFS
-create or replace function pypi() returns omni_vfs.local_fs language sql
-as $$
-select omni_vfs.local_fs(current_setting('omni_python.cmake_binary_dir') || '/python-index')
-$$;
-
---- Configure the index server
-update omni_httpd.handlers
-set
-query = (select
-omni_httpd.cascading_query(name, query order by priority desc nulls last)
-from (select * from omni_httpd.static_file_handlers('pypi', 0, listing => true)) routes);
-
-call omni_httpd.wait_for_configuration_reloads(1);
-
--- Configure the index
-select set_config('omni_python.extra_pip_index_url','http://localhost:'  || (select effective_port from omni_httpd.listeners), false);
+-- Configure the wheels
+insert
+into
+    omni_python.config (name, value)
+values
+    ('pip_find_links', current_setting('omni_python.cmake_binary_dir') || '/python-wheels');
 
 -- Get omni_python in
 select omni_python.install_requirements('omni_python');

--- a/languages/python/PythonPackage.cmake
+++ b/languages/python/PythonPackage.cmake
@@ -48,9 +48,24 @@ function(add_python_package NAME)
             DEPENDS ${CMAKE_BINARY_DIR}/python-index/${_py_NAME_normalized}/${_py_PACKAGE_NAME}-${_py_VERSION}.tar.gz ${CMAKE_BINARY_DIR}/python-index/${_py_NAME_normalized}/${_py_PACKAGE_NAME}-${_py_VERSION}-py3-none-any.whl
     )
 
+    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/python-wheels/${_py_PACKAGE_NAME}-${_py_VERSION}-py3-none-any.whl
+            COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/dist/${_py_PACKAGE_NAME}-${_py_VERSION}-py3-none-any.whl ${CMAKE_BINARY_DIR}/python-wheels/${_py_PACKAGE_NAME}-${_py_VERSION}-py3-none-any.whl
+            DEPENDS ${NAME} ${CMAKE_CURRENT_BINARY_DIR}/dist/${_py_PACKAGE_NAME}-${_py_VERSION}-py3-none-any.whl)
+
+    add_custom_target(
+            ${NAME}_wheeled ALL
+            DEPENDS ${CMAKE_BINARY_DIR}/python-wheels/${_py_PACKAGE_NAME}-${_py_VERSION}-py3-none-any.whl
+    )
+
+
 
     if(NOT TARGET pip_index)
         add_custom_target(pip_index ALL)
     endif()
     add_dependencies(pip_index ${NAME}_indexed)
+
+    if(NOT TARGET wheels_dir)
+        add_custom_target(wheels_dir ALL)
+    endif()
+    add_dependencies(wheels_dir ${NAME}_wheeled)
 endfunction()


### PR DESCRIPTION
For pre-release scenarios we need to be able to use locally built versions of Python packages. This currently requires running an HTTP endpoint to serve this, and this is a little bit excessive and error-prone.

Solution: use pip's `--find-links` option

This allows us to point to a directory with wheel files. This is not ideal (can we avoid doing anything on the filesystem?) but this is way better than having to have an HTTP endpoint just for this.