### PR TITLE
Problem: omni_httpd content-length behavior is not clear

### DIFF
--- a/extensions/omni_httpd/docs/headers.md
+++ b/extensions/omni_httpd/docs/headers.md
@@ -45,34 +45,10 @@ Content-Type: text/plain
 Hi there
 ```
 
-If you set a lower `Content-Length`, the response body will be resized accordingly:
+!!! warning "Overriding Content-Length"
 
-```sql
-update
-omni_httpd.handlers
-set query = $$
-  select *
-  from omni_httpd.http_response(
-    headers => array [omni_http.http_header('Content-Type', 'text/plain'), omni_http.http_header('Content-Length', '2')],
-    body => 'Hi there'
-  )
-$$
-where id = 1;
-```
+    `omni_httpd` allows overriding the `Content-Length`. This is useful for integrating with other HTTP handlers (e.g. Flask) that set the `Content-Length`.
+    To ensure correctness, overriding works in the following way:
 
-```bash
-curl localhost:8080 -i
-
-HTTP/1.1 200 OK
-Connection: keep-alive
-Content-Length: 2
-Server: omni_httpd-0.1
-Content-Type: text/plain
-
-Hi
-```
-
-!!! warning "Overflowing Content-Length"
-
-    If you set a Content-Length higher than the size of the response body, `omni_httpd` will
-    emit a WARNING and defer to using the actual body size.
+    - If the `Content-Length` is set lower than the actual body size. `omni_httpd` will use the new `Content-Length` and downsize the response body.
+    - If the `Content-Length` is set higher than the actual body size. `omni_httpd` will keep its `Content-Length`, emit a WARNING and use the actual body size.

--- a/extensions/omni_httpd/docs/headers.md
+++ b/extensions/omni_httpd/docs/headers.md
@@ -9,3 +9,72 @@ select omni_http.http_header_get_all(request.headers, 'accept') as accept;
 ```
 
 The header name these functions take is case-insensitive.
+
+## Content-Length
+
+`omni_httpd` automatically sets the `Content-Length` header for any non-null response body.
+
+For instance, having:
+
+```sql
+create extension omni_httpd cascade;
+
+set omni_httpd.init_port to 8000;
+
+update
+omni_httpd.handlers
+set query = $$
+  select *
+  from omni_httpd.http_response(
+    headers => array [omni_http.http_header('Content-Type', 'text/plain')],
+    body => 'Hi there'
+  )
+$$
+where id = 1;
+```
+
+Will produce the response:
+
+```bash
+curl localhost:8000 -i
+
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Length: 8
+Server: omni_httpd-0.1
+Content-Type: text/plain
+
+Hi there
+```
+
+If you set a lower `Content-Length`, the response body will be resized accordingly:
+
+```sql
+update
+omni_httpd.handlers
+set query = $$
+  select *
+  from omni_httpd.http_response(
+    headers => array [omni_http.http_header('Content-Type', 'text/plain'), omni_http.http_header('Content-Length', '2')],
+    body => 'Hi there'
+  )
+$$
+where id = 1;
+```
+
+```bash
+curl localhost:8000 -i
+
+HTTP/1.1 200 OK
+Connection: keep-alive
+Content-Length: 2
+Server: omni_httpd-0.1
+Content-Type: text/plain
+
+Hi
+```
+
+!!! warning "Overflowing Content-Length"
+
+    If you set a Content-Length higher than the size of the response body, `omni_httpd` will
+    emit a WARNING and defer to using the actual body size.

--- a/extensions/omni_httpd/docs/headers.md
+++ b/extensions/omni_httpd/docs/headers.md
@@ -19,8 +19,6 @@ For instance, having:
 ```sql
 create extension omni_httpd cascade;
 
-set omni_httpd.init_port to 8000;
-
 update
 omni_httpd.handlers
 set query = $$
@@ -36,7 +34,7 @@ where id = 1;
 Will produce the response:
 
 ```bash
-curl localhost:8000 -i
+curl localhost:8080 -i
 
 HTTP/1.1 200 OK
 Connection: keep-alive
@@ -63,7 +61,7 @@ where id = 1;
 ```
 
 ```bash
-curl localhost:8000 -i
+curl localhost:8080 -i
 
 HTTP/1.1 200 OK
 Connection: keep-alive

--- a/extensions/omni_httpd/tests/http.yml
+++ b/extensions/omni_httpd/tests/http.yml
@@ -41,6 +41,15 @@ instance:
                   ('custom-content-length-1',
                    $$select omni_httpd.http_response(headers => array[omni_http.http_header('content-length', '3')], body => '0123456789')
                    from request where request.path = '/custom-content-length-1'$$, 1),
+                  ('custom-content-length-2',
+                   $$select omni_httpd.http_response(headers => array[omni_http.http_header('content-length', '100')], body => '0123456789')
+                   from request where request.path = '/custom-content-length-2'$$, 1),
+                  ('no-content-length',
+                   $$select omni_httpd.http_response(body => null)
+                   from request where request.path = '/no-content-length'$$, 1),
+                  ('0-content-length',
+                   $$select omni_httpd.http_response(body => '')
+                   from request where request.path = '/0-content-length'$$, 1),
                   ('headers',
                    $$SELECT omni_httpd.http_response(body => request.headers::text) FROM request WHERE request.path = '/headers'$$,
                    1),
@@ -155,6 +164,48 @@ tests:
   results:
   - status: 200
     body: 012
+- name: should not resize the content or modify the content-length if the set one overflows
+  query: |
+    with response as (select * from omni_httpc.http_execute(
+      omni_httpc.http_request('http://127.0.0.1:' ||
+      (select effective_port from omni_httpd.listeners where port = 0) || '/custom-content-length-2')))
+    select
+    response.status,
+    headers,
+    convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    headers: "{\"(connection,keep-alive)\",\"(content-length,10)\",\"(server,omni_httpd-0.1)\",\"(content-type,\\\"text/plain; charset=utf-8\\\")\"}"
+    body: 0123456789
+- name: should set content-length 0 on an empty string body
+  query: |
+    with response as (select * from omni_httpc.http_execute(
+      omni_httpc.http_request('http://127.0.0.1:' ||
+      (select effective_port from omni_httpd.listeners where port = 0) || '/0-content-length')))
+    select
+    response.status,
+    headers,
+    response.body
+    from response
+  results:
+  - status: 200
+    headers: "{\"(connection,keep-alive)\",\"(content-length,0)\",\"(server,omni_httpd-0.1)\",\"(content-type,\\\"text/plain; charset=utf-8\\\")\"}"
+    body: \x
+- name: should not set content-length if the handler response body is set to null
+  query: |
+    with response as (select * from omni_httpc.http_execute(
+      omni_httpc.http_request('http://127.0.0.1:' ||
+      (select effective_port from omni_httpd.listeners where port = 0) || '/no-content-length')))
+    select
+    response.status,
+    headers,
+    response.body
+    from response
+  results:
+  - status: 200
+    headers: "{\"(connection,keep-alive)\",\"(server,omni_httpd-0.1)\",\"(transfer-encoding,chunked)\"}"
+    body: \x
 - name: proxy
   query: |
     with response as (select * from omni_httpc.http_execute(


### PR DESCRIPTION
omni_httpd currently sets it automatically for any non-null response body.

Solution: document it and add a test for null response body behavior.

----

Related to the discussion on https://github.com/omnigres/omnigres/issues/279#issuecomment-1784135868