### PR TITLE
Doc: Fix some README commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ To build and run Omnigres, you would currently need a recent C compiler, OpenSSL
 ```shell
 cmake -S . -B build
 cmake --build build --parallel
+
+# in the build directory
 make psql_<COMPONENT_NAME> # for example, `psql_omni_containers`
 ```
 
@@ -136,7 +138,7 @@ make psql_<COMPONENT_NAME> # for example, `psql_omni_containers`
 
 ```shell
 # in the build directory
-CTEST_PARALLEL_LEVEL=$(nproc) make -j $(nproc) all test
+CTEST_PARALLEL_LEVEL=$(nproc) make -j $(nproc) test
 ```
 
 ## Devenv.sh-based local development environment


### PR DESCRIPTION
Added a comment indicating the directory to run `make psql_omni_containers` command from (for example).

Also, `make all test` was not working for me:
```
 ✘ akjn@aj-mbp-7md6m  ~/github-personal/omnigres   akshat/fix_build_commands  cd build
 akjn@aj-mbp-7md6m  ~/github-personal/omnigres/build   akshat/fix_build_commands  make all test
[  0%] Built target pugixml-static
[  0%] Performing build step for 'inja'
[100%] Built target inja
[  0%] No install step for 'inja'
[  0%] Completed 'inja'
[  0%] Built target inja
[  3%] Built target fyaml
[  3%] Built target pg_yregress
[  3%] Built target dynpgext_test
[  3%] Built target libpgaug
[  3%] Built target libpgaug_test
[ 26%] Built target libcurl
[ 26%] Built target libgluepg_curl
[ 33%] Built target curl
[ 36%] Built target yyjson
[ 40%] Built target libgluepg_yyjson
[ 40%] Built target checkauto
[ 43%] Built target omni_ext
[ 43%] Built target omni_ext_test
[ 43%] Built target omni_ext_test_no_preload
[ 43%] Built target omni_types
[ 43%] Built target omni_containers
[ 43%] Built target libomnisql
[ 43%] Built target gitrev
[ 63%] Built target libh2o-evloop
[ 63%] Built target omni_httpd
[ 63%] Built target h2o-httpclient
[ 90%] Built target h2o
[ 90%] Built target omni_sql
[ 90%] Built target omni_httpc
[ 90%] Built target uriparser
[ 90%] Built target omni_web
[ 93%] Built target omni_seq
[ 93%] Built target omni_vfs
[ 93%] Built target omni_txn
[ 96%] Built target omni_xml
[ 96%] Generating dist/omni_python-0.1.0.tar.gz, dist/omni_python-0.1.0-py3-none-any.whl
/Users/akjn/github-personal/omnigres/build/languages/python/omni_python/venv/bin/python3.9: No module named build
make[2]: *** [languages/python/omni_python/dist/omni_python-0.1.0.tar.gz] Error 1
make[1]: *** [languages/python/omni_python/CMakeFiles/py_omni_python.dir/all] Error 2
make: *** [all] Error 2
```

But `make test` works. So made the change. Happy to discuss this, in case I'm missing some context on this.