### PR TITLE
Problem: do we create correct S3 requests?

### DIFF
--- a/extensions/omni_aws/migrate/4_s3_list_objects_v2.sql
+++ b/extensions/omni_aws/migrate/4_s3_list_objects_v2.sql
@@ -101,6 +101,8 @@ begin
         region := request.region;
     end if;
 
+    request.path := omni_web.uri_encode(request.path);
+
     return omni_httpc.http_request(endpoint_url ||
                                    request.path || (case when length(query) > 0 then '?' || query else '' end),
                                    headers => array [

--- a/extensions/omni_aws/migrate/5_s3_put_object.sql
+++ b/extensions/omni_aws/migrate/5_s3_put_object.sql
@@ -35,10 +35,11 @@ declare
     ts8601 timestamp with time zone := now();
 begin
 
-
     if not request.path like '/%' then
         request.path := '/' || request.path;
     end if;
+
+    request.path := omni_web.uri_encode(request.path);
 
     if endpoint_url is null then
         endpoint_url := omni_aws.s3_endpoint_url(request.bucket, region);

--- a/extensions/omni_aws/migrate/7_s3_presigned_url.sql
+++ b/extensions/omni_aws/migrate/7_s3_presigned_url.sql
@@ -24,6 +24,7 @@ begin
         path := '/' || path;
     end if;
 
+    path := omni_web.uri_encode(path);
 
     if endpoint_url is null then
         endpoint_url := omni_aws.s3_endpoint_url(bucket, region);

--- a/extensions/omni_aws/tests/minio.yml
+++ b/extensions/omni_aws/tests/minio.yml
@@ -47,6 +47,18 @@ tests:
                                                                          minio))
   results: [ ]
 
+- name: list objects under a path that needs escaping
+  query: |
+    select *
+    from
+        omni_aws.aws_execute(access_key_id => 'minioadmin', secret_access_key => 'minioadmin',
+                             request => omni_aws.s3_list_objects_v2(bucket => 'omnigres-dev-test', path => '/te st'),
+                             endpoint_url => 'http://127.0.0.1:' || (select
+                                                                         inspect -> 'NetworkSettings' -> 'Ports' -> '9000/tcp' -> 0 ->> 'HostPort'
+                                                                     from
+                                                                         minio))
+  error: NoSuchKey
+
 - name: put object
   query: |
     select *

--- a/extensions/omni_aws/tests/minio.yml
+++ b/extensions/omni_aws/tests/minio.yml
@@ -3,6 +3,7 @@ instance:
   init:
   - create extension omni_aws cascade
   - create extension omni_containers cascade
+  - create extension if not exists omni_httpc cascade
 
 tests:
 
@@ -70,6 +71,27 @@ tests:
                                                                          inspect -> 'NetworkSettings' -> 'Ports' -> '9000/tcp' -> 0 ->> 'HostPort'
                                                                      from
                                                                          minio))
+
+- name: downloading pre-signed url
+  query: |
+    select
+        convert_from(body, 'utf-8') as body
+    from
+        omni_httpc.http_execute(omni_httpc.http_request((select
+                                                             omni_aws.s3_presigned_url(bucket => 'omnigres-dev-test',
+                                                                                       path => '/test',
+                                                                                       access_key_id => 'minioadmin',
+                                                                                       secret_access_key => 'minioadmin',
+                                                                                       endpoint_url =>
+                                                                                               'http://127.0.0.1:' ||
+                                                                                               (select
+                                                                                                    inspect -> 'NetworkSettings' -> 'Ports' -> '9000/tcp' -> 0 ->> 'HostPort'
+                                                                                                from
+                                                                                                    minio)
+                                                                 ))))
+  results:
+  - body: text
+
 - name: put object under a name that needs escaping
   query: |
     select *
@@ -81,6 +103,27 @@ tests:
                                                                          inspect -> 'NetworkSettings' -> 'Ports' -> '9000/tcp' -> 0 ->> 'HostPort'
                                                                      from
                                                                          minio))
+
+- name: downloading pre-signed url for path that needs escaping
+  query: |
+    select
+        convert_from(body, 'utf-8') as body
+    from
+        omni_httpc.http_execute(omni_httpc.http_request((select
+                                                             omni_aws.s3_presigned_url(bucket => 'omnigres-dev-test',
+                                                                                       path => '/t est',
+                                                                                       access_key_id => 'minioadmin',
+                                                                                       secret_access_key => 'minioadmin',
+                                                                                       endpoint_url =>
+                                                                                               'http://127.0.0.1:' ||
+                                                                                               (select
+                                                                                                    inspect -> 'NetworkSettings' -> 'Ports' -> '9000/tcp' -> 0 ->> 'HostPort'
+                                                                                                from
+                                                                                                    minio)
+                                                                 ))))
+  results:
+  - body: text
+
 - name: put a binary object
   query: |
     select *

--- a/extensions/omni_aws/tests/minio.yml
+++ b/extensions/omni_aws/tests/minio.yml
@@ -58,6 +58,17 @@ tests:
                                                                          inspect -> 'NetworkSettings' -> 'Ports' -> '9000/tcp' -> 0 ->> 'HostPort'
                                                                      from
                                                                          minio))
+- name: put a binary object
+  query: |
+    select *
+    from
+        omni_aws.aws_execute(access_key_id => 'minioadmin', secret_access_key => 'minioadmin',
+                             request => omni_aws.s3_put_object(bucket := 'omnigres-dev-test', path => '/bin',
+                                                               payload => decode('00FF', 'hex')),
+                             endpoint_url => 'http://127.0.0.1:' || (select
+                                                                         inspect -> 'NetworkSettings' -> 'Ports' -> '9000/tcp' -> 0 ->> 'HostPort'
+                                                                     from
+                                                                         minio))
 
 - name: put objects
   query: |
@@ -90,6 +101,9 @@ tests:
     order by
         key asc
   results:
+  - key: bin
+    size: 2
+    storage_class: STANDARD
   - key: test
     size: 4
     storage_class: STANDARD

--- a/extensions/omni_aws/tests/minio.yml
+++ b/extensions/omni_aws/tests/minio.yml
@@ -58,6 +58,17 @@ tests:
                                                                          inspect -> 'NetworkSettings' -> 'Ports' -> '9000/tcp' -> 0 ->> 'HostPort'
                                                                      from
                                                                          minio))
+- name: put object under a name that needs escaping
+  query: |
+    select *
+    from
+        omni_aws.aws_execute(access_key_id => 'minioadmin', secret_access_key => 'minioadmin',
+                             request => omni_aws.s3_put_object(bucket := 'omnigres-dev-test', path => '/t est',
+                                                               payload => 'text'),
+                             endpoint_url => 'http://127.0.0.1:' || (select
+                                                                         inspect -> 'NetworkSettings' -> 'Ports' -> '9000/tcp' -> 0 ->> 'HostPort'
+                                                                     from
+                                                                         minio))
 - name: put a binary object
   query: |
     select *
@@ -103,6 +114,9 @@ tests:
   results:
   - key: bin
     size: 2
+    storage_class: STANDARD
+  - key: t est
+    size: 4
     storage_class: STANDARD
   - key: test
     size: 4


### PR DESCRIPTION
Our tests don't try to upload actual (non-textual) binaries. Does the signing work correctly there? We don't have a clear answer to this.

I have a report that at least such requests resulted in a signing error and trying to investigate.

Solution: write a test and ensure it works in a basic case