### PR TITLE
Problem: sending NULL (but not empty) request body to omni_python

### DIFF
--- a/extensions/omni_python/tests/omni_python_flask.yml
+++ b/extensions/omni_python/tests/omni_python_flask.yml
@@ -70,8 +70,7 @@ tests:
          from
              omni_httpd.http_response_from_http_outcome(
                      handle(omni_httpd.http_request('/post/headers', method => 'POST',
-                                                    headers => array [omni_http.http_header('Test', 'Val')],
-                                                    body => ''
+                                                    headers => array [omni_http.http_header('Test', 'Val')]
                          )))
   results:
   - headers:

--- a/languages/python/omni_http/src/omni_http/omni_httpd/__init__.py
+++ b/languages/python/omni_http/src/omni_http/omni_httpd/__init__.py
@@ -23,7 +23,7 @@ class HTTPRequest:
         
         # set content-length header to enable body stream
         if not environ.get('CONTENT_LENGTH'): # TODO: how to handle chunked data?
-            environ['CONTENT_LENGTH'] = str(len(self.body))
+            environ['CONTENT_LENGTH'] = str(len(self.body or ""))
         return environ
 
     @classmethod


### PR DESCRIPTION
Fails with an attempt to do `len(None)`

Solution: ensure we handle this case correctly and assume it to be empty