### PR TITLE
Problem: Python code importing local modules

### DIFF
--- a/extensions/omni_python/migrate/2_functions.sql
+++ b/extensions/omni_python/migrate/2_functions.sql
@@ -42,16 +42,20 @@ $$
         if have_omni_vfs:
             import importlib.abc, importlib.machinery
             class CustomImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+                query = f"""
+                         select $1 as filename from omni_vfs.file_info('{fs}'::{fs_type}, $1) where kind = 'file'
+                         union
+                         select $2 as filename from omni_vfs.file_info('{fs}'::{fs_type}, $2) where kind = 'file'
+                         """
                 @classmethod
                 def find_spec(cls, fullname, path, target=None):
                     results = plpy.execute(
-                        plpy.prepare(
-                            f"select $1 as filename from omni_vfs.file_info('{fs}'::{fs_type}, $1) where kind = 'file'",
-                            ["text"]),
-                        [f"{fullname}.py"]
+                        plpy.prepare(cls.query, ["text", "text"]),
+                        [f"{os.path.join(*fullname.split('.'))}.py",
+                         f"{os.path.join(*fullname.split('.'))}/__init__.py"]
                     )
                     if len(results) > 0:
-                        return importlib.machinery.ModuleSpec(fullname, cls)
+                        return importlib.machinery.ModuleSpec(fullname, cls, is_package=True)
 
                 @classmethod
                 def create_module(self, spec):
@@ -61,9 +65,11 @@ $$
                 def exec_module(cls, mod):
                     source = plpy.execute(
                         plpy.prepare(
-                            f"""with files as (select $1 as filename from omni_vfs.file_info('{fs}'::{fs_type}, $1) where kind = 'file')
+                            f"""with files as ({cls.query})
                              select omni_vfs.read('{fs}'::{fs_type}, filename) as source from files
-                             """, ["text"]), [f"{mod.__name__}.py"])[0]["source"]
+                             """, ["text", "text"]),
+                        [f"{os.path.join(*mod.__name__.split('.'))}.py",
+                         f"{os.path.join(*mod.__name__.split('.'))}/__init__.py"])[0]["source"]
                     exec(source, globals(), mod.__dict__)
 
             sys.meta_path.insert(0, CustomImporter)

--- a/extensions/omni_python/migrate/2_functions.sql
+++ b/extensions/omni_python/migrate/2_functions.sql
@@ -1,4 +1,4 @@
-create function functions(code text, filename text default null)
+create function functions(code text, filename text default null, fs text default null, fs_type regtype default null)
     returns table
             (
                 name     name,
@@ -33,6 +33,41 @@ $$
 
     sys.path.insert(0, site_packages)
     import omni_python
+
+    # Consider omni_vfs as a source of custom imports
+    if fs is not None:
+        have_omni_vfs = plpy.execute(
+            plpy.prepare("select count(*) from pg_extension where extname = 'omni_vfs'")
+        )[0]['count'] > 0
+        if have_omni_vfs:
+            import importlib.abc, importlib.machinery
+            class CustomImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+                @classmethod
+                def find_spec(cls, fullname, path, target=None):
+                    results = plpy.execute(
+                        plpy.prepare(
+                            f"select $1 as filename from omni_vfs.file_info('{fs}'::{fs_type}, $1) where kind = 'file'",
+                            ["text"]),
+                        [f"{fullname}.py"]
+                    )
+                    if len(results) > 0:
+                        return importlib.machinery.ModuleSpec(fullname, cls)
+
+                @classmethod
+                def create_module(self, spec):
+                    return types.ModuleType(spec.name)
+
+                @classmethod
+                def exec_module(cls, mod):
+                    source = plpy.execute(
+                        plpy.prepare(
+                            f"""with files as (select $1 as filename from omni_vfs.file_info('{fs}'::{fs_type}, $1) where kind = 'file')
+                             select omni_vfs.read('{fs}'::{fs_type}, filename) as source from files
+                             """, ["text"]), [f"{mod.__name__}.py"])[0]["source"]
+                    exec(source, globals(), mod.__dict__)
+
+            sys.meta_path.insert(0, CustomImporter)
+    #
 
     code_locals = {}
 

--- a/extensions/omni_python/migrate/3_create_functions.sql
+++ b/extensions/omni_python/migrate/3_create_functions.sql
@@ -1,4 +1,5 @@
-create function create_functions(code text, filename text default null, replace boolean default false) returns setof regprocedure
+create function create_functions(code text, filename text default null, replace boolean default false,
+                                 fs anyelement default null::bool) returns setof regprocedure
     language plpgsql
 as
 $$
@@ -8,7 +9,8 @@ declare
     fun  regprocedure;
 begin
     lock table pg_proc in access exclusive mode;
-    for rec in select * from omni_python.functions(code, filename)
+    for rec in select *
+               from omni_python.functions(code => code, filename => filename, fs => fs::text, fs_type => pg_typeof(fs))
         loop
             select
                 array_to_string(array_agg(name || ' ' || type), ', ')

--- a/extensions/omni_schema/migrate/4_load_from_fs.sql
+++ b/extensions/omni_schema/migrate/4_load_from_fs.sql
@@ -67,8 +67,8 @@ begin
     delete from omni_schema.class;
     -- Execute
     for rec in select
-                   case when path = '' then '' else path || '/' end || name      as name,
-                   convert_from(omni_vfs.read(fs, path || '/' || name), 'utf-8') as code,
+                   case when path = '' then '' else path || '/' end || name as name,
+                   omni_vfs.read(fs, path || '/' || name)                   as code,
                    language,
                    extension,
                    file_processor,
@@ -81,63 +81,71 @@ begin
                    left join omni_schema.auxiliary_tools
                              on files.name like concat(coalesce(auxiliary_tools.filename_stem, '%'), '.',
                                                        auxiliary_tools.filename_extension)
+               where
+                   auxiliary_tools.id is not null or
+                   languages.id is not null
                order by coalesce(auxiliary_tools.priority, languages.priority) desc, name
         loop
-            if rec.language is null and rec.processor is not null then
-                if not exists(select from pg_extension where extname = rec.processor_extension) then
-                    raise notice 'Extension % required for auxiliary tool (required for %) is not installed', rec.processor_extension, rec.name;
-                else
-                    execute format('select %s(%L::text)', rec.processor, rec.code);
-                end if;
-                continue;
-            end if;
-            if rec.code ~ 'omni_schema\[\[ignore\]\]' then
-                -- Ignore the file
-                continue;
-            end if;
-            if rec.language = 'sql' then
-                execute rec.code;
-            else
-                if rec.language is null then
-                    -- Ignore file
+            declare
+                rec_code text;
+            begin
+                rec_code := convert_from(rec.code, 'utf-8');
+                if rec.language is null and rec.processor is not null then
+                    if not exists(select from pg_extension where extname = rec.processor_extension) then
+                        raise notice 'Extension % required for auxiliary tool (required for %) is not installed', rec.processor_extension, rec.name;
+                    else
+                        execute format('select %s(%L::text)', rec.processor, rec_code);
+                    end if;
                     continue;
                 end if;
-                -- Check if the language is available
-                if not exists(select from pg_extension where extname = rec.extension) then
-                    raise notice 'Extension % required for language % (required for %) is not installed', rec.extension, rec.language, rec.name;
-                    -- Don't include it in the list of loaded files
+                if rec_code ~ 'omni_schema\[\[ignore\]\]' then
+                    -- Ignore the file
                     continue;
+                end if;
+                if rec.language = 'sql' then
+                    execute rec_code;
                 else
-                    -- Prepare and execute the SQL create function construct
-                    declare
-                        sql_snippet text;
-                        regprocs    regprocedure[];
-                    begin
-                        if rec.file_processor is not null then
-                            if (rec.file_processor_extension is not null and
-                                exists(select from pg_extension where extname = rec.file_processor_extension)) or
-                               rec.file_processor_extension is null then
-                                -- Can use the file processor
-                                execute format(
-                                        'select array_agg(processor) from %s(%L::text, filename => %L::text, replace => true, fs => %L::%s) processor',
-                                        rec.file_processor,
-                                        rec.code, rec.name, fs::text, pg_typeof(fs)) into regprocs;
-                                if array_length(regprocs, 1) > 0 then
-                                    return next rec.name;
-                                    continue;
+                    if rec.language is null then
+                        -- Ignore file
+                        continue;
+                    end if;
+                    -- Check if the language is available
+                    if not exists(select from pg_extension where extname = rec.extension) then
+                        raise notice 'Extension % required for language % (required for %) is not installed', rec.extension, rec.language, rec.name;
+                        -- Don't include it in the list of loaded files
+                        continue;
+                    else
+                        -- Prepare and execute the SQL create function construct
+                        declare
+                            sql_snippet text;
+                            regprocs    regprocedure[];
+                        begin
+                            if rec.file_processor is not null then
+                                if (rec.file_processor_extension is not null and
+                                    exists(select from pg_extension where extname = rec.file_processor_extension)) or
+                                   rec.file_processor_extension is null then
+                                    -- Can use the file processor
+                                    execute format(
+                                            'select array_agg(processor) from %s(%L::text, filename => %L::text, replace => true, fs => %L::%s) processor',
+                                            rec.file_processor,
+                                            rec_code, rec.name, fs::text, pg_typeof(fs)) into regprocs;
+                                    if array_length(regprocs, 1) > 0 then
+                                        return next rec.name;
+                                        continue;
+                                    end if;
                                 end if;
                             end if;
-                        end if;
-                        if rec.code ~ 'SQL\[\[.*\]\]' then
-                            sql_snippet := format('%s language %I as %L',
-                                                  substring(rec.code from 'SQL\[\[(.*?)\]\]'), rec.language,
-                                                  rec.code);
-                            execute sql_snippet;
-                        end if;
-                    end;
+                            if rec_code ~ 'SQL\[\[.*\]\]' then
+                                sql_snippet := format('%s language %I as %L',
+                                                      substring(rec_code from 'SQL\[\[(.*?)\]\]'), rec.language,
+                                                      rec_code);
+                                execute sql_snippet;
+                            end if;
+                        end;
+                    end if;
                 end if;
-            end if;
-            return next rec.name;
+                return next rec.name;
+            end;
         end loop;
     -- New procs
     insert

--- a/extensions/omni_schema/migrate/4_load_from_fs.sql
+++ b/extensions/omni_schema/migrate/4_load_from_fs.sql
@@ -119,9 +119,9 @@ begin
                                rec.file_processor_extension is null then
                                 -- Can use the file processor
                                 execute format(
-                                        'select array_agg(processor) from %s(%L::text, filename => %L::text, replace => true) processor',
+                                        'select array_agg(processor) from %s(%L::text, filename => %L::text, replace => true, fs => %L::%s) processor',
                                         rec.file_processor,
-                                        rec.code, rec.name) into regprocs;
+                                        rec.code, rec.name, fs::text, pg_typeof(fs)) into regprocs;
                                 if array_length(regprocs, 1) > 0 then
                                     return next rec.name;
                                     continue;

--- a/extensions/omni_schema/tests/fixture/omni_python/another_module.py
+++ b/extensions/omni_schema/tests/fixture/omni_python/another_module.py
@@ -1,0 +1,2 @@
+def impl():
+    return "another module"

--- a/extensions/omni_schema/tests/fixture/omni_python/module1/__init__.py
+++ b/extensions/omni_schema/tests/fixture/omni_python/module1/__init__.py
@@ -1,0 +1,2 @@
+def impl():
+    return "module1"

--- a/extensions/omni_schema/tests/fixture/omni_python/module1/submod.py
+++ b/extensions/omni_schema/tests/fixture/omni_python/module1/submod.py
@@ -1,0 +1,2 @@
+def impl():
+    return "submod"

--- a/extensions/omni_schema/tests/fixture/omni_python/test.py
+++ b/extensions/omni_schema/tests/fixture/omni_python/test.py
@@ -1,5 +1,7 @@
 from omni_python import pg
 
+import another_module
+
 
 @pg
 def fun1(v: str) -> int:
@@ -10,6 +12,10 @@ def fun1(v: str) -> int:
 def fun2(v: str) -> str:
     return v[::-1]
 
+
+@pg
+def fun3() -> str:
+    return another_module.impl()
 
 @pg
 def add(v1: str, v2: str) -> str:

--- a/extensions/omni_schema/tests/fixture/omni_python/test.py
+++ b/extensions/omni_schema/tests/fixture/omni_python/test.py
@@ -1,7 +1,8 @@
 from omni_python import pg
 
 import another_module
-
+import module1
+import module1.submod
 
 @pg
 def fun1(v: str) -> int:
@@ -16,6 +17,17 @@ def fun2(v: str) -> str:
 @pg
 def fun3() -> str:
     return another_module.impl()
+
+
+@pg
+def fun4() -> str:
+    return module1.impl()
+
+
+@pg
+def fun5() -> str:
+    return module1.submod.impl()
+
 
 @pg
 def add(v1: str, v2: str) -> str:

--- a/extensions/omni_schema/tests/omni_python.yml
+++ b/extensions/omni_schema/tests/omni_python.yml
@@ -24,6 +24,8 @@ tests:
     - load_from_fs: a_load_time_test.py
     - load_from_fs: another_module.py
     - load_from_fs: foo.py
+    - load_from_fs: module1/__init__.py
+    - load_from_fs: module1/submod.py
     - load_from_fs: test.py
   # omni_python integration
   - query: select fun1('test')
@@ -36,6 +38,14 @@ tests:
     query: select fun3()
     results:
     - fun3: another module
+  - name: loaded `module1`
+    query: select fun4()
+    results:
+    - fun4: module1
+  - name: loaded `module1.submod`
+    query: select fun5()
+    results:
+    - fun5: submod
   # requirements.txt-dependant code
   - query: |
       select add('-539980584635519517644606174820023097370977572779217236866897631496501.40991196066825563084376519821275241099',

--- a/extensions/omni_schema/tests/omni_python.yml
+++ b/extensions/omni_schema/tests/omni_python.yml
@@ -22,6 +22,7 @@ tests:
         omni_schema.load_from_fs(omni_vfs.local_fs('../../../../extensions/omni_schema/tests/fixture/omni_python')) order by load_from_fs asc
     results:
     - load_from_fs: a_load_time_test.py
+    - load_from_fs: another_module.py
     - load_from_fs: foo.py
     - load_from_fs: test.py
   # omni_python integration
@@ -31,6 +32,10 @@ tests:
   - query: select fun2('test')
     results:
     - fun2: tset
+  - name: loaded `another_module`
+    query: select fun3()
+    results:
+    - fun3: another module
   # requirements.txt-dependant code
   - query: |
       select add('-539980584635519517644606174820023097370977572779217236866897631496501.40991196066825563084376519821275241099',


### PR DESCRIPTION
omni_schema + omni_python do not collaborate to provide local imports. One has to resort to providing path-based dependencies through requirements.txt.

Solution: implement a custom importer

The importer requires a (currently janky [1]) integration with omni_vfs.

[1] We can't pass `anyelement` in plpython so we're resorting to pass the textual representation of the fs and its type and then sticking that into a new query. Would having our own fork of plpython resolve this?

--- 

Action plan:

- [x] The importer would only consider files in the same directory, no submodules or directories. This is just to get going. This has to be fixed.
