### PR TITLE
Problem: fast is never fast enough

### DIFF
--- a/extensions/omni_httpd/migrate/1_basic_types.sql
+++ b/extensions/omni_httpd/migrate/1_basic_types.sql
@@ -14,6 +14,7 @@ create function http_request(path text, method omni_http.http_method default 'GE
                              headers http_headers default array []::http_headers)
     returns http_request
     language sql
+    immutable
 as
 $$
 select row (method, path, query_string, body, headers)
@@ -39,13 +40,12 @@ select omni_types.sum_type('http_outcome', 'http_response', 'abort', 'http_proxy
 create function abort() returns http_outcome as
 $$
 select omni_httpd.http_outcome_from_abort(omni_types.unit())
-$$ language sql;
+$$ language sql immutable;
 
 create function http_proxy(url text, preserve_host boolean default true) returns http_outcome as
 $$
 select omni_httpd.http_outcome_from_http_proxy(row (url, preserve_host))
-$$ language sql;
-
+$$ language sql immutable;
 
 create function http_response(
     body anycompatible default null,
@@ -56,6 +56,6 @@ create function http_response(
 as
 'MODULE_PATHNAME',
 'http_response'
-    language c;
+    language c immutable;
 
 create type http_protocol as enum ('http', 'https');


### PR DESCRIPTION
We all want omni_httpd to be as fast as possible

Solution: mark commonly used functions immutable as an optimization

Measured a ~3% improvement on a simple static response test.