### PR TITLE
Problem: apt command is unstable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG PLRUST_VERSION=1.2.6
 # Base builder image
 FROM debian:${DEBIAN_VER}-slim AS builder
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main contrib non-free" >> /etc/apt/sources.list 
-RUN apt update
+RUN apt-get update
 RUN apt install -y wget build-essential git clang lld flex libreadline-dev zlib1g-dev libssl-dev tmux lldb gdb make perl python3-dev python3-venv python3-pip netcat
 # current cmake is too old
 ARG DEBIAN_VER
@@ -69,7 +69,7 @@ ARG PLRUST_VERSION
 ENV PLRUST_VERSION=${PLRUST_VERSION}
 ARG PG
 ENV PG=${PG}
-RUN apt update && apt install -y curl pkg-config git build-essential libssl-dev libclang-dev flex libreadline-dev zlib1g-dev crossbuild-essential-arm64 crossbuild-essential-amd64
+RUN apt-get update && apt install -y curl pkg-config git build-essential libssl-dev libclang-dev flex libreadline-dev zlib1g-dev crossbuild-essential-arm64 crossbuild-essential-amd64
 USER postgres
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN . "$HOME/.cargo/env" && \
@@ -101,8 +101,8 @@ COPY --from=build /build/python-index /python-packages
 COPY --from=build /build/python-wheels /python-wheels
 COPY docker/initdb-slim/* /docker-entrypoint-initdb.d/
 RUN cp -R /omni/extension $(pg_config --sharedir)/ && cp -R /omni/*.so $(pg_config --pkglibdir)/ && rm -rf /omni
-RUN apt update && apt -y install libtclcl1 libpython3.9 libperl5.32
-RUN PG_VER=${PG%.*} && apt update && apt -y install postgresql-pltcl-${PG_VER} postgresql-plperl-${PG_VER} postgresql-plpython3-${PG_VER} python3-dev python3-venv python3-pip
+RUN apt-get update && apt -y install libtclcl1 libpython3.9 libperl5.32
+RUN PG_VER=${PG%.*} && apt-get update && apt -y install postgresql-pltcl-${PG_VER} postgresql-plperl-${PG_VER} postgresql-plpython3-${PG_VER} python3-dev python3-venv python3-pip
 EXPOSE 8080
 EXPOSE 5432
 


### PR DESCRIPTION
Building Docker image sometimes fails with:
```
#53 0.355 E: Package 'wget' has no installation candidate
#53 0.355 E: Package 'build-essential' has no installation candidate
#53 0.355 E: Unable to locate package clang
#53 0.355 E: Unable to locate package lld
#53 0.355 E: Package 'flex' has no installation candidate
#53 0.355 E: Unable to locate package libreadline-dev
#53 0.355 E: Package 'zlib1g-dev' has no installation candidate
#53 0.355 E: Package 'libssl-dev' has no installation candidate
#53 0.355 E: Unable to locate package lldb
#53 0.355 E: Package 'gdb' has no installation candidate
#53 0.355 E: Package 'make' has no installation candidate
#53 0.355 E: Package 'perl' has no installation candidate
#53 0.355 E: Package 'python3-dev' has no installation candidate
#53 0.355 E: Package 'python3-venv' has no installation candidate
#53 0.355 E: Package 'python3-pip' has no installation candidate
#53 0.355 E: Unable to locate package netcat
------
process "/bin/sh -c apt install -y wget build-essential git clang lld flex libreadline-dev zlib1g-dev libssl-dev tmux lldb gdb make perl python3-dev python3-venv python3-pip netcat" did not complete successfully: exit code: 100
```

Solution: use apt-get instead