### PR TITLE
Problem: Migrations are not sorted in order of versions

### DIFF
--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -318,7 +318,7 @@ if [ -d \"$_dir/${NAME}\" ]; then
   _dir=\"$_dir/${NAME}\"
 fi
 # Create file (using $$ for pid to avoid race conditions)
-for f in $(ls \"$_dir/\"*.sql | sort -n)
+for f in $(ls \"$_dir/\"*.sql | sort -V)
   do
   $<TARGET_FILE:inja> \"$f\" >> \"$1/_$$_${NAME}--${_ext_VERSION}.sql\"
   echo >> \"$1/_$$_${NAME}--${_ext_VERSION}.sql\"


### PR DESCRIPTION
This is because we use `sort -n` on the relative file paths, not just on the file names.

```shell
$ ls extensions/omni_python/migrate/*.sql | sort -n
extensions/omni_python/migrate/12_test_sorting.sql
extensions/omni_python/migrate/1_config.sql
extensions/omni_python/migrate/2_functions.sql
extensions/omni_python/migrate/3_create_functions.sql
extensions/omni_python/migrate/4_execute.sql
extensions/omni_python/migrate/5_install_requirements.sql
```

Solution: Use version sort instead of numeric sort.
```shell
$ ls extensions/omni_python/migrate/*.sql | sort -V
extensions/omni_python/migrate/1_config.sql
extensions/omni_python/migrate/2_functions.sql
extensions/omni_python/migrate/3_create_functions.sql
extensions/omni_python/migrate/4_execute.sql
extensions/omni_python/migrate/5_install_requirements.sql
extensions/omni_python/migrate/12_test_sorting.sql
```

Test plan: Validated by running `make all psql_omni_python` and verified the order of contents in generated `./pg-share/extension/omni_python--xyz.sql` file.