### PR TITLE
Problem: wrapping callables in Python is a bit annoying

### DIFF
--- a/extensions/omni_python/migrate/2_functions.sql
+++ b/extensions/omni_python/migrate/2_functions.sql
@@ -108,7 +108,7 @@ $$
                  decimal.Decimal: 'numeric', float: 'double precision'}
 
     def resolve_type(function, arg):
-        type = function.__annotations__[arg]
+        type = inspect.getfullargspec(function).annotations[arg]
         if hasattr(type, '__pg_type_hint__') and callable(type.__pg_type_hint__):
             type.__pg_type_hint__.__globals__.update(code_locals)
             type = type.__pg_type_hint__()
@@ -135,7 +135,7 @@ $$
                 return 'unknown'
 
     def process_argument(function, arg):
-        type = function.__annotations__[arg]
+        type = inspect.getfullargspec(function).annotations[arg]
         if hasattr(type, '__pg_type_hint__') and callable(type.__pg_type_hint__):
             type.__pg_type_hint__.__globals__.update(code_locals)
             type = type.__pg_type_hint__()
@@ -164,8 +164,8 @@ $$
     from textwrap import dedent
 
     return [(pgargs.get('name', name),
-             [a for a in inspect.getfullargspec(f).args],
-             [resolve_type(f, a) for a in inspect.getfullargspec(f).args], resolve_type(f, 'return'),
+             [a for a in inspect.getfullargspec(f).args if a != 'self'],
+             [resolve_type(f, a) for a in inspect.getfullargspec(f).args if a != 'self'], resolve_type(f, 'return'),
              dedent("""
              import sys
              if '__omni_python__functions__' in GD:
@@ -182,6 +182,6 @@ $$
                          site_packages=site_packages,
                          args=', '.join(
                              [process_argument(f, a) for a in
-                              inspect.getfullargspec(f).args])))
+                              inspect.getfullargspec(f).args if a != 'self'])))
             for name, f, pgargs in pg_functions]
 $$;

--- a/extensions/omni_python/tests/functions.yml
+++ b/extensions/omni_python/tests/functions.yml
@@ -246,3 +246,28 @@ tests:
   - name: execute it
     query: select fun1('test')
     notices: [ ]
+
+- name: exporting callables
+  steps:
+  - name: create
+    query: select *
+           from
+               omni_python.create_functions($1)
+    params:
+    #language=Python
+    - |
+      from omni_python import pg
+      
+      
+      class C:
+          def __call__(self, v: str) -> int:
+              return len(v)
+      
+      
+      fun1 = pg(C())
+    results:
+    - create_functions: fun1(text)
+  - name: execute it
+    query: select fun1('test')
+    results:
+    - fun1: 4


### PR DESCRIPTION
Currently, if we want to expose a callable to Postgres, we have to do something like this:

```python
thing_ = Thing()

def thing(in: int) -> int:
  return thing_(in)
```

This is particularly common for Flask integration.

While certainly doable, it is a bit annoying/redundant.

Solution: make any callable a fair game

Now it is possible to wring the code above as:

```python
thing = pg(Thing())
```