### PR TITLE
Problem: importing request from flask

### DIFF
--- a/extensions/omni_python/docs/intro.md
+++ b/extensions/omni_python/docs/intro.md
@@ -158,7 +158,7 @@ Now you can update your Python files (in the mounted volume) to include Flask fu
 from omni_python import pg
 from omni_http import omni_httpd
 from omni_http.omni_httpd import flask
-from flask import Flask, jsonify, make_response
+from flask import Flask, jsonify, make_response, request
 import uuid
 
 app = Flask('myapp')
@@ -168,7 +168,6 @@ def employees_to_json(employees):
 
 @app.route('/employees', methods=['POST'])
 def create_employee():
-    from flask import make_response, request
     json_data = json.loads(request.data.decode('UTF-8'))
 
     employee_name = json_data.get('name')

--- a/extensions/omni_python/tests/omni_python_flask.yml
+++ b/extensions/omni_python/tests/omni_python_flask.yml
@@ -22,9 +22,8 @@ instance:
     #language=Python
     - |
       from omni_python import pg
-      from omni_http import omni_httpd
       from omni_http.omni_httpd import flask
-      from flask import Flask
+      from flask import Flask, make_response, request
       import json
 
       app = Flask('myapp')
@@ -33,25 +32,17 @@ instance:
       
       @app.route('/post/body', methods=['POST'])
       def do_post():
-          from flask import make_response, request
           resp = make_response(request.data)
           return resp
       
       
       @app.route('/post/headers', methods=['POST'])
       def do_headers():
-          from flask import make_response, request
           resp = make_response(json.dumps({**request.headers}))
           return resp
       
       
-      app_ = flask.Adapter(app)
-      
-      
-      @pg
-      def handle(request: omni_httpd.HTTPRequest) -> omni_httpd.HTTPOutcome:
-          return app_(request)
-
+      handle = pg(flask.Adapter(app))
 
 tests:
 - name: POST body


### PR DESCRIPTION
At the time of the loading a Python file with such import, we'd get the following error:

```
RuntimeError: Working outside of request context.

This typically means that you attempted to use functionality that needed
an active HTTP request. Consult the documentation on testing for
information about how to avoid this problem.
```

Solution: don't consider callables without any attributes

If a callable has an empty `dir`, then there's no `__pg_stored_procedure__ and we can avoid calling `hasattr` which triggers the above error.