### PR TITLE
Problem: omni_python Flask tests may fail to start

### DIFF
--- a/extensions/omni_python/CMakeLists.txt
+++ b/extensions/omni_python/CMakeLists.txt
@@ -15,4 +15,5 @@ add_postgresql_extension(
         SCHEMA omni_python
         RELOCATABLE false
         REQUIRES plpython3u
+        TESTS_REQUIRE omni_httpd
 )


### PR DESCRIPTION
Can't find omni_httpd.

Solution: ensure omni_httpd is required for omni_python tests