### PR TITLE
Problem: reports of omni_ext/httpd crashing postgres

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: .pg
-        key: ${{ matrix.os }}-pg-${{ matrix.pgver }}-${{ hashFiles('cmake/FindPostgreSQL.cmake') }}
+        key: ${{ matrix.os }}-pg-${{ matrix.pgver }}-${{ matrix.build_type }}-${{ hashFiles('cmake/FindPostgreSQL.cmake') }}
 
     - uses: actions/cache@v3
       with:

--- a/extensions/omni_ext/init.c
+++ b/extensions/omni_ext/init.c
@@ -137,10 +137,9 @@ void shmem_hook() {
 
   {
     // Initialize the allocation dictionary
-    HTAB *dict = ShmemInitHash("omni_ext_allocation_dictionary",
-                               cdeq_allocation_request_size(&allocation_requests),
-                               max_allocation_dictionary_entries, &allocation_dictionary_ctl,
-                               ALLOCATION_DICTIONARY_HASH_ELEM);
+    HTAB *dict = ShmemInitHash(
+        "omni_ext_allocation_dictionary", cdeq_allocation_request_size(&allocation_requests),
+        max_allocation_dictionary_entries, &allocation_dictionary_ctl, HASH_ELEM | HASH_STRINGS);
 
     LWLock *lock = &(GetNamedLWLockTranche("omni_ext_allocation_dictionary")->lock);
 
@@ -178,7 +177,7 @@ void shmem_hook() {
 
   {
     HTAB *dict = ShmemInitHash("omni_ext_worker_rendezvous", 0, max_databases,
-                               &worker_rendezvous_ctl, HASH_ELEM);
+                               &worker_rendezvous_ctl, HASH_ELEM | HASH_BLOBS);
   }
 
   LWLockRelease(AddinShmemInitLock);

--- a/extensions/omni_ext/omni_ext.c
+++ b/extensions/omni_ext/omni_ext.c
@@ -187,7 +187,7 @@ void allocate_shmem_runtime(const dynpgext_handle *handle, const char *name, siz
   HTAB *dict = ShmemInitHash("omni_ext_allocation_dictionary",
                              cdeq_allocation_request_size(&allocation_requests),
                              max_allocation_dictionary_entries, &allocation_dictionary_ctl,
-                             ALLOCATION_DICTIONARY_HASH_ELEM | HASH_ATTACH);
+                             HASH_ELEM | HASH_STRINGS | HASH_ATTACH);
 
   LWLock *lock = &(GetNamedLWLockTranche("omni_ext_allocation_dictionary")->lock);
 
@@ -241,7 +241,7 @@ void *dynpgext_lookup_shmem(const char *name) {
   HTAB *dict = ShmemInitHash("omni_ext_allocation_dictionary",
                              cdeq_allocation_request_size(&allocation_requests),
                              max_allocation_dictionary_entries, &allocation_dictionary_ctl,
-                             ALLOCATION_DICTIONARY_HASH_ELEM | HASH_ATTACH);
+                             HASH_ELEM | HASH_STRINGS | HASH_ATTACH);
   LWLock *lock = &(GetNamedLWLockTranche("omni_ext_allocation_dictionary")->lock);
   LWLockAcquire(lock, LW_SHARED);
   bool found = false;

--- a/extensions/omni_ext/omni_ext.h
+++ b/extensions/omni_ext/omni_ext.h
@@ -23,10 +23,8 @@ extern dsa_area *My_dsa_area;
 extern void *My_dsa_mem;
 extern pid_t My_dsa_pid;
 
-#if PG_MAJORVERSION_NUM < 14
-#define ALLOCATION_DICTIONARY_HASH_ELEM HASH_ELEM
-#else
-#define ALLOCATION_DICTIONARY_HASH_ELEM HASH_ELEM | HASH_STRINGS
+#ifndef HASH_STRINGS
+#define HASH_STRINGS 0
 #endif
 
 #define ALLOCATION_DICTIONARY_KEY_SIZE 128

--- a/extensions/omni_httpc/tests/test.yml
+++ b/extensions/omni_httpc/tests/test.yml
@@ -26,6 +26,13 @@ instance:
   - call omni_httpd.wait_for_configuration_reloads(1)
 
 tests:
+
+- name: NULL request
+  query: select *
+         from
+             omni_httpc.http_execute(null)
+  results: [ ]
+
 - name: default GET request
   query: |
     with response as (select * from omni_httpc.http_execute(

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -171,7 +171,7 @@ static inline Datum add_header(Datum headers, char *name, char *value, bool appe
     ereport(ERROR, (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE), errmsg("integer out of range")));
 
   return array_set_element(EOHPGetRWDatum(&eah->hdr), 1, &indx, HeapTupleGetDatum(header), false,
-                           -1, -1, false, TYPALIGN_INT);
+                           -1, -1, false, eah->typalign);
 }
 
 PG_FUNCTION_INFO_V1(http_response);


### PR DESCRIPTION
This happens if Postgres is built with assertions enabled.

Solution: enable assertions and figure out the crashes

1. Ensure we always set hash element type (there are assertions checking for defaults)
2. Ensure we allocate background worker handles in top memory context to avoid reclaiming them too early.
3. Ensure we restore user and security context after committing transactions (abort reverts them, commit doesn't)

Also, discovered a case when omni_httpc client is used with null queries only: it'll crash. Avoid doing anything on requests if there are no actual requests to make.

Importantly, this makes Postgres builds slower and these are not as suitable for benchmarking as before. However, correctness being more important, this is a better default for development.