### PR TITLE
Problem: stopping minio doesn't work in macOS GitHub Actions

### DIFF
--- a/extensions/omni_aws/tests/minio.yml
+++ b/extensions/omni_aws/tests/minio.yml
@@ -185,8 +185,9 @@ tests:
 
 
 - name: stop minio
+  # long timeout because on some machine it takes a while
   query: |
     select
-        omni_containers.docker_container_stop(inspect ->> 'Id')
+        omni_containers.docker_container_stop(inspect ->> 'Id', timeout => 30000)
     from
         minio

--- a/extensions/omni_containers/migrate/5_docker_container_stop.sql
+++ b/extensions/omni_containers/migrate/5_docker_container_stop.sql
@@ -1,5 +1,5 @@
 -- API: PUBLIC
-create function docker_container_stop(id text)
+create function docker_container_stop(id text, timeout int default null)
     returns void
 as
 $$
@@ -9,7 +9,8 @@ begin
     select *
     into response
     from
-        omni_httpc.http_execute(
+        omni_httpc.http_execute_with_options(
+                omni_httpc.http_execute_options(timeout => timeout, first_byte_timeout => timeout),
                 omni_httpc.http_request(
                         format('http://%s/containers/%s/stop', omni_containers.docker_api_base_url(), id),
                         'POST'

--- a/extensions/omni_httpc/docs/reference.md
+++ b/extensions/omni_httpc/docs/reference.md
@@ -195,11 +195,13 @@ headers      | {"(age,500311)","(cache-control,max-age=604800)","(content-type,\
 
 #### Options
 
-|                    Option | Type     | Description                                                                     | Default |
-|--------------------------:|----------|---------------------------------------------------------------------------------|---------|
-|           **http2_ratio** | smallint | Percentage of requests to be attempted with HTTP/2 `(0..100)` [^ratio]          | `0`     |
+|                    Option | Type     | Description                                                            | Default |
+|--------------------------:|----------|------------------------------------------------------------------------|---------|
+|           **http2_ratio** | smallint | Percentage of requests to be attempted with HTTP/2 `(0..100)` [^ratio] | `0`     |
 |           **http3_ratio** | smallint | Percentage of requests to be attempted with HTTP/3 `(0..100)` [^ratio] | `0`     |
-| **force_cleartext_http2** | bool     | Allow HTTP/2 to be used without SSL                                             | `false` |
+| **force_cleartext_http2** | bool     | Allow HTTP/2 to be used without SSL                                    | `false` |
+|    **first_byte_timeout** | int      | Timeout before first bytes received in milliseconds.                   | 5000    |
+|               **timeout** | int      | General timeout                                                        | 5000    |
 
 !!! tip "More options will be added in the near future"
 

--- a/extensions/omni_httpc/migrate/3_http_execute.sql
+++ b/extensions/omni_httpc/migrate/3_http_execute.sql
@@ -2,7 +2,9 @@ create type http_execute_options as
 (
     http2_ratio           smallint,
     http3_ratio           smallint,
-    force_cleartext_http2 bool
+    force_cleartext_http2 bool,
+    timeout               int,
+    first_byte_timeout    int
 );
 
 create domain valid_http_execute_options as http_execute_options
@@ -12,10 +14,13 @@ create domain valid_http_execute_options as http_execute_options
         );
 
 create function http_execute_options(http2_ratio integer default 0, http3_ratio integer default 0,
-                                     force_cleartext_http2 bool default false) returns http_execute_options
+                                     force_cleartext_http2 bool default false,
+                                     timeout int default null,
+                                     first_byte_timeout int default null) returns http_execute_options
 as
 $$
-select row (http2_ratio, http3_ratio, force_cleartext_http2)::omni_httpc.valid_http_execute_options
+select
+    row (http2_ratio, http3_ratio, force_cleartext_http2, timeout, first_byte_timeout)::omni_httpc.valid_http_execute_options
 $$ language sql immutable;
 
 create function http_execute(variadic requests http_request[]) returns setof http_response

--- a/extensions/omni_httpc/omni_httpc.c
+++ b/extensions/omni_httpc/omni_httpc.c
@@ -399,6 +399,20 @@ Datum http_execute(PG_FUNCTION_ARGS) {
     if (!isnull && DatumGetBool(option_force_cleartext_http2)) {
       ctx.force_cleartext_http2 = 1;
     }
+
+    Datum option_first_byte_timeout = GetAttributeByName(options, "first_byte_timeout", &isnull);
+    int first_byte_timeout = IO_TIMEOUT;
+    if (!isnull) {
+      first_byte_timeout = DatumGetInt32(option_first_byte_timeout);
+    }
+    ctx.first_byte_timeout = first_byte_timeout;
+
+    Datum option_timeout = GetAttributeByName(options, "timeout", &isnull);
+    int timeout = IO_TIMEOUT;
+    if (!isnull) {
+      timeout = DatumGetInt32(option_timeout);
+    }
+    ctx.connect_timeout = ctx.io_timeout = ctx.keepalive_timeout = timeout;
   }
 
   if (PG_ARGISNULL(1)) {

--- a/extensions/omni_httpc/tests/timeout.yml
+++ b/extensions/omni_httpc/tests/timeout.yml
@@ -1,0 +1,96 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+    max_worker_processes: 64
+  init:
+  - set session omni_httpd.init_port = 0
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - delete
+    from
+        omni_httpd.configuration_reloads
+  - |
+    update omni_httpd.handlers
+    set
+        query = $$
+      select pg_sleep(2), omni_httpd.http_response(json_build_object(
+      'method', request.method,
+      'path', request.path,
+      'qs', request.query_string,
+      'headers', (select json_agg(json_build_object(h.name, h.value))
+                          from
+                              unnest(request.headers) h
+                          where h.name not in ('user-agent')
+                          ),
+      'body', convert_from(request.body, 'utf-8')
+      )) from request
+    $$
+  - call omni_httpd.wait_for_configuration_reloads(1)
+
+tests:
+
+- name: works as is
+  query: |
+    with
+        response as (select *
+                     from
+                         omni_httpc.http_execute(
+                                 omni_httpc.http_request('http://127.0.0.1:' ||
+                                                         (select effective_port from omni_httpd.listeners) ||
+                                                         '/test?q=1')))
+    select
+        response.status,
+        (select
+             json_agg(json_build_object(h.name, h.value))
+         from
+             unnest(response.headers) h
+         where
+             h.name not in ('server', 'content-length', 'connection')) as headers,
+        convert_from(response.body, 'utf-8')::json                     as body
+    from
+        response
+  results:
+  - status: 200
+    headers:
+    - content-type: application/json
+    body:
+      method: GET
+      path: /test
+      qs: q=1
+      headers: null
+      body: ""
+
+- name: short first byte timeout
+  query: |
+    with
+        response as (select *
+                     from
+                         omni_httpc.http_execute_with_options(
+                                 omni_httpc.http_execute_options(first_byte_timeout => 100),
+                                 omni_httpc.http_request('http://127.0.0.1:' ||
+                                                         (select effective_port from omni_httpd.listeners) ||
+                                                         '/test?q=1')))
+    select
+        error
+    from
+        response
+  results:
+  - error: first byte timeout
+
+- name: short timeout
+  # Not sure how to test it yet because first byte == response (currently)
+  skip: true
+  query: |
+    with
+        response as (select *
+                     from
+                         omni_httpc.http_execute_with_options(omni_httpc.http_execute_options(timeout => 100),
+                                                              omni_httpc.http_request('http://127.0.0.1:' ||
+                                                                                      (select effective_port from omni_httpd.listeners) ||
+                                                                                      '/test?q=1')))
+    select
+        error
+    from
+        response
+  results:


### PR DESCRIPTION
It times out.

Solution: enable timeouts for container stopping

This finally brought timeout options to the HTTP client.