### PR TITLE
Problem: verbose output in GitHub Action tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: TMPDIR=$RUNNER_TEMP ctest -timeout 1000 --force-new-ctest-process --verbose --output-on-failure -j $(nproc) -C ${{matrix.build_type}}
+      run: TMPDIR=$RUNNER_TEMP ctest -timeout 1000 --force-new-ctest-process --output-on-failure -j $(nproc) -C ${{matrix.build_type}}
 
     - uses: actions/upload-artifact@v3
       if: failure()


### PR DESCRIPTION
It makes it harded to find actual failed tests.

Solution: don't make them verbose