### PR TITLE
Problem: rebuilding extensions doesn't change their git version

### DIFF
--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -149,6 +149,8 @@ function(add_postgresql_extension NAME)
         add_library(${NAME} MODULE ${_ext_SOURCES})
     endif()
 
+    add_dependencies(${NAME} check_git_commit_hash)
+
     foreach(requirement ${_ext_REQUIRES})
         if(NOT TARGET ${requirement})
             if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../${requirement}")

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -1,3 +1,18 @@
+if(NOT TARGET check_git_commit_hash)
+    find_package(Git REQUIRED)
+
+    if(DEFINED OMNIGRES_VERSION)
+        file(GENERATE OUTPUT ${CMAKE_BINARY_DIR}/git_commit CONTENT "${OMNIGRES_VERSION}")
+    else()
+        add_custom_command(
+                OUTPUT ${CMAKE_BINARY_DIR}/git_commit
+                COMMAND ${GIT_EXECUTABLE} rev-parse HEAD > ${CMAKE_BINARY_DIR}/git_commit
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+    endif()
+
+    add_custom_target(check_git_commit_hash ALL DEPENDS ${CMAKE_BINARY_DIR}/git_commit)
+endif()
+
 macro(get_version NAME VERSION_VAR)
 
     string(TOUPPER ${NAME} _name)


### PR DESCRIPTION
If we don't trigger cmake rerun, it won't assign new versions based on Git revision to extensions. This is problematic as versions becomes desynchronized.

Solution: always trigger a reconfigure if Git revision changes