### PR TITLE
Problem: setting path to some AWS S3 functions without /

### DIFF
--- a/extensions/omni_aws/migrate/3_s3.sql
+++ b/extensions/omni_aws/migrate/3_s3.sql
@@ -50,5 +50,5 @@ as
 $$
 select
         replace(replace(endpoint.url, '${bucket}', bucket), '${region}', region) ||
-        (case when path = '/' then '' else path end)
+        (case when path = '/' then '' else '/' || ltrim(path, '/') end)
 $$;

--- a/extensions/omni_aws/tests/minio.yml
+++ b/extensions/omni_aws/tests/minio.yml
@@ -73,6 +73,17 @@ tests:
                                                                                           inspect -> 'NetworkSettings' -> 'Ports' -> '9000/tcp' -> 0 ->> 'HostPort'
                                                                                       from
                                                                                           minio)))
+- name: put object without leading slash
+  query: |
+    select *
+    from
+        omni_aws.aws_execute(access_key_id => 'minioadmin', secret_access_key => 'minioadmin',
+                             request => omni_aws.s3_put_object(bucket := 'omnigres-dev-test', path => 'test',
+                                                               payload => 'text'),
+                             endpoint => omni_aws.s3_endpoint('http://127.0.0.1:' || (select
+                                                                                          inspect -> 'NetworkSettings' -> 'Ports' -> '9000/tcp' -> 0 ->> 'HostPort'
+                                                                                      from
+                                                                                          minio)))
 
 - name: downloading pre-signed url
   query: |


### PR DESCRIPTION
For example, whem using PutObject and setting path to `test` it will error out with a malformed request.

Solution: ensure we always have a leading slash there