### PR TITLE
Problem: pg_yregress not collecting notices done during commit (deferred triggers)

### DIFF
--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -99,6 +99,8 @@ typedef struct {
     } query;
   } info;
   struct fy_node *node;
+  // To restore PQsetNoticeReceiver
+  struct fy_node *prev_notices;
   bool commit;
   bool negative;
   bool reset;

--- a/pg_yregress/test.c
+++ b/pg_yregress/test.c
@@ -421,6 +421,8 @@ proceed:
 
     while ((step = fy_node_sequence_iterate(steps, &iter))) {
       ytest *y_test = (ytest *)fy_node_get_meta(step);
+      // save notice receiver arg of parent test for multi-step tests
+      y_test->prev_notices = notices;
       if (!step_failed) {
         bool errored = false;
         bool step_success = ytest_run_internal(
@@ -496,7 +498,7 @@ proceed:
     fy_node_mapping_append(test->node, notices_key, notices);
   }
 
-  PQsetNoticeReceiver(conn, prev_notice_receiver, NULL);
+  PQsetNoticeReceiver(conn, prev_notice_receiver, test->prev_notices);
 
   // Handle `todo` tests
   struct fy_node *todo = fy_node_mapping_lookup_by_string(test->node, STRLIT("todo"));

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -199,6 +199,32 @@ tests:
   # Ensure no notices get here
   notices: [ ]
 
+- name: multi-step constraint trigger notices
+  steps:
+  - query: create table constraint_trigger_notices(id int)
+  - query: |
+      create function constraint_trigger_notices() returns trigger as $$
+      begin
+        raise notice 'raising notice %', new.id;
+        return new;
+      end;
+      $$ language plpgsql
+  - query: |
+      create constraint trigger constraint_trigger_notices after insert on constraint_trigger_notices
+      deferrable initially deferred
+      for each row execute function constraint_trigger_notices()
+    commit: true
+  - query: insert into constraint_trigger_notices values (1)
+    # Ensure no notices get here
+    notices: [ ]
+  - query: insert into constraint_trigger_notices values (2)
+    # Ensure no notices get here
+    notices: [ ]
+  commit: true
+  notices:
+  - raising notice 1
+  - raising notice 2
+
 - name: binary format
   query: select true as value
   binary: true


### PR DESCRIPTION
Notice receiver was not restored properly for multi-step tests

Solution: save notice receiver arg of parent test for multi-step tests

#261