### PR TITLE
Problem: sporadic failures in macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,13 @@ jobs:
         path: ${{github.workspace}}/build/_deps
         key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('extensions/**/CMakeLists.txt', '*/CMakeLists.txt', 'cmake/*.cmake') }}
 
+    # This is to address the fact that we build .pg in different directories on our current macOS runners
+    # and thus we need to ensure that install_name of the libraries is correct and the binaries are linked correctly
+    # as well.
+    - name: Update install_name for libraries
+      if: matrix.os == 'macos'
+      run: ci/macos_install_name .pg
+
     - name: Configure
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/ci/macos_install_name
+++ b/ci/macos_install_name
@@ -1,0 +1,39 @@
+#! /usr/bin/env bash
+
+DIRECTORY=$(realpath $1)
+
+if [[ -z "$DIRECTORY" ]]; then
+    echo "Usage: $0 path_to_directory"
+    exit 1
+fi
+
+is_mach_o() {
+    local file=$1
+    if file "$file" | grep -q 'Mach-O'; then
+        return 0  # It's a Mach-O file
+    else
+        return 1  # Not a Mach-O file
+    fi
+}
+
+update_dylibs() {
+    find "$DIRECTORY" -type f -name 'libpq*.dylib' | while read -r dylib; do
+        install_name=$(otool -D ${dylib} | tail -1)
+        dylib_name=$(basename ${dylib})
+        echo -n "Updating install name for $dylib_name: "
+        install_name_tool -id "$dylib" "$dylib"
+        dylib_path=$(realpath $dylib)
+        find "$DIRECTORY" -type f -perm +111 | while read -r binary; do
+                    if is_mach_o $binary; then
+                      install_name_tool -change "$install_name" "$dylib_path" "$binary"
+                      binary_basename=$(basename ${binary})
+                      echo -n "$binary_basename "
+                    fi
+        done
+        echo
+    done
+}
+
+update_dylibs
+
+echo "Update process complete."


### PR DESCRIPTION
The error looks like this:

```
dyld[62749]: Library not loaded: /Users/ci/actions-runner/_work/omnigres/omnigres/.pg/Darwin-Release/16.1/build/lib/libpq.5.dylib
  Referenced from: <9334436C-BA46-32DC-873D-CAAE0C09F2A1>
  /Users/ci/actions-runner1/_work/omnigres/omnigres/build/pg_yregress/pg_yregress
```

Solution: ensure we use correct install names of libraries

Bascially, we have two action runners, in $HOME/actions_runner and $HOME/actions_runner1 and when they get .pg restored from the action cache, the libraries that get built in one (like libpq) have install_name that contains a full path to where it was built. Thus. When we have `actions_runner/_work/omnigres/omnigres/.pg/.../libpq.dylib` and then restore it as
`actions_runner1/_work/omnigres/omnigres/.pg/.../libpq.dylib` and link against it, at the start time it'll try to load install_name (the original path) and will fail.

So, for now, we'll just make sure that all binaries and libraries are linked against correct libpq.