### PR TITLE
Problem: sporadic failures in macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,24 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    # This is done to address the problem on macOS where .pg built in a directory of one
+    # GitHub Action runner won't work when restored in another one since dylds have install_name pointing
+    # to the original location. We include the hash of their path into the cache name.
+    - name: Get path hash
+      if: matrix.os == 'macos'
+      run: |
+        echo "PATH_SUFFIX=-$(pwd | sha256sum | awk '{print $1}')" >> $GITHUB_ENV
+
+    # On other systems, make it explicitly empty
+    - name: Get path hash
+      if: matrix.os != 'macos'
+      run: |
+        echo "PATH_SUFFIX=" >> $GITHUB_ENV
+
     - uses: actions/cache@v3
       with:
         path: .pg
-        key: ${{ matrix.os }}-pg-${{ matrix.pgver }}-${{ matrix.build_type }}-${{ hashFiles('cmake/FindPostgreSQL.cmake') }}
+        key: ${{ matrix.os }}-pg-${{ matrix.pgver }}-${{ matrix.build_type }}-${{ hashFiles('cmake/FindPostgreSQL.cmake') }}${{ env.PATH_SUFFIX }}
 
     - uses: actions/cache@v3
       with:


### PR DESCRIPTION
The error looks like this:

```
dyld[62749]: Library not loaded: /Users/ci/actions-runner/_work/omnigres/omnigres/.pg/Darwin-Release/16.1/build/lib/libpq.5.dylib
  Referenced from: <9334436C-BA46-32DC-873D-CAAE0C09F2A1>
  /Users/ci/actions-runner1/_work/omnigres/omnigres/build/pg_yregress/pg_yregress
```

Solution: ensure we only use cached builds from the space path

Bascially, we have two action runners, in $HOME/actions_runner and $HOME/actions_runner1 and when they get .pg restored from the action cache, the libraries that get built in one (like libpq) have install_name that contains a full path to where it was built. Thus. When we have `actions_runner/_work/omnigres/omnigres/.pg/.../libpq.dylib` and then restore it as `actions_runner1/_work/omnigres/omnigres/.pg/.../libpq.dylib` and link against it, at the start time it'll try to load install_name (the original path) and will fail.

So, for now, we'll just make sure that all binaries and libraries are linked against correct libpq by using builds produced in a runner at the correct path.