### PR TITLE
Problem: h2o_url_parse fails on http://example.com:8080?abc

### DIFF
--- a/cmake/FindH2O.cmake
+++ b/cmake/FindH2O.cmake
@@ -6,6 +6,6 @@ list(APPEND _h2o_options "WITH_MRUBY OFF")
 list(APPEND _h2o_options "DISABLE_LIBUV ON")
 
 cmake_policy(SET CMP0042 NEW)
-CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG 9b260ce VERSION 2.3.0-9b260ce OPTIONS "${_h2o_options}")
+CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG cec8046 VERSION 2.3.0-cec8046 OPTIONS "${_h2o_options}")
 set_property(TARGET libh2o PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET libh2o-evloop PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/extensions/omni_httpc/omni_httpc.c
+++ b/extensions/omni_httpc/omni_httpc.c
@@ -456,7 +456,8 @@ Datum http_execute(PG_FUNCTION_ARGS) {
     }
     text *arg_url = (text *)PG_DETOAST_DATUM_PACKED(url);
 
-    if (h2o_url_parse(VARDATA_ANY(arg_url), VARSIZE_ANY_EXHDR(arg_url), &request->url) == -1) {
+    if (h2o_url_parse(pool, VARDATA_ANY(arg_url), VARSIZE_ANY_EXHDR(arg_url), &request->url) ==
+        -1) {
       ereport(ERROR, errmsg("can't parse URL"), errdetail("%s", text_to_cstring(arg_url)));
     }
 

--- a/extensions/omni_httpd/event_loop.c
+++ b/extensions/omni_httpd/event_loop.c
@@ -181,7 +181,7 @@ static void on_message(h2o_multithread_receiver_t *receiver, h2o_linklist_t *mes
       overrides->upstream =
           (h2o_url_t *)h2o_mem_alloc_pool(&req->pool, sizeof(*overrides->upstream), 1);
 
-      h2o_url_parse(proxy.url, strlen(proxy.url), overrides->upstream);
+      h2o_url_parse(&req->pool, proxy.url, strlen(proxy.url), overrides->upstream);
 
       prepare_req_for_reprocess(req);
 


### PR DESCRIPTION
However, according to RFC 3986, this is a valid URL as path/path-abempty part of the grammar allows for this (section 3.3):

"If a URI contains an authority component, then the path component must either be empty or begin with a slash ("/") character."

Solution: use a newer version of H2O that addresses this issue

Original PR: https://github.com/h2o/h2o/pull/3313
Effective PR: https://github.com/h2o/h2o/pull/3314