### PR TITLE
Problem: omni_aws DigitalOcean S3 support

### DIFF
--- a/extensions/omni_aws/migrate/4_s3_list_objects_v2.sql
+++ b/extensions/omni_aws/migrate/4_s3_list_objects_v2.sql
@@ -107,7 +107,8 @@ begin
             omni_aws.endpoint_url(endpoint, bucket => request.bucket, region => region, path => request.path);
     endpoint_uri := omni_web.text_to_uri(endpoint_url);
 
-    request.path := endpoint_uri.path;
+    -- here null path is same as root
+    request.path := coalesce(endpoint_uri.path, '/');
 
     if not request.path like '/%' then
         request.path := '/' || request.path;

--- a/extensions/omni_aws/migrate/5_s3_put_object.sql
+++ b/extensions/omni_aws/migrate/5_s3_put_object.sql
@@ -72,7 +72,7 @@ begin
                                                'AWS4-HMAC-SHA256 Credential=' || access_key_id || '/'
                                                    || to_char((ts8601 at time zone 'UTC'), 'YYYYMMDD') ||
                                                '/' || region ||
-                                               '/s3/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;content-type, Signature='
+                                               '/s3/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature='
                                                    || omni_aws.hash_string_to_sign(
                                                        'AWS4-HMAC-SHA256',
                                                        ts8601,


### PR DESCRIPTION
Seemingly everything (with the exception signed) URLs doesn't work with the digitalocean_s3_endpoint() backend, returning a signature mismatch error

Solution: set null path to '/' for methods with optional paths and send empty payload for create bucket because DigitalOcean rejects it

#391