### PR TITLE
Problem: impossible to run tests in a different database

### DIFF
--- a/pg_yregress/CHANGELOG.md
+++ b/pg_yregress/CHANGELOG.md
@@ -12,6 +12,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Test suites (YAML files) can now be named using optional `name` property.
 * Tests can now reset connections with the boolean `reset` property.
+* Tests can now be executed without a transaction (for non-transactional commands) using optional `transaction` property
+* Tests can now be executed on a different database using optional `database` property
 
 ## [0.2.0]
 

--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -367,6 +367,28 @@ tests:
   query: ...
 ```
 
+## Running queries outside explicit transaction block
+
+All the test queries are executed inside an explicit transaction block (by executing `BEGIN`) to rollback or commit side effects of tests but some queries like `CREATE DATABASE` fail with `CREATE DATABASE cannot run inside a transaction block` if executed in a transaction block. To run such queries set `transaction` property(`true` by default) to `false`:
+
+```yaml
+- name: create database outside transaction
+  transaction: false
+  query: create database another_db
+```
+
+## Connecting to another database
+
+To connect to other database in a test set `database` property to name of the other database
+
+```yaml
+- name: connect to different database
+  database: another_db
+  query: select current_database()
+  results:
+  - current_database: another_db
+```
+
 ## Configuring instances
 
 Tests may have one more instances they run on. By default, `pg_yregress` will provision one. However, if you want to configure the instance or add more than one, you can use
@@ -457,6 +479,7 @@ pg_yregress -U omnigres -W tests.yml
 
     * `instance` and `instances` configuration keys
     * `restart` tests
+    * `database`
 
 ## Configuring test suite
 

--- a/pg_yregress/instance.c
+++ b/pg_yregress/instance.c
@@ -172,7 +172,7 @@ connect:
               if (cur_step >= init_step) {
                 // We want to keep the effects of these steps and therefore we don't
                 // wrap them into a rolled back transaction.
-                success = ytest_run_without_transaction((ytest *)fy_node_get_meta(step));
+                success = ytest_run_without_transaction((ytest *)fy_node_get_meta(step), 1);
                 if (!success) {
                   break;
                 }

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -104,10 +104,14 @@ typedef struct {
   bool commit;
   bool negative;
   bool reset;
+  // If false don't execute begin statement, set to true by default
+  bool transaction;
+  // connect to other database
+  iovec_t database;
 } ytest;
 
 bool ytest_run(ytest *test);
-bool ytest_run_without_transaction(ytest *test);
+bool ytest_run_without_transaction(ytest *test, int sub_test);
 
 iovec_t ytest_name(ytest *test);
 

--- a/pg_yregress/schema.json
+++ b/pg_yregress/schema.json
@@ -303,6 +303,15 @@
                 }
               ]
             },
+            "database": {
+              "description": "Database name to connect to",
+              "type": "string"
+            },
+            "transaction": {
+              "description": "Wrap test into a transaction",
+              "type": "boolean",
+              "default": true
+            },
             "error": {
               "oneOf": [
                 {

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -454,3 +454,23 @@ tests:
     query: select current_setting('pg_yregress.test', true)
     results:
     - current_setting: null
+
+- name: create database outside transaction
+  transaction: false
+  tests:
+  - query: create database another_db_success
+  - query: select datname from pg_database where datname = 'another_db_success'
+    results:
+    - datname: another_db_success
+  - name: connect to other database
+    query: select current_database()
+    database: another_db_success
+    results:
+    - current_database: another_db_success
+
+- name: create database in transaction fail
+  # transaction: true # default value of transaction
+  query: create database another_db_fail
+  error:
+    severity: ERROR
+    message: CREATE DATABASE cannot run inside a transaction block


### PR DESCRIPTION
In some obscure cases (like omni_ext), we want to be able to test against multiple databases.

Currently, we can't do create database because we're wrapping everything into a transaction (CREATE DATABASE cannot run inside a transaction block error), and we can't switch databases on the fly (pg_yregress doesn't have support for it).

Solution: add transaction and database properties to pg_yregress test spec

setting `database` to a database name will create a connection to the specified database and close it at the end of the test

setting `transaction` to false (default is true) will not execute a `BEGIN` statement before running the test queries

#351 