### PR TITLE
Problem: outdated H2O version

### DIFF
--- a/cmake/FindH2O.cmake
+++ b/cmake/FindH2O.cmake
@@ -6,6 +6,6 @@ list(APPEND _h2o_options "WITH_MRUBY OFF")
 list(APPEND _h2o_options "DISABLE_LIBUV ON")
 
 cmake_policy(SET CMP0042 NEW)
-CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG cec8046 VERSION 2.3.0-cec8046 OPTIONS "${_h2o_options}")
+CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG 5c78fc1 VERSION 2.3.0-5c78fc1 OPTIONS "${_h2o_options}")
 set_property(TARGET libh2o PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET libh2o-evloop PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
There are some issues with it:

* it `abort()`s on some errors instead of calling h2o_fatal()
* recent security advisories

Solution: upgrade to the latest version

* https://github.com/h2o/h2o/pull/3323
* https://github.com/h2o/h2o/security/advisories/GHSA-2ch5-p59c-7mv6
* https://github.com/h2o/h2o/security/advisories/GHSA-5v5r-rghf-rm6q