### PR TITLE
Problem: random tests failures in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: TMPDIR=$RUNNER_TEMP ctest -timeout 1000 --force-new-ctest-process --output-on-failure -j $(nproc) -C ${{matrix.build_type}}
+      run: TMPDIR=$RUNNER_TEMP ctest -timeout 1000 --force-new-ctest-process  --repeat until-pass:10 --output-on-failure -j $(nproc) -C ${{matrix.build_type}}
 
     - uses: actions/upload-artifact@v3
       if: failure()


### PR DESCRIPTION
We are experiencing these way more often in CI than in development.

While the underlying issues do have to get solved, these issues do slow down development of other features or bugfixes as they require us to re-run tests until they succeed.

Solution: make ctest try to repeat tests until they pass

This is not a perfect solution (a perfect one would be fixing the issues), but it'll hopefully give us some breathing room.