### PR TITLE
Problem: locale setting of database is dependent on environment

### DIFF
--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -482,7 +482,7 @@ if [ -z \"$PGPORT\" ]; then
 fi
 export EXTENSION_SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"
 rm -rf \"${CMAKE_CURRENT_BINARY_DIR}/data/${NAME}\"
-${INITDB} -D \"${CMAKE_CURRENT_BINARY_DIR}/data/${NAME}\" --no-clean --no-sync
+${INITDB} -D \"${CMAKE_CURRENT_BINARY_DIR}/data/${NAME}\" --no-clean --no-sync --locale=C --encoding=UTF8
 export SOCKDIR=$(mktemp -d)
 echo host all all all trust >>  \"${CMAKE_CURRENT_BINARY_DIR}/data/${NAME}/pg_hba.conf\"
 PGSHAREDIR=${_share_dir} \

--- a/pg_yregress/CHANGELOG.md
+++ b/pg_yregress/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Tests can now reset connections with the boolean `reset` property.
 * Tests can now be executed without a transaction (for non-transactional commands) using optional `transaction` property
 * Tests can now be executed on a different database using optional `database` property
+* Default encoding and locale for databases can be specified using `encoding` and `locale` property of `instance`
 
 ## [0.2.0]
 

--- a/pg_yregress/docs/usage.md
+++ b/pg_yregress/docs/usage.md
@@ -433,6 +433,16 @@ instances:
 
 This is useful when tests impose special authentication requirements.
 
+You can configure default encoding and locale for databases in an instance by
+using `encoding` and `locale` key:
+
+```yaml
+instances:
+  configured:
+    encoding: SQL_ASCII
+    locale: en_US.UTF-8
+```
+
 ### Single instance configuration
 
 In case when only one instance is necessary but it needs to be configured,

--- a/pg_yregress/instance.c
+++ b/pg_yregress/instance.c
@@ -213,8 +213,10 @@ void yinstance_start(yinstance *instance) {
     // Initialize the cluster
     char *initdb_command;
     asprintf(&initdb_command,
-             "%s/pg_ctl initdb -o '-A trust -U yregress --no-clean --no-sync' -s -D %s", bindir,
-             datadir);
+             "%s/pg_ctl initdb -o '-A trust -U yregress --no-clean --no-sync --encoding=%.*s "
+             "--locale=%.*s' -s -D %s",
+             bindir, (int)IOVEC_STRLIT(instance->info.managed.encoding),
+             (int)IOVEC_STRLIT(instance->info.managed.locale), datadir);
     system(initdb_command);
 
     // Add configuration

--- a/pg_yregress/pg_yregress.c
+++ b/pg_yregress/pg_yregress.c
@@ -428,6 +428,40 @@ static int execute_document(struct fy_document *fyd, bool managed, char *host, i
           y_instance->is_default = fy_node_get_boolean(is_default);
         }
 
+        struct fy_node *encoding =
+            fy_node_mapping_lookup_by_string(y_instance->node, STRLIT("encoding"));
+        if (encoding != NULL) {
+          if (!fy_node_is_scalar(encoding)) {
+            fprintf(stderr, "encoding should be a string, got: %s",
+                    fy_emit_node_to_string(encoding, FYECF_DEFAULT));
+            return 1;
+          }
+          if (managed) {
+            y_instance->info.managed.encoding.base =
+                fy_node_get_scalar(encoding, &y_instance->info.managed.encoding.len);
+          }
+        } else if (managed) {
+          // default encoding
+          y_instance->info.managed.encoding = (iovec_t){.base = "UTF8", .len = strlen("UTF8")};
+        }
+
+        struct fy_node *locale =
+            fy_node_mapping_lookup_by_string(y_instance->node, STRLIT("locale"));
+        if (locale != NULL) {
+          if (!fy_node_is_scalar(locale)) {
+            fprintf(stderr, "locale should be a string, got: %s",
+                    fy_emit_node_to_string(locale, FYECF_DEFAULT));
+            return 1;
+          }
+          if (managed) {
+            y_instance->info.managed.locale.base =
+                fy_node_get_scalar(locale, &y_instance->info.managed.locale.len);
+          }
+        } else if (managed) {
+          // default locale
+          y_instance->info.managed.locale = (iovec_t){.base = "C", .len = strlen("C")};
+        }
+
         break;
       default:
         fprintf(stderr, "instance member has an unsupported shape: %s",

--- a/pg_yregress/pg_yregress.h
+++ b/pg_yregress/pg_yregress.h
@@ -26,6 +26,8 @@ typedef struct {
     struct {
       iovec_t datadir;
       uint16_t port;
+      iovec_t encoding;
+      iovec_t locale;
     } managed;
     struct {
       char *host;

--- a/pg_yregress/schema.json
+++ b/pg_yregress/schema.json
@@ -55,6 +55,14 @@
         "hba": {
           "type": "string",
           "description": "pg_hba.conf config"
+        },
+        "encoding": {
+          "type": "string",
+          "description": "default encoding for database"
+        },
+        "locale": {
+          "type": "string",
+          "description": "default locale for database"
         }
       }
     },

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -26,6 +26,9 @@ instances:
     hba: |
       local all all trust
       host all all all trust
+  encoding_locale:
+    encoding: SQL_ASCII
+    locale: en_US.UTF-8
 
 tests:
 
@@ -474,3 +477,26 @@ tests:
   error:
     severity: ERROR
     message: CREATE DATABASE cannot run inside a transaction block
+
+- name: default encoding and collation of instance
+  query: |
+    select
+       pg_catalog.pg_encoding_to_char(encoding) as encoding,
+       datcollate as collate
+    from pg_catalog.pg_database
+    where datname = current_database()
+  results:
+  - encoding: UTF8
+    collate: C
+
+- name: custom encoding and collation of instance
+  instance: encoding_locale
+  query: |
+    select
+       pg_catalog.pg_encoding_to_char(encoding) as encoding,
+       datcollate as collate
+    from pg_catalog.pg_database
+    where datname = current_database()
+  results:
+  - encoding: SQL_ASCII
+    collate: en_US.UTF-8


### PR DESCRIPTION
omni_vfs table_fs tests failed due to inconsistent sort ordering of text between my machine and CI runners.

The reason turned out to be different LC_COLLATE(responsible for String sort order) was different en_US.UTF-8 (on my machine) and C.UTF-8 (on CI runners) because initdb will initialize the database cluster with the locale setting of its execution environment by default.

Solution: explicitly set encoding and locale for initdb to avoid any surprises

Closes #416 