### PR TITLE
Problem: configuring psql target dbs

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,13 @@
+## Development
+
+### Using `psql` targets
+
+You can call `psql` on any of the extensions in the tree:
+
+```shell
+make psql_<EXTENSION NAME>
+```
+
+It'll try to find `postgresql.conf`, `pg_hba.conf` and `.psqlrc` in `extensions/<EXTENSION NAME>`
+to use when preparing the database and calling psql. If any are found, they will be used. Locations for these can also
+be overriden with `POSTGRESQLCONF`, `PGBHACONF` and `PSQLRC`.


### PR DESCRIPTION
Currently it's impossible to configure the databases `psql_` targets create. However, this is very limiting because sometimes we want to use them with a particular configuration.

Solution: use postgresql.conf and pg_hba.confi if provided