### PR TITLE
Problem: building OpenSSL in a container

### DIFF
--- a/cmake/OpenSSL.cmake
+++ b/cmake/OpenSSL.cmake
@@ -4,8 +4,13 @@ if(NOT DEFINED OPENSSL_CONFIGURED)
     set(OPENSSL_USE_STATIC_LIBS ON CACHE INTERNAL "OpenSSL")
     find_package(OpenSSL)
 
-    if(NOT OPENSSL_FOUND OR NOT OPENSSL_VERSION VERSION_EQUAL "3.2")
+    if(NOT OPENSSL_FOUND OR NOT OPENSSL_VERSION VERSION_GREATER_EQUAL "3.0")
 
+        if(OPENSSL_FOUND)
+            message(STATUS "OpenSSL version is expected to be 3.0 or greater, found ${OPENSSL_VERSION}")
+        else()
+            message(STATUS "No OpenSSL with static library has been found")
+        endif()
 
         find_package(Perl)
         if(PERL_FOUND AND PERL_VERSION_STRING VERSION_GREATER_EQUAL "5.10") # Version requirement from NOTES-PERL.md


### PR DESCRIPTION
Currently there is a problem building OpenSSL for a container, something with OpenSSL:

```
/usr/bin/ld: libpq/be-secure-openssl.o: in function `be_tls_open_server':
be-secure-openssl.c:(.text+0x1032): undefined reference to `SSL_get1_peer_certificate'
/usr/bin/ld: libpq/be-secure-openssl.o: in function `my_SSL_set_fd':
be-secure-openssl.c:(.text+0x1bd9): undefined reference to `ERR_new'
/usr/bin/ld: be-secure-openssl.c:(.text+0x1bf1): undefined reference to `ERR_set_debug'
/usr/bin/ld: be-secure-openssl.c:(.text+0x1c0a): undefined reference to `ERR_set_error'
/usr/bin/ld: be-secure-openssl.c:(.text+0x1c2b): undefined reference to `ERR_new'
/usr/bin/ld: be-secure-openssl.c:(.text+0x1c43): undefined reference to `ERR_set_debug'
/usr/bin/ld: be-secure-openssl.c:(.text+0x1c5c): undefined reference to `ERR_set_error'
collect2: error: ld returned 1 exit status
```

Solution: allow system OpenSSL to be used if it is >=3.0

If it is not available, we'll still try to build 3.2