### PR TITLE
Problem: in release mode, omni_ext/omni_httpd might crash

### DIFF
--- a/extensions/omni_ext/init.c
+++ b/extensions/omni_ext/init.c
@@ -211,11 +211,6 @@ void _PG_init() {
                           NULL, NULL, NULL);
   MemoryContext old_context = MemoryContextSwitchTo(TopMemoryContext);
 
-  // Initialize storage for requests
-  allocation_requests = cdeq_allocation_request_init();
-  background_worker_requests = cdeq_background_worker_request_init();
-  handles = cdeq_handle_init();
-
   // Scan the directory unless disabled
   if (getenv("OMNI_EXT_NOPRELOAD") == NULL) {
     struct load_control_file_config config = {.preload = true,

--- a/extensions/omni_ext/omni_ext.c
+++ b/extensions/omni_ext/omni_ext.c
@@ -115,9 +115,9 @@ int max_allocation_dictionary_entries;
 dsa_area *My_dsa_area;
 void *My_dsa_mem;
 pid_t My_dsa_pid;
-cdeq_allocation_request allocation_requests;
-cdeq_background_worker_request background_worker_requests;
-cdeq_handle handles;
+cdeq_allocation_request allocation_requests = {0};
+cdeq_background_worker_request background_worker_requests = {0};
+cdeq_handle handles = {0};
 
 HASHCTL allocation_dictionary_ctl = {.keysize = ALLOCATION_DICTIONARY_KEY_SIZE,
                                      .entrysize = sizeof(allocation_dictionary_entry)};

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -64,7 +64,7 @@
 h2o_multithread_receiver_t handler_receiver;
 h2o_multithread_queue_t *handler_queue;
 
-static clist_listener_contexts listener_contexts;
+static clist_listener_contexts listener_contexts = {NULL};
 
 static void on_message(h2o_multithread_receiver_t *receiver, h2o_linklist_t *messages) {
   while (!h2o_linklist_is_empty(messages)) {
@@ -134,8 +134,6 @@ void http_worker(Datum db_oid) {
   // Connect worker to the database
   BackgroundWorkerInitializeConnectionByOid(db_oid, InvalidOid, 0);
   TopUser = GetAuthenticatedUserId();
-
-  listener_contexts = clist_listener_contexts_init();
 
   volatile pg_atomic_uint32 *semaphore =
       dynpgext_lookup_shmem(OMNI_HTTPD_CONFIGURATION_RELOAD_SEMAPHORE);

--- a/extensions/omni_httpd/master_worker.c
+++ b/extensions/omni_httpd/master_worker.c
@@ -88,7 +88,7 @@ static h2o_evloop_t *event_loop;
  * Maintained and used by the master worker
  *
  */
-static cvec_fd sockets;
+static cvec_fd sockets = {NULL};
 
 /**
  * @brief UNIX socket connection accept handler
@@ -223,7 +223,6 @@ void master_worker(Datum db_oid) {
   event_loop = h2o_evloop_create();
   prepare_share_fd();
 
-  sockets = cvec_fd_init();
   cmap_portsock portsocks = cmap_portsock_init();
   cvec_bgwhandle http_workers = cvec_bgwhandle_init();
 


### PR DESCRIPTION
Observed a segmentation fault preparing background worker records in omni_ext.

Solution: ensure static initialization of global containers

Valgrind indicated use of stack-allocated uninitialized values, and this has led to changes in how we initialize global containers to ensure we don't run into this problem.