### PR TITLE
Problem: debugging remote Omnigres

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,14 @@ COPY docker/initdb-slim/* /docker-entrypoint-initdb.d/
 RUN cp -R /omni/extension $(pg_config --sharedir)/ && cp -R /omni/*.so $(pg_config --pkglibdir)/ && rm -rf /omni
 RUN apt-get update && apt-get -y install libtclcl1 libpython3.11 libperl5.36
 RUN PG_VER=${PG%.*} && apt-get update && apt-get -y install postgresql-pltcl-${PG_VER} postgresql-plperl-${PG_VER} postgresql-plpython3-${PG_VER} python3-dev python3-venv python3-pip
+RUN apt-get -y install curl
+RUN curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null && \
+    curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list | tee /etc/apt/sources.list.d/tailscale.list
+RUN apt-get update && apt-get -y install tailscale
+COPY docker/entrypoint.sh /usr/local/bin/omnigres-entrypoint.sh
+ENTRYPOINT ["omnigres-entrypoint.sh"]
+CMD ["postgres"]
+EXPOSE 22
 EXPOSE 8080
 EXPOSE 5432
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG OMNIGRES_VERSION=current
 # Version of PostgreSQL
 ARG PG=16.1
 # Build type
-ARG BUILD_TYPE=Release
+ARG BUILD_TYPE=RelWithDebInfo
 # User name to be used for builder
 ARG USER=omni
 # Using 501 to match Colima's default
@@ -107,6 +107,7 @@ RUN apt-get -y install curl
 RUN curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null && \
     curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list | tee /etc/apt/sources.list.d/tailscale.list
 RUN apt-get update && apt-get -y install tailscale
+RUN apt-get install -y lldb-16 libc6-dbg vim valgrind # Ultimate debug toolkit
 COPY docker/entrypoint.sh /usr/local/bin/omnigres-entrypoint.sh
 ENTRYPOINT ["omnigres-entrypoint.sh"]
 CMD ["postgres"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env bash
+
+if [ -n "$TAILSCALE_AUTHKEY" ]; then
+  echo "Initializing Tailscale"
+  tailscaled --tun=userspace-networking &
+  echo "Connecting to Tailscale"
+  tailscale up --ssh --authkey=$TAILSCALE_AUTHKEY --hostname=$TAILSCALE_HOSTNAME
+fi
+source docker-entrypoint.sh
+_main $@

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,10 @@
 #! /usr/bin/env bash
 
+if [ -n "$ALLOW_CORE_FILES" ]; then
+  # Allow unlimited core files
+  ulimit -c unlimited
+fi
+
 if [ -n "$TAILSCALE_AUTHKEY" ]; then
   echo "Initializing Tailscale"
   tailscaled --tun=userspace-networking &


### PR DESCRIPTION
When a user experiences a problem, a crash or something of the kind,
it's difficult to figure out what happened.
    
Solution: enable Tailscale integration
    
When Tailscale auth key is specified, it'll connect to the appropriate
Tailnet and remote access to the instance will be possible.

This also changes the settings and adds some tools (like lldb, valgrind, etc.) to make it more debuggable.