### PR TITLE
Problem: omni_var.get crashes with SIGSEGV

### DIFF
--- a/extensions/omni_var/omni_var.c
+++ b/extensions/omni_var/omni_var.c
@@ -226,7 +226,7 @@ Datum get(PG_FUNCTION_ARGS) {
   }
 
   bool found = false;
-  Variable *var = (Variable *)hash_search(current_tab, PG_GETARG_NAME(0), HASH_ENTER, &found);
+  Variable *var = (Variable *)hash_search(current_tab, PG_GETARG_NAME(0), HASH_FIND, &found);
   if (found) {
     VariableValue *vvar = var->variable_value;
     if (vvar->isnull) {

--- a/extensions/omni_var/tests/variables.yml
+++ b/extensions/omni_var/tests/variables.yml
@@ -133,3 +133,11 @@ tests:
   - query: select omni_var.get('test', null::int4)
     results:
     - get: 1
+
+- name: double-find bug
+  # This bug occurred because we were populating an entry in the hashtable when a variable was not found
+  steps:
+  # Ensure we set something to initialize the hashtable
+  - select omni_var.set('some', 1)
+  - select omni_var.get('test', 1)
+  - select omni_var.get('test', 1)


### PR DESCRIPTION
Solution: ensure we don't create a new hashtable entry when we search for a variable.