### PR TITLE
Problem: preloading some extensions in tests

### DIFF
--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -120,7 +120,7 @@ foreach(file \${files})
     add_test(\"${NAME}/\${file}\" ${CMAKE_BINARY_DIR}/script_${NAME} ${_ext_dir} \"$<TARGET_FILE:pg_yregress>\" \"${dir}/\${file}\")
     set_tests_properties(\"${NAME}/\${file}\" PROPERTIES
     WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\"
-    ENVIRONMENT \"PGCONFIG=${PG_CONFIG};PGSHAREDIR=${_share_dir};OMNI_EXT_SO=$<$<TARGET_EXISTS:omni_ext>:$<TARGET_FILE:omni_ext>>\")
+    ENVIRONMENT \"PGCONFIG=${PG_CONFIG};PGSHAREDIR=${_share_dir};OMNI_EXT_SO=$<$<TARGET_EXISTS:omni_ext>:$<TARGET_FILE:omni_ext>>;EXTENSION_FILE=$<$<STREQUAL:$<TARGET_PROPERTY:${NAME},TYPE>,MODULE_LIBRARY>:$<TARGET_FILE:${NAME}>>\")
 endforeach()
 ")
         get_directory_property(current_includes TEST_INCLUDE_FILES)


### PR DESCRIPTION
If an extension is not a dynpgext extension, we need to be able to load it without omni_ext. But we don't know the filename because it contains a version.

Solution: pass `EXTENSION_FILE` environment variable to pg_yregress

It can now be used as `*/env/EXTENSION_FILE` in the test