### PR TITLE
Problem: manually trying certain behaviours between restarts

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -11,3 +11,6 @@ make psql_<EXTENSION NAME>
 It'll try to find `postgresql.conf`, `pg_hba.conf` and `.psqlrc` in `extensions/<EXTENSION NAME>`
 to use when preparing the database and calling psql. If any are found, they will be used. Locations for these can also
 be overriden with `POSTGRESQLCONF`, `PGBHACONF` and `PSQLRC`.
+
+If you want to persist a database between runs, use `PSQLDB` environment variable to point to a directory that should
+contain the database.


### PR DESCRIPTION
One problem with `make psql_<EXT>` workflow is that it re-initializes a database every time it start. This makes it hard to explore scenarios that require restarting the database and still having the same data.

Solution: introduce PSQLDB environment variable

Specifying this variable instructs the aforementioned `psql` targets to use a specific location for the database and don't wipe it.