### PR TITLE
Problem: mktemp -d may fail in `psql_<EXT>`

### DIFF
--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -498,6 +498,7 @@ if [ -z \"$PGPORT\" ]; then
 fi
 export EXTENSION_SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"
 if [ -z \"$PSQLDB\" ]; then
+   mkdir -p \"${CMAKE_CURRENT_BINARY_DIR}/data\"
    PSQLDB=\"$(mktemp -d ${CMAKE_CURRENT_BINARY_DIR}/data/${NAME}.XXXXXX)\"
    rm -rf \"$PSQLDB\"
 fi


### PR DESCRIPTION
It fails because `CMAKE_CURRENT_BINARY_DIR/data` might not exist.

Solution: ensure it does