### PR TITLE
Problem: upgrading omni_httpd in runtime

### DIFF
--- a/extensions/omni_ext/control_file.c
+++ b/extensions/omni_ext/control_file.c
@@ -284,11 +284,17 @@ void load_control_file(const char *control_path, void *data) {
         // Only proceed if there's a module pathname and a matching version
         bool proceed = (control_file.module_pathname != NULL) && matching_version;
         // Check if this extension was already loaded at the statup time
-        if (!config->preload) {
+        if (proceed && !config->preload) {
           c_FOREACH(it, cdeq_handle, handles) {
             // and if it was, don't proceed with it
             proceed = !(strcmp((*it.ref)->name, control_file.ext_name) == 0 &&
                         strcmp((*it.ref)->version, control_file.ext_version) == 0);
+
+            if (config->action == UNLOAD && !proceed) {
+              // However, if we're unloading, then it is the opposite: we should
+              // proceed with it
+              proceed = true;
+            }
 
             if (!proceed)
               break;

--- a/extensions/omni_httpd/migrate/6_unload.sql
+++ b/extensions/omni_httpd/migrate/6_unload.sql
@@ -1,0 +1,3 @@
+create function unload() returns void
+    language c as
+'MODULE_PATHNAME';

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -32,6 +32,8 @@ static const char *OMNI_HTTPD_CONFIGURATION_NOTIFY_CHANNEL = "omni_httpd_configu
 static const char *OMNI_HTTPD_CONFIGURATION_RELOAD_SEMAPHORE =
     "omni_httpd:" EXT_VERSION ":_configuration_reload_semaphore";
 
+static const char *OMNI_HTTPD_MASTER_WORKER = "omni_httpd:" EXT_VERSION ":_master_worker";
+
 #define HTTP_RESPONSE_TUPLE_BODY 0
 #define HTTP_RESPONSE_TUPLE_STATUS 1
 #define HTTP_RESPONSE_TUPLE_HEADERS 2

--- a/extensions/omni_httpd/tests/unloading.yml
+++ b/extensions/omni_httpd/tests/unloading.yml
@@ -27,7 +27,6 @@ tests:
 - name: stops working after unloading
   steps:
   - select omni_httpd.unload()
-  - select pg_sleep(1)
   - query: |
       with
           response as (select *

--- a/extensions/omni_httpd/tests/unloading.yml
+++ b/extensions/omni_httpd/tests/unloading.yml
@@ -4,7 +4,6 @@ instance:
     shared_preload_libraries: */env/OMNI_EXT_SO
     max_worker_processes: 64
   init:
-  - create extension omni_ext
   - create extension omni_httpd cascade
   - create extension omni_httpc cascade
   - call omni_httpd.wait_for_configuration_reloads(1)
@@ -27,9 +26,7 @@ tests:
 
 - name: stops working after unloading
   steps:
-  - select
-        omni_ext.unload('omni_httpd'::cstring,
-                        (select extversion::cstring from pg_extension where extname = 'omni_httpd'))
+  - select omni_httpd.unload()
   - select pg_sleep(1)
   - query: |
       with

--- a/extensions/omni_httpd/tests/unloading.yml
+++ b/extensions/omni_httpd/tests/unloading.yml
@@ -1,0 +1,46 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+    max_worker_processes: 64
+  init:
+  - create extension omni_ext
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - call omni_httpd.wait_for_configuration_reloads(1)
+
+tests:
+- name: works
+  query: |
+    with
+        response as (select *
+                     from
+                         omni_httpc.http_execute(
+                                 omni_httpc.http_request('http://127.0.0.1:' ||
+                                                         (select effective_port from omni_httpd.listeners) || '/')))
+    select
+        response.error
+    from
+        response
+  results:
+  - error: null
+
+- name: stops working after unloading
+  steps:
+  - select
+        omni_ext.unload('omni_httpd'::cstring,
+                        (select extversion::cstring from pg_extension where extname = 'omni_httpd'))
+  - select pg_sleep(1)
+  - query: |
+      with
+          response as (select *
+                       from
+                           omni_httpc.http_execute(
+                                   omni_httpc.http_request('http://127.0.0.1:' ||
+                                                           (select effective_port from omni_httpd.listeners) || '/')))
+      select
+          response.error is null as error
+      from
+          response
+    results:
+    - error: false


### PR DESCRIPTION
There is no way to stop it to load another version of the extension.

Solution: use omni_ext unloading to kill the master worker

The master worker's PID is set by the master worker itself upon startup.

Also fixes a bug in omni_ext that wouldn't really unload anything that was already loaded during startup.

This is not a complete end-to-end solution to upgrading omni_httpd, but it is definitely a component to it.