### PR TITLE
Problem: Scheduled Builds require approval

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
 
     needs: [ approve ] # Require the first step to finish
-    environment: ${{ (github.event_name == 'push' || contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association)) && 'master' || 'Integrate Pull Request' }}
+    environment: ${{ (github.event_name == 'push' || github.event_name == 'schedule' || contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association)) && 'master' || 'Integrate Pull Request' }}
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Context: It looks like scheduled builds were introduced to keep the [GitHub build cache warm](https://github.com/omnigres/omnigres/commit/95e1d839992aa587fe47029bfd2b5387b44eb608). Later an approval step was introduced to the workflow which requires approval even for the scheduled builds, which results in those scheduled builds not being run without manual approval.

Solution: Run scheduled builds on the `master` environment. 

Alternative Solution: Alternatively we can delete the scheduled cron because this particular workflow has been migrated to Warp and FlyCI.

_P.S.: I'm one of the co-founders of [FlyCI](https://www.flyci.net/)._