### PR TITLE
Problem: seeing superfluous data in pg_yregress test results

### DIFF
--- a/pg_yregress/CHANGELOG.md
+++ b/pg_yregress/CHANGELOG.md
@@ -8,6 +8,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* Test query parameters (`params`) may have been passed with trailing data from the test suite because scalars were
+  processed without their length. This could have led to sending superfluous trailing data to Postgres.
+
 ## [0.3.0]
 
 ### Added

--- a/pg_yregress/test.c
+++ b/pg_yregress/test.c
@@ -210,13 +210,14 @@ proceed:
             } else {
               // Use the supplied string as the source for binary
               // if it is not a hex
-              param_length[i] = strlen(values[i]);
+              param_length[i] = len;
               // This way we can free it, too
-              values[i] = strdup(values[i]);
+              values[i] = strndup(values[i], len);
             }
           } else {
             // This way we can free it, too
-            values[i] = strdup(values[i]);
+            values[i] = strndup(values[i], len);
+            param_length[i] = len;
           }
           break;
         }


### PR DESCRIPTION
Under some circumstances (while developing Logtalk integration) pg_yregress tests with `params` were (oddly) returning results that were containing a portion of the test suite file.

Solution: ensure param scalars are constrained by their length before sending them off to Postgres.

Not doing so opens up the problem of pointing to the whole file's content.