### PR TITLE
Problem: older clang-format

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,5 +10,5 @@ jobs:
     - name: Run clang-format style check
       uses: jidicula/clang-format-action@v4.10.2
       with:
-        clang-format-version: '15'
+        clang-format-version: '17'
         check-path: '.'

--- a/extensions/omni_ext/control_file.h
+++ b/extensions/omni_ext/control_file.h
@@ -16,7 +16,7 @@ typedef struct {
   char *comment;
   char *encoding;
   char *module_pathname;
-  char *requires;
+  char *requires_extensions;
 
   bool superuser;
   bool trusted;

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -218,7 +218,7 @@ void http_worker(Datum db_oid) {
           h2o_context_dispose(&iter.ref->context);
           MemoryContextDelete(iter.ref->memory_context);
           iter = clist_listener_contexts_erase_at(&listener_contexts, iter);
-        next_ctx : {}
+        next_ctx: {}
         }
       }
 


### PR DESCRIPTION
We were stuck with clang-format 15 for a while and (for example), on homebrew it is now 17.

Solution: switch to 17

I have to rename `requires` as 17 formats it differently now.