### PR TITLE
Problem: loading omni_ext without preloading

### DIFF
--- a/extensions/omni_ext/init.c
+++ b/extensions/omni_ext/init.c
@@ -186,6 +186,9 @@ void shmem_hook() {
 static bool _dynpgext_loader_present = true;
 
 void _PG_init() {
+  if (!process_shared_preload_libraries_in_progress) {
+    return;
+  }
   DefineCustomBoolVariable("dynpgext.loader_present",
                            "Flag indicating presence of a Dynpgext loader", NULL,
                            &_dynpgext_loader_present, true, PGC_BACKEND, 0, NULL, NULL, NULL);


### PR DESCRIPTION
It tries to initialize PGC_POSTMASTER variables and do other things that can only be done during shared preloading.

Solution: don't try to initialize omni_ext unless being preloaded