### PR TITLE
Problem: omni_schema migrations are not always ordered correctly

### DIFF
--- a/extensions/omni_schema/src/migrate_from_fs.sql
+++ b/extensions/omni_schema/src/migrate_from_fs.sql
@@ -15,7 +15,7 @@ begin
                where
                    files.name like '%.sql' and
                    migrations.name is null
-               order by files.name asc
+               order by substring(files.name from '[0-9]+')::int asc
         loop
             execute rec.code;
             return next rec.name;

--- a/extensions/omni_schema/tests/fixture/natsort/04_.sql
+++ b/extensions/omni_schema/tests/fixture/natsort/04_.sql
@@ -1,0 +1,5 @@
+insert
+into
+    test (value)
+values
+    (4);

--- a/extensions/omni_schema/tests/fixture/natsort/1_.sql
+++ b/extensions/omni_schema/tests/fixture/natsort/1_.sql
@@ -1,0 +1,5 @@
+create table test
+(
+    id    integer primary key generated always as identity,
+    value int
+);

--- a/extensions/omni_schema/tests/fixture/natsort/2_.sql
+++ b/extensions/omni_schema/tests/fixture/natsort/2_.sql
@@ -1,0 +1,5 @@
+insert
+into
+    test (value)
+values
+    (2);

--- a/extensions/omni_schema/tests/fixture/natsort/33_.sql
+++ b/extensions/omni_schema/tests/fixture/natsort/33_.sql
@@ -1,0 +1,5 @@
+insert
+into
+    test (value)
+values
+    (33);

--- a/extensions/omni_schema/tests/fixture/natsort/3_.sql
+++ b/extensions/omni_schema/tests/fixture/natsort/3_.sql
@@ -1,0 +1,5 @@
+insert
+into
+    test (value)
+values
+    (3);

--- a/extensions/omni_schema/tests/fixture/natsort/5_.sql
+++ b/extensions/omni_schema/tests/fixture/natsort/5_.sql
@@ -1,0 +1,5 @@
+insert
+into
+    test (value)
+values
+    (5);

--- a/extensions/omni_schema/tests/test.yml
+++ b/extensions/omni_schema/tests/test.yml
@@ -207,3 +207,37 @@ tests:
   results:
   - migrate_from_fs: 1/1_create_table_x.sql
   - migrate_from_fs: 1/2_add_column_to_x.sql
+
+- name: migrations are naturally sorted
+  steps:
+  - query: select
+               count(*)
+           from
+               omni_schema.migrations
+    results:
+    - count: 0
+  - query: |
+      select *
+      from
+          omni_schema.migrate_from_fs(omni_vfs.local_fs('../../../../extensions/omni_schema/tests/fixture/natsort'))
+    results:
+    - migrate_from_fs: 1_.sql
+    - migrate_from_fs: 2_.sql
+    - migrate_from_fs: 3_.sql
+    - migrate_from_fs: 04_.sql
+    - migrate_from_fs: 5_.sql
+    - migrate_from_fs: 33_.sql
+  - name: executed in the right order
+    query: |
+      select
+          value
+      from
+          test
+      order by
+          id asc
+    results:
+    - value: 2
+    - value: 3
+    - value: 4
+    - value: 5
+    - value: 33


### PR DESCRIPTION
For example, `33_descr` may precede `3_descr`. Also, zero-prefixed numbers will misplace ordering as well.

Solution: ensure omni_schema.migrate_from_fs uses natural sorting