### PR TITLE
Problem: omni_ext does not start database-local workers in runtime

### DIFF
--- a/dynpgext/docs/usage.md
+++ b/dynpgext/docs/usage.md
@@ -41,7 +41,7 @@ BackgroundWorker bgw = {.bgw_name = "worker",
                           .bgw_flags = BGWORKER_SHMEM_ACCESS,
                           .bgw_start_time = BgWorkerStart_RecoveryFinished};
 strncpy(bgw.bgw_library_name, handle->library_name, BGW_MAXLEN);
-handle->register_bgworker(handle, &bgw, NULL, NULL,
+handle->register_bgworker(handle, &bgw,
                            DYNPGEXT_REGISTER_BGWORKER_NOTIFY | DYNPGEXT_SCOPE_GLOBAL /* can also take DYNPGEXT_SCOPE_DATABASE_LOCAL */);
 ```
 

--- a/dynpgext/dynpgext.h
+++ b/dynpgext/dynpgext.h
@@ -160,10 +160,9 @@ typedef void (*dynpgext_allocate_shmem_function)(const dynpgext_handle *handle, 
  * @brief Background worker registration function
  *
  */
-typedef void (*dynpgext_register_bgworker_function)(
-    const dynpgext_handle *handle, BackgroundWorker *bgw,
-    void (*callback)(BackgroundWorkerHandle *handle, void *data), void *data,
-    dynpgext_register_bgworker_flags flags);
+typedef void (*dynpgext_register_bgworker_function)(const dynpgext_handle *handle,
+                                                    BackgroundWorker *bgw,
+                                                    dynpgext_register_bgworker_flags flags);
 
 /**
  * @brief Handle provided by the loader

--- a/extensions/omni_ext/test/migrate/omni_ext_test_no_preload/omni_ext_test_no_preload.sql
+++ b/extensions/omni_ext/test/migrate/omni_ext_test_no_preload/omni_ext_test_no_preload.sql
@@ -7,3 +7,10 @@ CREATE FUNCTION alloc_shmem_database_local()
     RETURNS cstring
     AS 'MODULE_PATHNAME', 'alloc_shmem_database_local'
     LANGUAGE C;
+
+create function wait_for_table(name text)
+    returns bool
+as
+'MODULE_PATHNAME',
+'wait_for_table'
+    language c;

--- a/extensions/omni_ext/test/tests/omni_ext_test_no_preload/bgw.yml
+++ b/extensions/omni_ext/test/tests/omni_ext_test_no_preload/bgw.yml
@@ -1,0 +1,41 @@
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+  init:
+  - create extension omni_ext_test_no_preload cascade
+
+tests:
+
+- name: prepare another database
+  transaction: false
+  tests:
+  - create database another_db
+  - query: create extension omni_ext_test_no_preload cascade
+    database: another_db
+
+- name: database-local worker not started yet
+  query: select omni_ext_test_no_preload.wait_for_table('local_worker_started')
+  database: another_db
+  results:
+  - wait_for_table: false
+
+- name: global worker not started yet
+  query: select omni_ext_test_no_preload.wait_for_table('global_worker_started')
+  results:
+  - wait_for_table: false
+
+- name: Load the extension
+  query: select omni_ext.load('omni_ext_test_no_preload')
+  results:
+  - load: 0.1
+
+- name: database-local worker started
+  query: select omni_ext_test_no_preload.wait_for_table('local_worker_started')
+  database: another_db
+  results:
+  - wait_for_table: true
+
+- name: global worker started
+  query: select omni_ext_test_no_preload.wait_for_table('global_worker_started')
+  results:
+  - wait_for_table: true

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -117,7 +117,7 @@ void _Dynpgext_init(const dynpgext_handle *handle) {
                           .bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION,
                           .bgw_start_time = BgWorkerStart_RecoveryFinished};
   strncpy(bgw.bgw_library_name, handle->library_name, BGW_MAXLEN);
-  handle->register_bgworker(handle, &bgw, NULL, NULL,
+  handle->register_bgworker(handle, &bgw,
                             DYNPGEXT_REGISTER_BGWORKER_NOTIFY | DYNPGEXT_SCOPE_DATABASE_LOCAL);
 }
 


### PR DESCRIPTION
When an extension is not preloaded, database-local workers are not started since we need to scan extensions in different databases.

Solution: use a shared table to list background worker requests

This also avoids the need for a rather convoluted rendezvous we had.

I got rid of callbacks in background worker registration. While this has worked for workers initialized during the initial startup phase, this has become increasingly more complex for runtime-started workers. Problem is that we can't simply point to the function or the callback payload if they weren't loaded and prepared during the startup phase in the parent process. To date, this capability hasn't been used and, as far as I can tell, it doesn't provide any extra functionality that can't be achieved by executing that logic in the worker itself.

Closes #21
Closes #22