### PR TITLE
Problem: omni_ext background worker startup not tested correctly

### DIFF
--- a/extensions/omni_ext/init.c
+++ b/extensions/omni_ext/init.c
@@ -185,6 +185,8 @@ void shmem_hook() {
     shared_info =
         (SharedInfo *)ShmemInitStruct("omni_ext: shared_info", sizeof(SharedInfo), &found);
     Assert(!found);
+    // ensure it's all zeroes for the sake of tests using reserved space
+    memset((void *)shared_info, 0, sizeof(SharedInfo));
     // Initialize background worker request counter
     pg_atomic_write_u64(&shared_info->bgworker_next_id, 0);
   }

--- a/extensions/omni_ext/omni_ext.h
+++ b/extensions/omni_ext/omni_ext.h
@@ -109,6 +109,8 @@ extern HTAB *BackgroundWorkerRequests;
 
 typedef struct {
   pg_atomic_uint64 bgworker_next_id;
+  // This is currently used by tests and nothing else:
+  char reserved[64];
 } SharedInfo;
 
 extern SharedInfo *shared_info;

--- a/extensions/omni_ext/test/migrate/omni_ext_test/omni_ext_test.sql
+++ b/extensions/omni_ext/test/migrate/omni_ext_test/omni_ext_test.sql
@@ -17,3 +17,7 @@ CREATE FUNCTION wait_for_table(name text)
     RETURNS bool
     AS 'MODULE_PATHNAME', 'wait_for_table'
     LANGUAGE C;
+
+create function wait_for_global_bgworker()
+    returns bool as
+'MODULE_PATHNAME' language c;

--- a/extensions/omni_ext/test/migrate/omni_ext_test_no_preload/omni_ext_test_no_preload.sql
+++ b/extensions/omni_ext/test/migrate/omni_ext_test_no_preload/omni_ext_test_no_preload.sql
@@ -14,3 +14,7 @@ as
 'MODULE_PATHNAME',
 'wait_for_table'
     language c;
+
+create function wait_for_global_bgworker()
+    returns bool as
+'MODULE_PATHNAME' language c;

--- a/extensions/omni_ext/test/omni_ext_test.c
+++ b/extensions/omni_ext/test/omni_ext_test.c
@@ -12,6 +12,7 @@
 #endif
 #include <executor/spi.h>
 #include <miscadmin.h>
+#include <storage/shmem.h>
 #include <utils/snapmgr.h>
 #include <utils/timestamp.h>
 
@@ -34,19 +35,37 @@ int db_counter = 0;
 void cb(void *ptr, void *data) { strcpy((char *)ptr, "test"); }
 void cb_dblocal(void *ptr, void *data) { sprintf((char *)ptr, "testdb %d", db_counter++); }
 
+typedef struct {
+  pg_atomic_uint64 bgworker_next_id;
+  union {
+    char reserved[64];
+    struct {
+      bool global_worker_started;
+    } info;
+  } scratchpad;
+} SharedInfo;
+
 void global_worker(Datum dboid) {
-  BackgroundWorkerInitializeConnectionByOid(dboid, InvalidOid, 0);
+  bool found;
+  SharedInfo *info =
+      (SharedInfo *)ShmemInitStruct("omni_ext: shared_info", sizeof(SharedInfo), &found);
+  info->scratchpad.info.global_worker_started = true;
+}
 
-  SetCurrentStatementStartTimestamp();
-  StartTransactionCommand();
-  PushActiveSnapshot(GetTransactionSnapshot());
+PG_FUNCTION_INFO_V1(wait_for_global_bgworker);
 
-  SPI_connect();
-  SPI_execute("CREATE TABLE IF NOT EXISTS global_worker_started ();", false, 0);
-  SPI_finish();
-
-  PopActiveSnapshot();
-  CommitTransactionCommand();
+Datum wait_for_global_bgworker(PG_FUNCTION_ARGS) {
+  bool found;
+  SharedInfo *info =
+      (SharedInfo *)ShmemInitStruct("omni_ext: shared_info", sizeof(SharedInfo), &found);
+  TimestampTz start = GetCurrentTimestamp();
+  while (!info->scratchpad.info.global_worker_started) {
+    TimestampTz now = GetCurrentTimestamp();
+    // timeout
+    if (now - start >= 3000000)
+      break;
+  }
+  PG_RETURN_BOOL(info->scratchpad.info.global_worker_started);
 }
 
 PG_FUNCTION_INFO_V1(wait_for_table);
@@ -91,7 +110,6 @@ void database_local_worker(Datum dboid) {
 }
 
 void _Dynpgext_init(const dynpgext_handle *handle) {
-  ereport(NOTICE, errmsg("_Dynpgext_init"));
   handle->allocate_shmem(handle, GLOBAL_ID, 1024, cb, NULL, DYNPGEXT_SCOPE_GLOBAL);
   handle->allocate_shmem(handle, DATABASE_LOCAL_ID, 1024, cb_dblocal, NULL,
                          DYNPGEXT_SCOPE_DATABASE_LOCAL);
@@ -101,7 +119,6 @@ void _Dynpgext_init(const dynpgext_handle *handle) {
                           .bgw_function_name = "global_worker",
                           .bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION,
                           .bgw_start_time = BgWorkerStart_RecoveryFinished,
-                          .bgw_main_arg = MyDatabaseId,
                           .bgw_restart_time = BGW_NEVER_RESTART};
   strncpy(bgw.bgw_library_name, handle->library_name, BGW_MAXLEN);
   handle->register_bgworker(handle, &bgw,

--- a/extensions/omni_ext/test/tests/omni_ext_test/tests.yml
+++ b/extensions/omni_ext/test/tests/omni_ext_test/tests.yml
@@ -61,15 +61,10 @@ tests:
     
   - name: global bg worker
     steps:
-    - query: CREATE TABLE IF NOT EXISTS global_worker_started ()
-    - query: SELECT omni_ext_test.wait_for_table('global_worker_started')
+    - query: select omni_ext_test.wait_for_global_bgworker()
       results:
-      - wait_for_table: true
-    - query: select n.nspname, c.relname from pg_catalog.pg_class c left join pg_catalog.pg_namespace  n on n.oid=c.relnamespace where c.relname='global_worker_started'
-      results:
-      - nspname: public
-        relname: global_worker_started
-   
+      - wait_for_global_bgworker: true
+
   - name: database local bgworker on another database
     transaction: false
     tests:

--- a/extensions/omni_ext/test/tests/omni_ext_test_no_preload/bgw.yml
+++ b/extensions/omni_ext/test/tests/omni_ext_test_no_preload/bgw.yml
@@ -20,9 +20,9 @@ tests:
   - wait_for_table: false
 
 - name: global worker not started yet
-  query: select omni_ext_test_no_preload.wait_for_table('global_worker_started')
+  query: select omni_ext_test_no_preload.wait_for_global_bgworker()
   results:
-  - wait_for_table: false
+  - wait_for_global_bgworker: false
 
 - name: Load the extension
   query: select omni_ext.load('omni_ext_test_no_preload')
@@ -36,6 +36,6 @@ tests:
   - wait_for_table: true
 
 - name: global worker started
-  query: select omni_ext_test_no_preload.wait_for_table('global_worker_started')
+  query: select omni_ext_test_no_preload.wait_for_global_bgworker()
   results:
-  - wait_for_table: true
+  - wait_for_global_bgworker: true


### PR DESCRIPTION
Specifically, the test for global background worker for preloaded extensions pre-creates a table in its schema and the table is used as a marker. So it never really tests it.

Also, to add, recent change that passed db_oid to global worker won't work during preloading as `MyDatabaseId` at that time is 0 (if it is actually initialized at the time we prepare the background worker entry)

Solution: introduce some "reserved" space in SharedInfo of omni_ext

This is a strictly internal hack for the time being that allows tests to have a shared location in memory to write something to.

The test will now write a flag there once the global background worker is started. A new utility function has been added to track that.

This could have been done better, but I am a bit tired and I need this to work right now.