### PR TITLE
Problem: running additional workers in omni_ext

### DIFF
--- a/extensions/omni_ext/CMakeLists.txt
+++ b/extensions/omni_ext/CMakeLists.txt
@@ -28,7 +28,7 @@ endfunction()
                 omni_ext
                 SCHEMA omni_ext
                 RELOCATABLE false
-                SOURCES omni_ext.c control_file.c init.c workers.c strverscmp.c
+                SOURCES omni_ext.c control_file.c init.c hooks.c workers.c strverscmp.c
                 DEPENDS_ON libgluepg_stc dynpgext
                 UNVERSIONED_SO ON
                 SHARED_PRELOAD ON)

--- a/extensions/omni_ext/control_file.c
+++ b/extensions/omni_ext/control_file.c
@@ -345,7 +345,8 @@ void load_control_file(const char *control_path, void *data) {
 
                   ereport(
                       LOG,
-                      errmsg("Loaded Dynpgext extension %s (version %s)", control_file.ext_name,
+                      errmsg("%s Dynpgext extension %s (version %s)",
+                             config->action == LOAD ? "Loaded" : "Unloaded", control_file.ext_name,
                              control_file.ext_version ? control_file.ext_version : "unspecified"));
                 }
               }

--- a/extensions/omni_ext/hooks.c
+++ b/extensions/omni_ext/hooks.c
@@ -1,0 +1,155 @@
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+#include <access/genam.h>
+#include <access/skey.h>
+#include <access/table.h>
+#include <access/xact.h>
+#include <catalog/pg_extension.h>
+#if PG_MAJORVERSION_NUM == 13
+#include <catalog/indexing.h>
+#endif
+#include <commands/dbcommands.h>
+#include <commands/defrem.h>
+#include <commands/extension.h>
+#include <miscadmin.h>
+#include <storage/lwlock.h>
+#include <utils/builtins.h>
+#include <utils/fmgroids.h>
+#include <utils/rel.h>
+
+#include "omni_ext.h"
+
+ProcessUtility_hook_type old_process_utility_hook;
+
+typedef struct {
+  char *name;
+  char *version;
+} LoadExtension;
+
+static List *pending_loads = NIL;
+
+void omni_ext_process_utility_hook(PlannedStmt *pstmt, const char *queryString,
+#if PG_MAJORVERSION_NUM > 13
+                                   bool readOnlyTree,
+#endif
+                                   ProcessUtilityContext context, ParamListInfo params,
+                                   QueryEnvironment *queryEnv, DestReceiver *dest,
+                                   QueryCompletion *qc) {
+  if (old_process_utility_hook != NULL) {
+    old_process_utility_hook(pstmt, queryString,
+#if PG_MAJORVERSION_NUM > 13
+                             readOnlyTree,
+#endif
+                             context, params, queryEnv, dest, qc);
+  } else {
+    standard_ProcessUtility(pstmt, queryString,
+#if PG_MAJORVERSION_NUM > 13
+                            readOnlyTree,
+#endif
+                            context, params, queryEnv, dest, qc);
+  }
+  Node *node = pstmt->utilityStmt;
+  if (node != NULL) {
+    switch (nodeTag(node)) {
+    case T_CreatedbStmt: {
+      // This one is not transactional so we can process it right away
+      CreatedbStmt *stmt = castNode(CreatedbStmt, node);
+      Oid dboid = get_database_oid(stmt->dbname, false);
+      populate_bgworker_requests_for_db(dboid);
+      break;
+    }
+    case T_CreateExtensionStmt: {
+      // At this point, the extension has been created. We don't know the version necessarily,
+      // but we do know the name.
+      //
+      CreateExtensionStmt *stmt = castNode(CreateExtensionStmt, node);
+      char *extname = stmt->extname;
+      char *version = NULL;
+      // Try to see if the version is supplied
+      {
+        ListCell *lc;
+        foreach (lc, stmt->options) {
+          DefElem *defelem = lfirst_node(DefElem, lc);
+          if (strncmp(defelem->defname, "new_version", sizeof("new_version")) == 0) {
+            // If we do know the version, it's easy:
+            version = defGetString(defelem);
+            // proceed
+            goto version_ready;
+          }
+        }
+      }
+      // The version was not supplied, going to find it
+
+      {
+        Oid result;
+        Relation rel;
+        SysScanDesc scandesc;
+        HeapTuple tuple;
+        struct ScanKeyData entry[1];
+
+        rel = table_open(ExtensionRelationId, AccessShareLock);
+
+        ScanKeyInit(&entry[0], Anum_pg_extension_extname, BTEqualStrategyNumber, F_NAMEEQ,
+                    CStringGetDatum(extname));
+
+        scandesc = systable_beginscan(rel, ExtensionNameIndexId, true, NULL, 1, entry);
+
+        tuple = systable_getnext(scandesc);
+
+        /* We assume that there can be at most one matching tuple */
+        if (HeapTupleIsValid(tuple)) {
+          bool is_version_null;
+          Datum version_datum =
+              heap_getattr(tuple, Anum_pg_extension_extversion, rel->rd_att, &is_version_null);
+          if (!is_version_null) {
+            version = text_to_cstring(DatumGetTextPP(version_datum));
+          }
+        }
+
+        systable_endscan(scandesc);
+
+        table_close(rel, AccessShareLock);
+
+        if (version == NULL)
+          ereport(ERROR, (errcode(ERRCODE_UNDEFINED_OBJECT),
+                          errmsg("extension \"%s\" does not exist", extname)));
+      }
+
+    version_ready: {
+      MemoryContext oldcontext = MemoryContextSwitchTo(TopTransactionContext);
+      LoadExtension *load = palloc(sizeof(LoadExtension));
+      load->name = pstrdup(extname);
+      load->version = pstrdup(version);
+      pending_loads = lappend(pending_loads, load);
+      MemoryContextSwitchTo(oldcontext);
+    } break;
+    }
+    default:
+      break;
+    }
+  }
+}
+
+void omni_ext_transaction_callback(XactEvent event, void *arg) {
+  switch (event) {
+  case XACT_EVENT_COMMIT: {
+    ListCell *lc;
+    foreach (lc, pending_loads) {
+      LoadExtension *ext = (LoadExtension *)lfirst(lc);
+      load_extension(ext->name, ext->version);
+
+      // Process new matching entries
+      process_extensions_for_database(ext->name, ext->version, MyDatabaseId);
+    }
+  }
+  case XACT_EVENT_ABORT:
+    // Cleanup
+    list_free_deep(pending_loads);
+    pending_loads = NIL;
+    break;
+  default:
+    break;
+  }
+}

--- a/extensions/omni_ext/omni_ext.h
+++ b/extensions/omni_ext/omni_ext.h
@@ -1,6 +1,10 @@
 #ifndef OMNI_EXT_H
 #define OMNI_EXT_H
 
+#include <access/xact.h>
+#include <executor/executor.h>
+#include <tcop/utility.h>
+
 #include <dynpgext.h>
 
 #include <libgluepg_stc.h>
@@ -102,7 +106,8 @@ int background_worker_request_cmp(const background_worker_request *left,
 typedef struct {
   uint64 id;
   background_worker_request request;
-  bool globally_started;
+  bool started;
+  Oid databaseOid;
 } BackgroundWorkerRequest;
 
 extern HTAB *BackgroundWorkerRequests;
@@ -174,5 +179,22 @@ const char *get_library_name();
 
 extern bool dsa_attached;
 void ensure_dsa_attached();
+
+char *load_extension(char *name, char *version);
+
+extern ExecutorFinish_hook_type old_executor_finish_hook;
+extern ProcessUtility_hook_type old_process_utility_hook;
+void omni_ext_executor_finish_hook(QueryDesc *queryDesc);
+void omni_ext_process_utility_hook(PlannedStmt *pstmt, const char *queryString,
+#if PG_MAJORVERSION_NUM > 13
+                                   bool readOnlyTree,
+#endif
+                                   ProcessUtilityContext context, ParamListInfo params,
+                                   QueryEnvironment *queryEnv, DestReceiver *dest,
+                                   QueryCompletion *qc);
+void omni_ext_transaction_callback(XactEvent event, void *arg);
+
+void populate_bgworker_requests_for_db(Oid dboid);
+void process_extensions_for_database(char *extname, char *extversion, Oid dboid);
 
 #endif // OMNI_EXT_H

--- a/extensions/omni_ext/omni_ext.h
+++ b/extensions/omni_ext/omni_ext.h
@@ -180,6 +180,7 @@ const char *get_library_name();
 extern bool dsa_attached;
 void ensure_dsa_attached();
 
+bool unload_extension(char *name, char *version);
 char *load_extension(char *name, char *version);
 
 extern ExecutorFinish_hook_type old_executor_finish_hook;

--- a/extensions/omni_ext/test/CMakeLists.txt
+++ b/extensions/omni_ext/test/CMakeLists.txt
@@ -19,6 +19,16 @@ add_postgresql_extension(
         REQUIRES omni_ext
         VERSION 0.1)
 
+
+add_postgresql_extension(
+        omni_ext_test
+        TARGET omni_ext_test_2
+        UPGRADE_SCRIPTS tests/omni_ext_test--0.1--0.2.sql
+        NO_DEFAULT_CONTROL ON
+        VERSION 0.2
+        PRIVATE ON
+        TESTS OFF)
+
 add_postgresql_extension(
         omni_ext_test_no_preload
         SCHEMA omni_ext_test_no_preload

--- a/extensions/omni_ext/test/omni_ext_test.c
+++ b/extensions/omni_ext/test/omni_ext_test.c
@@ -137,6 +137,17 @@ void _Dynpgext_init(const dynpgext_handle *handle) {
                             DYNPGEXT_REGISTER_BGWORKER_NOTIFY | DYNPGEXT_SCOPE_DATABASE_LOCAL);
 }
 
+void _Dynpgext_fini(const dynpgext_handle *handle) {
+  A_Const *val = makeNode(A_Const);
+#if PG_MAJORVERSION_NUM >= 15
+  val->val.sval = *makeString("yes");
+#else
+  val->val.type = T_String;
+  strVal(&val->val) = "yes";
+#endif
+  SetPGVariable("omni_ext_test.done", list_make1(val), false);
+}
+
 PG_FUNCTION_INFO_V1(alloc_shmem_global);
 
 Datum alloc_shmem_global(PG_FUNCTION_ARGS) {

--- a/extensions/omni_ext/test/tests/omni_ext_test/rollback.yml
+++ b/extensions/omni_ext/test/tests/omni_ext_test/rollback.yml
@@ -1,0 +1,64 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+  init:
+  - create extension omni_ext
+
+tests:
+
+- name: try to create extension and then roll back
+  query: create extension omni_ext_test
+  commit: false # this is the default but we're making it clear
+
+- name: ensure bg worker doesn't start if rolled back
+  steps:
+  - select pg_sleep(1) # we can't use the extension to wait for the table
+  - query: select
+               n.nspname,
+               c.relname
+           from
+               pg_catalog.pg_class               c
+               left join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+           where
+               c.relname = 'local_worker_started'
+    results: [ ]
+
+- name: create extension and commit
+  query: create extension omni_ext_test
+  commit: true
+
+- name: ensure the database local bgworker has started
+  steps:
+  - query: select omni_ext_test.wait_for_table('local_worker_started')
+    results:
+    - wait_for_table: true
+  - query: select
+               n.nspname,
+               c.relname
+           from
+               pg_catalog.pg_class               c
+               left join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+           where
+               c.relname = 'local_worker_started'
+    results:
+    - nspname: public
+      relname: local_worker_started
+
+- name: try to drop the extension and roll back
+  query: drop extension omni_ext_test
+  commit: false # this is the default but we're making it clear
+
+- name: was it unloaded?
+  query: select current_setting('omni_ext_test.done', true)
+  results:
+  - current_setting: null
+
+- name: try to update the extension and roll back
+  query: alter extension omni_ext_test update to '0.2'
+  commit: false # this is the default but we're making it clear
+
+- name: was it unloaded?
+  query: select current_setting('omni_ext_test.done', true)
+  results:
+  - current_setting: null

--- a/extensions/omni_ext/test/tests/omni_ext_test/tests.yml
+++ b/extensions/omni_ext/test/tests/omni_ext_test/tests.yml
@@ -79,3 +79,14 @@ tests:
       results:
       - nspname: public
         relname: local_worker_started
+
+  - name: unload by dropping
+    tests:
+    - query: select current_setting('omni_ext_test.done', true)
+      results:
+      - current_setting: null
+    - query: drop extension omni_ext_test
+      commit: true
+    - query: select current_setting('omni_ext_test.done')
+      results:
+      - current_setting: yes

--- a/extensions/omni_ext/test/tests/omni_ext_test/tests.yml
+++ b/extensions/omni_ext/test/tests/omni_ext_test/tests.yml
@@ -39,7 +39,7 @@ tests:
         results:
           - update_global_value: updated
       - name: re-load again
-        query: select omni_ext.load('omni_ext_test')
+        query: select omni_ext.load('omni_ext_test', '0.1')
         results:
           - load: 0.1
       - name: should not be rolled back to the initial value

--- a/extensions/omni_ext/test/tests/omni_ext_test/update.yml
+++ b/extensions/omni_ext/test/tests/omni_ext_test/update.yml
@@ -1,0 +1,15 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+  init:
+  - create extension omni_ext_test version '0.1' cascade
+
+tests:
+
+- alter extension omni_ext_test update to '0.2'
+
+- name: was previous version unloaded?
+  query: select current_setting('omni_ext_test.done')
+  results:
+  - current_setting: yes

--- a/extensions/omni_ext/test/tests/omni_ext_test_no_preload/bgw.yml
+++ b/extensions/omni_ext/test/tests/omni_ext_test_no_preload/bgw.yml
@@ -13,21 +13,7 @@ tests:
   - query: create extension omni_ext_test_no_preload cascade
     database: another_db
 
-- name: database-local worker not started yet
-  query: select omni_ext_test_no_preload.wait_for_table('local_worker_started')
-  database: another_db
-  results:
-  - wait_for_table: false
-
-- name: global worker not started yet
-  query: select omni_ext_test_no_preload.wait_for_global_bgworker()
-  results:
-  - wait_for_global_bgworker: false
-
-- name: Load the extension
-  query: select omni_ext.load('omni_ext_test_no_preload')
-  results:
-  - load: 0.1
+# The extension was not pre-loaded but was loaded by `create extension`, so should work:
 
 - name: database-local worker started
   query: select omni_ext_test_no_preload.wait_for_table('local_worker_started')

--- a/extensions/omni_ext/test/tests/omni_ext_test_no_preload/no_preload.yml
+++ b/extensions/omni_ext/test/tests/omni_ext_test_no_preload/no_preload.yml
@@ -7,27 +7,15 @@ instance:
 tests:
   - name: shmem no preload
     steps:
-      - name: fail since it's not preloaded
-        query: select omni_ext_test_no_preload.alloc_shmem_global()
-        error:
-          severity: ERROR
-          message: no allocation found
-      - query: select omni_ext_test_no_preload.alloc_shmem_database_local()
-        error:
-          severity: ERROR
-          message: no allocation found
-      - name: Load
-        query: select omni_ext.load('omni_ext_test_no_preload')
-        results:
-        - load: 0.1
-      - name: alloc_shmem_global() should work after loading
-        query: select omni_ext_test_no_preload.alloc_shmem_global()
-        results:
-        - alloc_shmem_global: test
-      - name: alloc_shmem_database_local() should work after loading
-        query: select omni_ext_test_no_preload.alloc_shmem_database_local()
-        results:
-        - alloc_shmem_database_local: testdb 0
+    # The extension was not preloaded but it was loaded by `create extension` and therefore was loaded
+    - name: alloc_shmem_global() should work
+      query: select omni_ext_test_no_preload.alloc_shmem_global()
+      results:
+      - alloc_shmem_global: test
+    - name: alloc_shmem_database_local() should work
+      query: select omni_ext_test_no_preload.alloc_shmem_database_local()
+      results:
+      - alloc_shmem_database_local: testdb 0
   
   - name: install in separate database
     transaction: false

--- a/extensions/omni_ext/tests/tests.yml
+++ b/extensions/omni_ext/tests/tests.yml
@@ -8,13 +8,13 @@ tests:
   - name: load
     query: select omni_ext.load('omni_ext_test')
     results:
-      - load: 0.1
+    - load: 0.2
 
   - name: load version
     steps:
       - query: select omni_ext.load('omni_ext_test', 'unknown')
         results:
-          - load:
+        - load:
       - query: select omni_ext.load('omni_ext_test', '0.1')
         results:
           - load: 0.1

--- a/extensions/omni_ext/workers.c
+++ b/extensions/omni_ext/workers.c
@@ -7,7 +7,6 @@
 // clang-format on
 
 #include <access/heapam.h>
-#include <access/sdir.h>
 #include <access/table.h>
 #include <access/tableam.h>
 #include <access/xact.h>
@@ -22,17 +21,7 @@
 #if PG_MAJORVERSION_NUM >= 13
 #include <postmaster/interrupt.h>
 #endif
-#include <storage/fd.h>
-#include <storage/ipc.h>
-#include <storage/latch.h>
-#include <storage/lwlock.h>
-#include <storage/shmem.h>
-#include <tcop/utility.h>
 #include <utils/builtins.h>
-#include <utils/dsa.h>
-#include <utils/guc.h>
-#include <utils/hsearch.h>
-#include <utils/rel.h>
 
 #if PG_MAJORVERSION_NUM >= 14
 #include <utils/wait_event.h>
@@ -55,16 +44,7 @@ typedef struct {
   char dbname[NAMEDATALEN];
 } db_info;
 
-#define i_tag db
-#define i_key Oid
-#define i_val db_info
-#include <stc/cmap.h>
-
-static bool terminate = false;
-static void sigterm(SIGNAL_ARGS) {
-  terminate = true;
-  SetLatch(MyLatch);
-}
+static void sigterm(SIGNAL_ARGS) {}
 
 void master_worker(Datum main_arg) {
   BackgroundWorkerInitializeConnection(NULL, NULL, 0);
@@ -73,88 +53,51 @@ void master_worker(Datum main_arg) {
 
   BackgroundWorkerUnblockSignals();
 
-  cmap_db databases = cmap_db_init();
+  StartTransactionCommand();
 
-  while (!terminate) {
-    CHECK_FOR_INTERRUPTS();
+  Relation rel = table_open(DatabaseRelationId, AccessShareLock);
+  TableScanDesc scan = table_beginscan_catalog(rel, 0, NULL);
+  for (;;) {
+    HeapTuple tup = heap_getnext(scan, ForwardScanDirection);
+    if (tup == NULL)
+      break;
+    Form_pg_database db = (Form_pg_database)GETSTRUCT(tup);
+    if (db->datistemplate || !db->datallowconn)
+      continue;
+    db_info dbi = {.pid = 0};
+    strncpy(dbi.dbname, db->datname.data, sizeof(dbi.dbname));
+    populate_bgworker_requests_for_db(db->oid);
 
-    StartTransactionCommand();
+    // Start the database worker
+    BackgroundWorker worker = {.bgw_flags =
+                                   BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION,
+                               .bgw_main_arg = ObjectIdGetDatum(db->oid),
+                               .bgw_start_time = BgWorkerStart_RecoveryFinished,
+                               .bgw_restart_time = BGW_NEVER_RESTART,
+                               .bgw_function_name = "database_worker",
+                               .bgw_notify_pid = MyProcPid};
+    strncpy(worker.bgw_library_name, get_library_name(), BGW_MAXLEN);
+    char *name =
+        MemoryContextStrdup(TopMemoryContext, psprintf("omni_ext worker (%s)", dbi.dbname));
+    strncpy(worker.bgw_name, name, BGW_MAXLEN);
+    strncpy(worker.bgw_type, name, BGW_MAXLEN);
+    strncpy(worker.bgw_extra, db->datname.data, BGW_EXTRALEN);
 
-    Relation rel = table_open(DatabaseRelationId, AccessShareLock);
-    TableScanDesc scan = table_beginscan_catalog(rel, 0, NULL);
-    for (;;) {
-      HeapTuple tup = heap_getnext(scan, ForwardScanDirection);
-      if (tup == NULL)
-        break;
-      Form_pg_database db = (Form_pg_database)GETSTRUCT(tup);
-      if (db->datistemplate || !db->datallowconn)
-        continue;
-      db_info dbi = {.pid = 0};
-      strncpy(dbi.dbname, db->datname.data, sizeof(dbi.dbname));
-      cmap_db_result result = cmap_db_insert(&databases, db->oid, dbi);
-      if (result.inserted) {
-        BackgroundWorker worker = {.bgw_flags =
-                                       BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION,
-                                   .bgw_main_arg = ObjectIdGetDatum(db->oid),
-                                   .bgw_start_time = BgWorkerStart_RecoveryFinished,
-                                   .bgw_restart_time = BGW_NEVER_RESTART,
-                                   .bgw_function_name = "database_worker",
-                                   .bgw_notify_pid = MyProcPid};
-        strncpy(worker.bgw_library_name, get_library_name(), BGW_MAXLEN);
-        char *name =
-            MemoryContextStrdup(TopMemoryContext, psprintf("omni_ext worker (%s)", dbi.dbname));
-        strncpy(worker.bgw_name, name, BGW_MAXLEN);
-        strncpy(worker.bgw_type, name, BGW_MAXLEN);
-        strncpy(worker.bgw_extra, db->datname.data, BGW_EXTRALEN);
+    bool ok = RegisterDynamicBackgroundWorker(&worker, NULL);
 
-        // Ensure we allocate worker handles under the top memory context
-        MemoryContext old_context = MemoryContextSwitchTo(TopMemoryContext);
-        bool ok = RegisterDynamicBackgroundWorker(&worker, &result.ref->second.worker);
-        MemoryContextSwitchTo(old_context);
-
-        if (!ok) {
-          ereport(FATAL, errmsg("Can't register a dynamic eror"));
-        }
-      }
+    if (!ok) {
+      ereport(FATAL, errmsg("Can't register a dynamic background worker"));
     }
-    if (scan->rs_rd->rd_tableam->scan_end) {
-      scan->rs_rd->rd_tableam->scan_end(scan);
-    }
-    table_close(rel, AccessShareLock);
-
-    // Ensure we're not getting a XID
-    Assert(GetCurrentTransactionIdIfAny() == InvalidTransactionId);
-    AbortCurrentTransaction();
-
-    c_FOREACH(worker, cmap_db, databases) {
-      db_info *info = &worker.ref->second;
-      // If PID of the worker is not known yet
-      if (info->pid == 0) {
-        switch (GetBackgroundWorkerPid(info->worker, &info->pid)) {
-        case BGWH_STARTED:
-          ereport(LOG, errmsg("Started omni_ext database worker for %s (pid %d)", info->dbname,
-                              info->pid));
-          break;
-        case BGWH_STOPPED:
-          ereport(ERROR, errmsg("Failed to start omni_ext database worker for %s", info->dbname));
-        case BGWH_POSTMASTER_DIED:
-        case BGWH_NOT_YET_STARTED:
-          break;
-        }
-      }
-    }
-
-    (void)WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH, 1000L,
-                    PG_WAIT_EXTENSION);
-    ResetLatch(MyLatch);
   }
+  if (scan->rs_rd->rd_tableam->scan_end) {
+    scan->rs_rd->rd_tableam->scan_end(scan);
+  }
+  table_close(rel, AccessShareLock);
 
-  cmap_db_drop(&databases);
+  // Ensure we're not getting a XID
+  Assert(GetCurrentTransactionIdIfAny() == InvalidTransactionId);
+  AbortCurrentTransaction();
 }
-
-#define i_key uint64
-#define i_tag uint64
-#include <stc/cset.h>
 
 void database_worker(Datum db_oid) {
   ensure_dsa_attached();
@@ -164,89 +107,32 @@ void database_worker(Datum db_oid) {
 
   BackgroundWorkerUnblockSignals();
 
-  // This stores locally processed bgworker requests
-  cset_uint64 bgworker_requests = cset_uint64_init();
+  StartTransactionCommand();
 
-  while (!terminate) {
+  Relation rel = table_open(ExtensionRelationId, AccessShareLock);
+  TableScanDesc scan = table_beginscan_catalog(rel, 0, NULL);
+  for (;;) {
+    HeapTuple tup = heap_getnext(scan, ForwardScanDirection);
+    if (tup == NULL)
+      break;
+    Form_pg_extension ext = (Form_pg_extension)GETSTRUCT(tup);
 
-    StartTransactionCommand();
+    bool is_version_null;
+    Datum version_datum = heap_getattr(tup, 6, rel->rd_att, &is_version_null);
 
-    Relation rel = table_open(ExtensionRelationId, AccessShareLock);
-    TableScanDesc scan = table_beginscan_catalog(rel, 0, NULL);
-    for (;;) {
-      HeapTuple tup = heap_getnext(scan, ForwardScanDirection);
-      if (tup == NULL)
-        break;
-      Form_pg_extension ext = (Form_pg_extension)GETSTRUCT(tup);
+    text *version = is_version_null ? NULL : DatumGetTextPP(version_datum);
 
-      bool is_version_null;
-      Datum version_datum = heap_getattr(tup, 6, rel->rd_att, &is_version_null);
-
-      text *version = is_version_null ? NULL : DatumGetTextPP(version_datum);
-
-      {
-        LWLock *lock = &GetNamedLWLockTranche("omni_ext_bgworker_request")->lock;
-        // TODO: make this a shared lock but re-acquire an exclusive lock for globally started
-        // workers so that we can make this a notch faster?
-        LWLockAcquire(lock, LW_EXCLUSIVE);
-        // Iterate over background worker requests
-        HASH_SEQ_STATUS status;
-        hash_seq_init(&status, BackgroundWorkerRequests);
-        BackgroundWorkerRequest *req;
-        while ((req = hash_seq_search(&status)) != NULL) {
-          // Check if this request matches the extension we're currently looking at
-          char *cversion = text_to_cstring(version);
-          bool matching =
-              strncmp(NameStr(req->request.extname), NameStr(ext->extname), NAMEDATALEN) == 0 &&
-              strncmp(NameStr(req->request.extver), cversion, NAMEDATALEN) == 0;
-
-          pfree(cversion);
-
-          // Ignore it if it's not matching
-          if (!matching)
-            continue;
-
-          // Check if we already processed this request
-          if (!cset_uint64_insert(&bgworker_requests, req->id).inserted)
-            continue;
-
-          bool global_background_worker = (req->request.flags & DYNPGEXT_SCOPE_DATABASE_LOCAL) == 0;
-
-          // Since we're locking access to the entire table, we're sure that we're the only worker
-          // attempting to start this one at the moment.
-          if (!global_background_worker || (global_background_worker && !req->globally_started)) {
-            BackgroundWorker bgw = req->request.bgw;
-            if (!global_background_worker) {
-              bgw.bgw_main_arg = db_oid;
-            }
-            bgw.bgw_restart_time = BGW_NEVER_RESTART;
-            BackgroundWorkerHandle *handle;
-            RegisterDynamicBackgroundWorker(&bgw, &handle);
-            if (global_background_worker) {
-              req->globally_started = true;
-            }
-          }
-        }
-
-        LWLockRelease(lock);
-      }
-    }
-
-    if (scan->rs_rd->rd_tableam->scan_end) {
-      scan->rs_rd->rd_tableam->scan_end(scan);
-    }
-    table_close(rel, AccessShareLock);
-
-    // Ensure we're not getting a XID
-    Assert(GetCurrentTransactionIdIfAny() == InvalidTransactionId);
-    AbortCurrentTransaction();
-
-    (void)WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH, 1000L,
-                    PG_WAIT_EXTENSION);
-    ResetLatch(MyLatch);
-
-    CHECK_FOR_INTERRUPTS();
+    char *cversion = text_to_cstring(version);
+    process_extensions_for_database(NameStr(ext->extname), cversion, MyDatabaseId);
+    pfree(cversion);
   }
 
-  cset_uint64_drop(&bgworker_requests);
+  if (scan->rs_rd->rd_tableam->scan_end) {
+    scan->rs_rd->rd_tableam->scan_end(scan);
+  }
+  table_close(rel, AccessShareLock);
+
+  // Ensure we're not getting a XID
+  Assert(GetCurrentTransactionIdIfAny() == InvalidTransactionId);
+  AbortCurrentTransaction();
 }

--- a/extensions/omni_httpc/tests/test.yml
+++ b/extensions/omni_httpc/tests/test.yml
@@ -7,7 +7,7 @@ instance:
   - set session omni_httpd.init_port = 0
   - create extension omni_httpd cascade
   - create extension omni_httpc cascade
-  - delete from omni_httpd.configuration_reloads
+  - call omni_httpd.wait_for_configuration_reloads(1)
   - |
     update omni_httpd.handlers set query = $$
       select omni_httpd.http_response(json_build_object(

--- a/extensions/omni_httpc/tests/timeout.yml
+++ b/extensions/omni_httpc/tests/timeout.yml
@@ -7,9 +7,7 @@ instance:
   - set session omni_httpd.init_port = 0
   - create extension omni_httpd cascade
   - create extension omni_httpc cascade
-  - delete
-    from
-        omni_httpd.configuration_reloads
+  - call omni_httpd.wait_for_configuration_reloads(1)
   - |
     update omni_httpd.handlers
     set


### PR DESCRIPTION
Currently, we require 1+N_of_database workers to simply load background workers into any database that has a particular extension requiring database-local background workers. This is, frankly, wasteful.

Solution: hook into process utility statements

This allows us to capture extension and database creation to drive necessary provisioning of resources like database-local background workers.

This also opens a way to handle unloading and updating extensions the same way, transparently to the extensions, they wouldn't need `load/unload` anymore.