### PR TITLE
Problem: installing a set of Omnigres extensions

### DIFF
--- a/extensions/omni_manifest/migrate/4_artifact_functions.sql
+++ b/extensions/omni_manifest/migrate/4_artifact_functions.sql
@@ -1,0 +1,25 @@
+/*{% include "../src/text_to_artifact.sql" %}*/
+/*{% include "../src/text_to_artifacts.sql" %}*/
+/*{% include "../src/json_to_artifact.sql" %}*/
+/*{% include "../src/jsonb_to_artifact.sql" %}*/
+/*{% include "../src/json_to_artifacts.sql" %}*/
+/*{% include "../src/jsonb_to_artifacts.sql" %}*/
+/*{% include "../src/artifact_to_json.sql" %}*/
+/*{% include "../src/artifacts_to_json.sql" %}*/
+/*{% include "../src/artifact_to_jsonb.sql" %}*/
+/*{% include "../src/artifacts_to_jsonb.sql" %}*/
+/*{% include "../src/artifact_to_text.sql" %}*/
+/*{% include "../src/artifacts_to_text.sql" %}*/
+
+create cast (text as artifact) with function text_to_artifact as implicit;
+create cast (text as artifact[]) with function text_to_artifacts as implicit;
+create cast (json as artifact) with function json_to_artifact as implicit;
+create cast (jsonb as artifact) with function jsonb_to_artifact as implicit;
+create cast (json as artifact[]) with function json_to_artifacts as implicit;
+create cast (jsonb as artifact[]) with function jsonb_to_artifacts as implicit;
+create cast (artifact as json) with function artifact_to_json as implicit;
+create cast (artifact[] as json) with function artifacts_to_json as implicit;
+create cast (artifact as jsonb) with function artifact_to_jsonb as implicit;
+create cast (artifact[] as jsonb) with function artifacts_to_jsonb as implicit;
+create cast (artifact as text) with function artifact_to_text as implicit;
+create cast (artifact[] as text) with function artifacts_to_text as implicit;

--- a/extensions/omni_manifest/migrate/5_requirement_status_kept.sql
+++ b/extensions/omni_manifest/migrate/5_requirement_status_kept.sql
@@ -1,0 +1,1 @@
+alter type omni_manifest.requirement_status add value 'kept';

--- a/extensions/omni_manifest/src/artifact_to_json.sql
+++ b/extensions/omni_manifest/src/artifact_to_json.sql
@@ -1,0 +1,8 @@
+create function artifact_to_json(artifact artifact) returns json
+    language sql
+    immutable as
+$$
+select
+    json_build_object('target', artifact.self::json,
+                      'requirements', artifact.requirements::json)
+$$;

--- a/extensions/omni_manifest/src/artifact_to_jsonb.sql
+++ b/extensions/omni_manifest/src/artifact_to_jsonb.sql
@@ -1,0 +1,8 @@
+create function artifact_to_jsonb(artifact artifact) returns jsonb
+    language sql
+    immutable as
+$$
+select
+    jsonb_build_object('target', artifact.self::jsonb,
+                       'requirements', artifact.requirements::jsonb)
+$$;

--- a/extensions/omni_manifest/src/artifact_to_text.sql
+++ b/extensions/omni_manifest/src/artifact_to_text.sql
@@ -1,0 +1,9 @@
+create function artifact_to_text(artifact artifact) returns text
+    language sql
+    immutable as
+$$
+select
+    artifact.self::text || case
+                               when artifact.requirements is null then ''
+                               else '#' || artifact.requirements::text end
+$$;

--- a/extensions/omni_manifest/src/artifacts_to_json.sql
+++ b/extensions/omni_manifest/src/artifacts_to_json.sql
@@ -1,0 +1,9 @@
+create function artifacts_to_json(artifacts artifact[]) returns json
+    language sql
+    immutable as
+$$
+select
+    json_agg(a::json)
+from
+    unnest(artifacts) a
+$$;

--- a/extensions/omni_manifest/src/artifacts_to_jsonb.sql
+++ b/extensions/omni_manifest/src/artifacts_to_jsonb.sql
@@ -1,0 +1,9 @@
+create function artifacts_to_jsonb(artifacts artifact[]) returns jsonb
+    language sql
+    immutable as
+$$
+select
+    jsonb_agg(a::jsonb)
+from
+    unnest(artifacts) a
+$$;

--- a/extensions/omni_manifest/src/artifacts_to_text.sql
+++ b/extensions/omni_manifest/src/artifacts_to_text.sql
@@ -1,0 +1,14 @@
+create function artifacts_to_text(artifacts artifact[]) returns text
+    language sql
+    immutable as
+$$
+with
+    arts as (select
+                 a::text
+             from
+                 unnest(artifacts) a)
+select
+    string_agg(a, ';')
+from
+    arts
+$$;

--- a/extensions/omni_manifest/src/install.sql
+++ b/extensions/omni_manifest/src/install.sql
@@ -12,25 +12,32 @@ begin
     for rec in
         select
             row (r.name, r.version)::omni_manifest.requirement as req,
-            e.name                                             as ext_name
+            e.name                                                      as ext_name,
+            case when r.version = '*' then e.version else r.version end as target_version,
+            pg_extension.extversion                                     as installed_version
         from
             unnest(plan) with ordinality r(name, version, ord)
+            left outer join pg_extension on pg_extension.extname = r.name
             left outer join
                 pg_available_extension_versions e
-                on e.name = r.name and e.version = r.version
+                on e.name = r.name and (e.version = r.version or r.version = '*')
         order by ord
         loop
             if rec.ext_name is null then
                 missing_requirements = true;
                 return next row (rec.req, 'missing')::omni_manifest.install_report;
             else
+                if rec.target_version = rec.installed_version then
+                    return next row (rec.req, 'kept')::omni_manifest.install_report;
+                    continue;
+                end if;
                 if not missing_requirements then
-                    perform from pg_catalog.pg_extension where pg_extension.extname = rec.ext_name;
-                    if not found then
-                        execute format('create extension %s version %L', (rec.req).name, (rec.req).version);
+
+                    if rec.installed_version is null then
+                        execute format('create extension %s version %L', (rec.req).name, rec.target_version);
                         return next row (rec.req, 'installed')::omni_manifest.install_report;
                     else
-                        execute format('alter extension %s update to %L', (rec.req).name, (rec.req).version);
+                        execute format('alter extension %s update to %L', (rec.req).name, rec.target_version);
                         return next row (rec.req, 'updated')::omni_manifest.install_report;
                     end if;
                 end if;

--- a/extensions/omni_manifest/src/json_to_artifact.sql
+++ b/extensions/omni_manifest/src/json_to_artifact.sql
@@ -1,0 +1,7 @@
+create function json_to_artifact(artifact json) returns artifact
+    language sql
+    immutable as
+$$
+select
+    row ((artifact -> 'target')::omni_manifest.requirement, (artifact -> 'requirements')::omni_manifest.requirement[])::omni_manifest.artifact
+$$;

--- a/extensions/omni_manifest/src/json_to_artifacts.sql
+++ b/extensions/omni_manifest/src/json_to_artifacts.sql
@@ -1,0 +1,11 @@
+create function json_to_artifacts(artifacts json) returns artifact[]
+    language sql
+    immutable as
+$$
+with
+    artifacts_ as (select value::omni_manifest.artifact from json_array_elements(artifacts) t(value))
+select
+    array_agg(value)
+from
+    artifacts_
+$$;

--- a/extensions/omni_manifest/src/jsonb_to_artifact.sql
+++ b/extensions/omni_manifest/src/jsonb_to_artifact.sql
@@ -1,0 +1,7 @@
+create function jsonb_to_artifact(artifact jsonb) returns artifact
+    language sql
+    immutable as
+$$
+select
+    row ((artifact -> 'target')::omni_manifest.requirement, (artifact -> 'requirements')::omni_manifest.requirement[])::omni_manifest.artifact
+$$;

--- a/extensions/omni_manifest/src/jsonb_to_artifacts.sql
+++ b/extensions/omni_manifest/src/jsonb_to_artifacts.sql
@@ -1,0 +1,11 @@
+create function jsonb_to_artifacts(artifacts jsonb) returns artifact[]
+    language sql
+    immutable as
+$$
+with
+    artifacts_ as (select value::omni_manifest.artifact from jsonb_array_elements(artifacts) t(value))
+select
+    array_agg(value)
+from
+    artifacts_
+$$;

--- a/extensions/omni_manifest/src/text_to_artifact.sql
+++ b/extensions/omni_manifest/src/text_to_artifact.sql
@@ -1,0 +1,11 @@
+create function text_to_artifact(artifact text) returns artifact
+    language sql
+    immutable as
+$$
+with
+    arr as (select regexp_split_to_array(artifact, '#') val)
+select
+    row (arr.val[1]::omni_manifest.requirement, arr.val[2]::omni_manifest.requirement[])::omni_manifest.artifact
+from
+    arr
+$$;

--- a/extensions/omni_manifest/src/text_to_artifacts.sql
+++ b/extensions/omni_manifest/src/text_to_artifacts.sql
@@ -1,0 +1,9 @@
+create function text_to_artifacts(artifacts text) returns artifact[]
+    language sql
+    immutable as
+$$
+select
+            array_agg(omni_manifest.text_to_artifact(artifact)) filter (where length(artifact) > 0)
+from
+    regexp_split_to_table(artifacts, '\s*(\n+|;)\s*') r(artifact)
+$$;

--- a/extensions/omni_manifest/tests/artifact.yml
+++ b/extensions/omni_manifest/tests/artifact.yml
@@ -1,0 +1,227 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_manifest
+
+tests:
+
+- name: text conversion
+  tests:
+  - name: text to artifact
+    query: |
+      with
+          artifact as (select ('omni_test=1.2#req=2'::text::omni_manifest.artifact).*)
+      select
+          (self).*,
+          requirements::text
+      from
+          artifact
+    results:
+    - name: omni_test
+      version: 1.2
+      requirements: req=2
+  - name: text to artifacts
+    query: |
+      with
+          artifact as (select * from unnest(e'omni_test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]))
+      select
+          (self).*,
+          requirements::text
+      from
+          artifact
+      order by
+          name
+    results:
+    - name: omni_test
+      version: 1.2
+      requirements: req=2
+    - name: req
+      version: 2
+      requirements: base=0
+  - name: text to artifacts
+    query: |
+      with
+          artifact as (select * from unnest(e'omni_test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]))
+      select
+          (self).*,
+          requirements::text
+      from
+          artifact
+      order by
+          name
+    results:
+    - name: omni_test
+      version: 1.2
+      requirements: req=2
+    - name: req
+      version: 2
+      requirements: base=0
+
+  - name: text to artifacts (semicolon instead of newline)
+    query: |
+      with
+          artifact as (select * from unnest('omni_test=1.2#req=2;req=2#base=0'::text::omni_manifest.artifact[]))
+      select
+          (self).*,
+          requirements::text
+      from
+          artifact
+      order by
+          name
+    results:
+    - name: omni_test
+      version: 1.2
+      requirements: req=2
+    - name: req
+      version: 2
+      requirements: base=0
+
+  - name: text to artifacts (superfluous newline tolerance)
+    query: |
+      with
+          artifact as (select * from unnest(e'omni_test=1.2#req=2\nreq=2#base=0\n'::text::omni_manifest.artifact[]))
+      select
+          (self).*,
+          requirements::text
+      from
+          artifact
+      order by
+          name
+    results:
+    - name: omni_test
+      version: 1.2
+      requirements: req=2
+    - name: req
+      version: 2
+      requirements: base=0
+
+  - name: artifact to text
+    query: select 'omni_test=1.2#req=2'::text::omni_manifest.artifact::text as artifact
+    results:
+    - artifact: omni_test=1.2#req=2
+  - name: artifacts to text
+    query: select e'omni_test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]::text as artifact
+    results:
+    - artifact: omni_test=1.2#req=2;req=2#base=0
+  - name: artifacts to text
+    query: select e'omni_test=1.2#req=2\nreq=2'::text::omni_manifest.artifact[]::text as artifact
+    results:
+    - artifact: omni_test=1.2#req=2;req=2
+
+- name: JSON conversion
+  tests:
+  - name: JSON to artifact
+    query: |
+      with
+          artifact as (select
+                           ('{"target": {"omni_test": "1.2"}, "requirements": {"req": "2"}}'::json::omni_manifest.artifact).*)
+      select
+          (self).*,
+          requirements::text
+      from
+          artifact
+    results:
+    - name: omni_test
+      version: 1.2
+      requirements: req=2
+  - name: JSON to artifacts
+    query: |
+      with
+          artifact as (select *
+                       from
+                           unnest('[{"target": {"omni_test": "1.2"}, "requirements": {"req": "2"}}, {"target": {"req": "2"}, "requirements": {"base": "0"}}]'::json::omni_manifest.artifact[]))
+      select
+          (self).*,
+          requirements::text
+      from
+          artifact
+      order by
+          name
+    results:
+    - name: omni_test
+      version: 1.2
+      requirements: req=2
+    - name: req
+      version: 2
+      requirements: base=0
+  - name: artifact to JSON
+    query: select 'omni_test=1.2#req=2'::text::omni_manifest.artifact::json as artifact
+    results:
+    - artifact:
+        target:
+          omni_test: 1.2
+        requirements:
+          req: 2
+  - name: artifacts to JSON
+    query: select
+               json_array_elements(e'omni_test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]::json) as artifact
+    results:
+    - artifact:
+        target:
+          omni_test: 1.2
+        requirements:
+          req: 2
+    - artifact:
+        target:
+          req: 2
+        requirements:
+          base: 0
+
+- name: JSONB conversion
+  tests:
+  - name: JSONb to artifact
+    query: |
+      with
+          artifact as (select
+                           ('{"target": {"omni_test": "1.2"}, "requirements": {"req": "2"}}'::jsonb::omni_manifest.artifact).*)
+      select
+          (self).*,
+          requirements::text
+      from
+          artifact
+    results:
+    - name: omni_test
+      version: 1.2
+      requirements: req=2
+  - name: JSONB to artifacts
+    query: |
+      with
+          artifact as (select *
+                       from
+                           unnest('[{"target": {"omni_test": "1.2"}, "requirements": {"req": "2"}}, {"target": {"req": "2"}, "requirements": {"base": "0"}}]'::jsonb::omni_manifest.artifact[]))
+      select
+          (self).*,
+          requirements::text
+      from
+          artifact
+      order by
+          name
+    results:
+    - name: omni_test
+      version: 1.2
+      requirements: req=2
+    - name: req
+      version: 2
+      requirements: base=0
+  - name: artifact to JSONB
+    query: select 'omni_test=1.2#req=2'::text::omni_manifest.artifact::jsonb as artifact
+    results:
+    - artifact:
+        target:
+          omni_test: 1.2
+        requirements:
+          req: 2
+  - name: artifacts to JSONB
+    query: select
+               jsonb_array_elements(e'omni_test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]::jsonb) as artifact
+    results:
+    - artifact:
+        target:
+          omni_test: 1.2
+        requirements:
+          req: 2
+    - artifact:
+        target:
+          req: 2
+        requirements:
+          base: 0

--- a/extensions/omni_manifest/tests/install.yml
+++ b/extensions/omni_manifest/tests/install.yml
@@ -145,3 +145,16 @@ tests:
       extversion: 2
     - extname: omni_manifest_test_2
       extversion: 2
+
+- name: installing dependencies with any version
+  query: |
+    select
+        requirement::text,
+        status
+    from
+        omni_manifest.install('pgcrypto=*'::text)
+    order by
+        (requirement).name asc
+  results:
+  - requirement: pgcrypto=*
+    status: installed


### PR DESCRIPTION
It's still difficult to just take a version of Omnigres and install or upgrade a set of extensions from it.

Solution: provide exchange formats for artifact listing

Manifests are effectively artifact lists, so we now support text and JSON formats for describing artifacts. Omnigres build process produces such artifact lists upon each build (`artifacts.txt`).

The delivery of this file may depend on a particular process as we don't have a common one established yet. One can put it onto the file system and read it with `pg_read_file`, or can download it using `omni_httpc` (if they have it already, that is).

Quite a lot going on in this change besides this:

* It fixes an issue with omni_ext hooks incorrectly handling the case of an attempt to upgrade version of an extension to the same version, assuming there's an unloading to be made where there shouldn't be. The executor as it is doesn't fail to prevent this but just issues a notice.
* New requirement status `kept` added to signify the above case