### PR TITLE
Problem: is omni_ext handling all extension update edge cases?

### DIFF
--- a/extensions/omni_ext/test/tests/omni_ext_test/update_same_explicit.yml
+++ b/extensions/omni_ext/test/tests/omni_ext_test/update_same_explicit.yml
@@ -1,0 +1,17 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+  init:
+  - create extension omni_ext_test version '0.1' cascade
+
+tests:
+
+- name: update current version to the same one explicitly
+  query: alter extension omni_ext_test update to '0.1'
+  commit: true
+
+- name: was the version unloaded?
+  query: select current_setting('omni_ext_test.done', true)
+  results:
+  - current_setting: null

--- a/extensions/omni_ext/test/tests/omni_ext_test/update_same_implicit.yml
+++ b/extensions/omni_ext/test/tests/omni_ext_test/update_same_implicit.yml
@@ -1,0 +1,17 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+  init:
+  - create extension omni_ext_test version '0.1' cascade
+
+tests:
+
+- name: update current version to the same one implicitly
+  query: alter extension omni_ext_test update
+  commit: true
+
+- name: was the version unloaded?
+  query: select current_setting('omni_ext_test.done', true)
+  results:
+  - current_setting: null


### PR DESCRIPTION
There are two cases I can think of right now:

1. `alter extension update to 'VER'` where the current version is `VER`
2. `alter extension update` where the default and the current versions are both `VER`

Solution: write tests for these cases

Fix the second case as it didn't work correctly and was causing an error as omni_ext tried to unload in this case.