### PR TITLE
Problem: building extensions sometimes grabs wrong includes

### DIFF
--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.1)
 project(omnigres)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../cmake)
 
 include(Common)
 

--- a/extensions/omni_aws/CMakeLists.txt
+++ b/extensions/omni_aws/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CTest)
 include(FindPkgConfig)
 include(FindThreads)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 enable_testing()
 

--- a/extensions/omni_containers/CMakeLists.txt
+++ b/extensions/omni_containers/CMakeLists.txt
@@ -4,7 +4,7 @@ project(omni_containers)
 include(CTest)
 include(CheckIncludeFile)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 enable_testing()
 

--- a/extensions/omni_ext/CMakeLists.txt
+++ b/extensions/omni_ext/CMakeLists.txt
@@ -4,7 +4,7 @@ project(omni_ext)
 if(NOT DEFINED ENV{OMNI_EXT_ALREADY_INCLUDED})
         set(ENV{OMNI_EXT_ALREADY_INCLUDED} TRUE)
 
-        list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+        list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
         include(CPM)
         include(CTest)

--- a/extensions/omni_ext/test/CMakeLists.txt
+++ b/extensions/omni_ext/test/CMakeLists.txt
@@ -4,7 +4,7 @@ project(omni_ext_test)
 include(CPM)
 include(CTest)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../cmake)
 
 enable_testing()
 

--- a/extensions/omni_http/CMakeLists.txt
+++ b/extensions/omni_http/CMakeLists.txt
@@ -3,7 +3,7 @@ project(omni_http)
 
 include(CTest)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 enable_testing()
 find_package(PostgreSQL REQUIRED)

--- a/extensions/omni_httpc/CMakeLists.txt
+++ b/extensions/omni_httpc/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.1)
 project(omni_httpc)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 include(OpenSSL)
 
 include(CTest)

--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -6,7 +6,7 @@ include(FindPkgConfig)
 include(FindThreads)
 
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 include(OpenSSL)
 
 enable_testing()

--- a/extensions/omni_json/CMakeLists.txt
+++ b/extensions/omni_json/CMakeLists.txt
@@ -3,7 +3,7 @@ project(omni_json)
 
 include(CTest)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 enable_testing()
 

--- a/extensions/omni_manifest/CMakeLists.txt
+++ b/extensions/omni_manifest/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CTest)
 include(FindPkgConfig)
 include(FindThreads)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 enable_testing()
 

--- a/extensions/omni_mimetypes/CMakeLists.txt
+++ b/extensions/omni_mimetypes/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CTest)
 include(FindPkgConfig)
 include(FindThreads)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 enable_testing()
 

--- a/extensions/omni_os/CMakeLists.txt
+++ b/extensions/omni_os/CMakeLists.txt
@@ -4,7 +4,7 @@ project(omni_os)
 include(CTest)
 include(CheckIncludeFile)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 enable_testing()
 

--- a/extensions/omni_python/CMakeLists.txt
+++ b/extensions/omni_python/CMakeLists.txt
@@ -4,7 +4,7 @@ project(omni_python)
 include(CTest)
 include(CheckIncludeFile)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 enable_testing()
 

--- a/extensions/omni_schema/CMakeLists.txt
+++ b/extensions/omni_schema/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CTest)
 include(FindPkgConfig)
 include(FindThreads)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 enable_testing()
 

--- a/extensions/omni_seq/CMakeLists.txt
+++ b/extensions/omni_seq/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.1)
 project(omni_seq)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 include(CPM)
 include(CTest)

--- a/extensions/omni_sql/CMakeLists.txt
+++ b/extensions/omni_sql/CMakeLists.txt
@@ -4,7 +4,7 @@ project(omni_sql)
 if(NOT DEFINED ENV{OMNI_SQL_ALREADY_INCLUDED})
     set(ENV{OMNI_SQL_ALREADY_INCLUDED} TRUE)
 
-    list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+    list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
     include(CPM)
     include(CTest)

--- a/extensions/omni_txn/CMakeLists.txt
+++ b/extensions/omni_txn/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.1)
 project(omni_txn)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 include(CPM)
 include(CTest)

--- a/extensions/omni_types/CMakeLists.txt
+++ b/extensions/omni_types/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.1)
 project(omni_types)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 include(CPM)
 include(CTest)

--- a/extensions/omni_var/CMakeLists.txt
+++ b/extensions/omni_var/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.1)
 project(omni_var)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 include(CPM)
 include(CTest)

--- a/extensions/omni_vfs/CMakeLists.txt
+++ b/extensions/omni_vfs/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CTest)
 include(FindPkgConfig)
 include(FindThreads)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 enable_testing()
 

--- a/extensions/omni_web/CMakeLists.txt
+++ b/extensions/omni_web/CMakeLists.txt
@@ -4,7 +4,7 @@ project(omni_web)
 include(CTest)
 include(FindPkgConfig)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 enable_testing()
 

--- a/extensions/omni_xml/CMakeLists.txt
+++ b/extensions/omni_xml/CMakeLists.txt
@@ -3,7 +3,7 @@ project(omni_xml)
 
 include(CTest)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
 
 include(CPM)
 


### PR DESCRIPTION
I've noticed that if I checkout a copy of Omnigres inside of my working directory of Omnigres (two levels below: 'omnigres/path/checkout') it would grab CMake includes from the working directory instead of the new clone.

Solution: ensure we include relative to the CMakeLists.txt file