### PR TITLE
Problem: generate-upgrades.sh doesn't consider all extensions

### DIFF
--- a/.github/workflows/ext-scripts.yml
+++ b/.github/workflows/ext-scripts.yml
@@ -1,0 +1,102 @@
+name: Extension scripts
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master", "**" ]
+
+env:
+  CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
+
+jobs:
+
+  extscripts:
+
+    name: Extension scripts
+
+    strategy:
+      matrix:
+        pgver: [ 16, 15, 14, 13 ]
+        os: [ warp-ubuntu-latest-x64-4x ]
+        build_type: [ Release ]
+      fail-fast: false
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+    - uses: actions/checkout@v3
+      if: github.event_name == 'push'
+      with:
+        fetch-depth: all
+
+    - uses: actions/checkout@v3
+      if: github.event_name != 'push'
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: all
+
+    # This is done to address the problem on macOS where .pg built in a directory of one
+    # GitHub Action runner won't work when restored in another one since dylds have install_name pointing
+    # to the original location. We include the hash of their path into the cache name.
+    - name: Get path hash
+      if: matrix.os == 'macos'
+      run: |
+        echo "PATH_SUFFIX=-$(pwd | sha256sum | awk '{print $1}')" >> $GITHUB_ENV
+
+    # On other systems, make it explicitly empty
+    - name: Get path hash
+      if: matrix.os != 'macos'
+      run: |
+        echo "PATH_SUFFIX=" >> $GITHUB_ENV
+
+    - uses: actions/cache@v3
+      with:
+        path: .pg
+        key: ${{ matrix.os }}-pg-${{ matrix.pgver }}-${{ matrix.build_type }}-${{ hashFiles('cmake/FindPostgreSQL.cmake') }}${{ env.PATH_SUFFIX }}
+
+    - uses: actions/cache@v3
+      with:
+        path: ${{github.workspace}}/build/_deps
+        key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('extensions/**/CMakeLists.txt', '*/CMakeLists.txt', 'cmake/*.cmake') }}
+
+    - name: Configure
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DPGVER=${{ matrix.pgver }}
+
+    - name: Build inja
+      # (We need it)
+      run: cmake --build ${{github.workspace}}/build --parallel --config ${{matrix.build_type}} --target inja
+
+    - name: Download S3 cache for the Postgres ${{ matrix.pgver }}
+      # We don't sign S3 request here as the bucket is public and we want this to work in
+      # external pull requests
+      run: mkdir -p s3_extensions/packaged && aws --no-sign-request s3 sync s3://omnigres-extensions/${{ matrix.pgver }} s3_extensions/packaged
+
+    - name: For every commit between start of upgrades (${{ vars.EXT_UPGRADES_START }}) and now
+      run: |
+        export TMPDIR=$RUNNER_TEMP
+        export PG_CONFIG=$(find .pg -name pg_config -type f -executable | grep -v src | head -n 1)
+        export DEST_DIR=s3_extensions
+        echo "Using $PG_CONFIG"
+        for VER in "$(git rev-list ${{ vars.EXT_UPGRADES_START }}^1..HEAD^1 --reverse --abbrev-commit)"; do
+          echo "============> $VER"
+          if [ ! -f "s3_extensions/artifacts-$VER.txt" ]; then
+            ./generate-upgrades.sh || exit 1
+          fi
+        done
+
+    - name: Pretend to sync back to S3
+      if: github.event_name != 'push'
+      run: aws s3 sync --dryrun --exclude *.so s3_extensions/packaged s3://omnigres-extensions/${{ matrix.pgver }}
+
+    - name: Sync back to S3
+      if: github.event_name == 'push'
+      run: aws s3 sync --exclude *.so s3_extensions/packaged s3://omnigres-extensions/${{ matrix.pgver }}
+

--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -627,4 +627,17 @@ ${PG_CTL} stop -D  \"$PSQLDB\" -m smart
         file(APPEND "${omni_artifacts}" "\n")
     endif()
 
+    if(NOT _ext_PRIVATE)
+        get_property(omni_path_map GLOBAL PROPERTY omni_path_map)
+        if(NOT omni_artifacts)
+            # Make an empty file
+            set_property(GLOBAL PROPERTY omni_path_map "${CMAKE_BINARY_DIR}/paths.txt")
+            get_property(omni_path_map GLOBAL PROPERTY omni_path_map)
+            file(WRITE "${omni_path_map}" "")
+        endif()
+        set(relpath ${CMAKE_CURRENT_SOURCE_DIR})
+        cmake_path(RELATIVE_PATH relpath BASE_DIRECTORY ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/..)
+        file(APPEND "${omni_path_map}" "${NAME} ${relpath}\n")
+    endif()
+
 endfunction()

--- a/dynpgext/test/CMakeLists.txt
+++ b/dynpgext/test/CMakeLists.txt
@@ -14,7 +14,7 @@ add_postgresql_extension(
         dynpgext_test
         VERSION 0.1
         SCRIPTS dynpgext_test--0.1.sql
-        PRIVATE true
+        PRIVATE TRUE
         RELOCATABLE false
         REQUIRES omni_ext
         SOURCES dynpgext_test.c)

--- a/extensions/omni_ext/test/CMakeLists.txt
+++ b/extensions/omni_ext/test/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(PostgreSQL REQUIRED)
 add_postgresql_extension(
         omni_ext_test
         SCHEMA omni_ext_test
-        PRIVATE true
+        PRIVATE TRUE
         RELOCATABLE false
         SOURCES omni_ext_test.c
         REQUIRES omni_ext
@@ -32,7 +32,7 @@ add_postgresql_extension(
 add_postgresql_extension(
         omni_ext_test_no_preload
         SCHEMA omni_ext_test_no_preload
-        PRIVATE true
+        PRIVATE TRUE
         RELOCATABLE false
         SOURCES omni_ext_test.c
         REQUIRES omni_ext

--- a/libpgaug/test/CMakeLists.txt
+++ b/libpgaug/test/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(PostgreSQL REQUIRED)
 add_postgresql_extension(
         libpgaug_test
         VERSION 0.1
-        PRIVATE true
+        PRIVATE TRUE
         SOURCES libpgaug_test.c
         DEPENDS_ON libpgaug)
 


### PR DESCRIPTION
This is because we use directory tree for discovery, and some extensions share the directory (like omni_vfs_types_v1).
    
Solution: build extension/path mapping during build

Also, build these artifacts on-demand and store them in S3.
