### PR TITLE
Problem: dropping omni_httpd in quick succession to create

### DIFF
--- a/extensions/omni_httpd/tests/create_drop.yml
+++ b/extensions/omni_httpd/tests/create_drop.yml
@@ -1,0 +1,14 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_EXT_SO
+    max_worker_processes: 64
+
+tests:
+
+- name: shuts down after drop
+  tests:
+  - query: create extension omni_httpd cascade
+    commit: true
+  - query: drop extension omni_httpd
+    commit: true

--- a/extensions/omni_httpd/tests/unloading.yml
+++ b/extensions/omni_httpd/tests/unloading.yml
@@ -25,15 +25,23 @@ tests:
   - error: null
 
 - name: stops working after unloading
-  steps:
-  - select omni_httpd.unload()
+  # it is important to make this `tests` and not `steps` because unloading fires termination of
+  # the master worker only after the transaction has been released
+  tests:
+  - query: create table listeners as (select
+                                          effective_port::int
+                                      from
+                                          omni_httpd.listeners)
+    commit: true
+  - query: drop extension omni_httpd
+    commit: true
   - query: |
       with
           response as (select *
                        from
                            omni_httpc.http_execute(
                                    omni_httpc.http_request('http://127.0.0.1:' ||
-                                                           (select effective_port from omni_httpd.listeners) || '/')))
+                                                           (select effective_port from listeners) || '/')))
       select
           response.error is null as error
       from


### PR DESCRIPTION
The sequence below tends to (always?) lock up at `drop` waiting for the master worker to die and it never does.

```postgresql
create extension omni_httpd cascade; drop extension omni_httpd;
```

Solution: ensure we're not holding onto the transaction with catalog changes

We do this by awaiting for master worker termination at the point when all changes are visible and transaction's memory context is being deleted.