### PR TITLE
Problem: occassional FATAL error in omni_httpd's master worker

### DIFF
--- a/extensions/omni_ext/omni_ext.c
+++ b/extensions/omni_ext/omni_ext.c
@@ -249,11 +249,13 @@ void register_bgworker_runtime(const dynpgext_handle *handle, BackgroundWorker *
     strncpy(NameStr(request->request.extname), handle->name, NAMEDATALEN);
     strncpy(NameStr(request->request.extver), handle->version, NAMEDATALEN);
     request->started = false;
+    // This makes it a template
+    request->databaseOid = InvalidOid;
 
     // Before releasing the lock, launch it ourselves in the current database
     BackgroundWorker local_bgw = *bgw;
     local_bgw.bgw_main_arg = MyDatabaseId;
-    RegisterDynamicBackgroundWorker(bgw, &worker_handle);
+    RegisterDynamicBackgroundWorker(&local_bgw, &worker_handle);
     LWLockRelease(lock);
   } else {
     // Otherwise, start it right here


### PR DESCRIPTION
The error is: "cannot read pg_class without having selected a database"

Solution: ensure we start the worker with the correct database OID

Turned out that in some cases, we were going through the `register_bgworker_runtime` path and it was not registering the intended description of the background worker (`local_bgw`) but the original one that didn't have a correct main argument set.

With this change, it bow registers the correct one.

This applies to other dynpgext components beyond omni_httpd.