### PR TITLE
Problem: omni_ext's library path might not fit BGWLEN-1

### DIFF
--- a/extensions/omni_ext/omni_ext.h
+++ b/extensions/omni_ext/omni_ext.h
@@ -198,4 +198,6 @@ void omni_ext_transaction_callback(XactEvent event, void *arg);
 void populate_bgworker_requests_for_db(Oid dboid);
 void process_extensions_for_database(char *extname, char *extversion, Oid dboid);
 
+char *get_fitting_library_name(char *library_name);
+
 #endif // OMNI_EXT_H


### PR DESCRIPTION
This leads to odd errors like:

```
ERROR: could not access file "/home/runner/work/omnigres/omnigres/s3_extensions/16/09a1406/build/extensions/omni_ext/omni_ext.master_worker": No such file or directory
```

Solution: ensure it gets a fitting name, too