### PR TITLE
Problem: update of extensions to newer versions is unclear

### DIFF
--- a/extensions/omni_manifest/docs/usage.md
+++ b/extensions/omni_manifest/docs/usage.md
@@ -243,3 +243,77 @@ installed, at which point it'll return `kept`.
 
     It is highly recommended to perform installations transactionally to be able to check
     reports for missing dependencies.
+
+## Update extensions
+
+To update extensions using `omni_manifest.install` ensure the update scripts for the extensions is saved to the postgres
+extension scripts directory. Currently all the extensions are versioned using git commit sha of omnigres repo, extension
+update is only possible from older commit version to newer ones.
+
+```postgresql
+-- check available version of omni_python
+select * from pg_available_extension_versions where name = 'omni_python';
+    name     | version | installed | superuser | trusted | relocatable |   schema    |   requires   | comment 
+-------------+---------+-----------+-----------+---------+-------------+-------------+--------------+---------
+ omni_python | 2c7e737 | f         | t         | f       | f           | omni_python | {plpython3u} | 
+(1 row) 
+
+-- create omni_python extension with version '2c7e737'
+select *                                
+from
+    omni_manifest.install(
+            'omni_python=2c7e737#plpython3u=*'::text::omni_manifest.artifact[]
+    );
+      requirement      |  status   
+-----------------------+-----------
+ (plpython3u,*)        | installed
+ (omni_python,2c7e737) | installed
+(2 rows)
+```
+
+A public s3 endpoint is available to download extension update scripts (old to new versions) for omnigres provided
+extensions
+
+```bash
+# download all the extension update scripts to a local directory
+mkdir ext_updates && aws --no-sign-request s3 sync s3://omnigres-extensions/<postgres-major-version> ext_updates
+```
+
+To update `omni_python` to a later version for eg. `e135aa7` copy the following `omni_python` sql and control files
+from `ext_updates` created above to postgres extension script directory
+```bash
+cp omni_python--2c7e737--e135aa7.sql omni_python--e135aa7.control <postgres-extension-script-directory>
+```
+
+```postgresql
+-- recheck the available omni_python versions
+select * from pg_available_extension_versions where name = 'omni_python';
+    name     | version | installed | superuser | trusted | relocatable |   schema    |   requires   | comment 
+-------------+---------+-----------+-----------+---------+-------------+-------------+--------------+---------
+ omni_python | 2c7e737 | t         | t         | f       | f           | omni_python | {plpython3u} | 
+ omni_python | e135aa7 | f         | t         | f       | f           | omni_python | {plpython3u} | 
+(2 rows)
+
+-- update omni_python to version 'e135aa7' and plpythonu3u version unchanged using '*'
+select *                                
+from
+    omni_manifest.install(
+            'omni_python=e135aa7#plpython3u=*'::text::omni_manifest.artifact[]
+    );
+      requirement      | status  
+-----------------------+---------
+ (plpython3u,*)        | kept
+ (omni_python,e135aa7) | updated
+(2 rows)
+
+-- verify omni_python is updated
+select * from pg_extension where extname = 'omni_python';
+  oid  |   extname   | extowner | extnamespace | extrelocatable | extversion | extconfig | extcondition 
+-------+-------------+----------+--------------+----------------+------------+-----------+--------------
+ 16484 | omni_python |       10 |        16483 | f              | e135aa7    |           | 
+(1 row)
+```
+
+!!! tip "Artifact format of extensions"
+
+    The artifact format of extensions can be copied from files named `artifacts-<version>`.txt in `ext_updates` created above


### PR DESCRIPTION
There is a public s3 endpoint available to download extension update scripts but there is no documentation available on how to use it.

Solution: Add a section to `omni_manifest` docs to demonstrate update of extensions to newer versions.