### PR TITLE
Problem: omni_manifest fails to update extension version

### DIFF
--- a/extensions/omni_ext/hooks.c
+++ b/extensions/omni_ext/hooks.c
@@ -138,7 +138,7 @@ void omni_ext_process_utility_hook(PlannedStmt *pstmt, const char *queryString,
 
         char *extversion = pstrdup(altered_extversion);
         ExtensionReference *drop = palloc(sizeof(ExtensionReference));
-        drop->name = stmt->extname;
+        drop->name = pstrdup(stmt->extname);
         drop->version = extversion;
         extensions_to_drop = lappend(extensions_to_drop, drop);
 

--- a/extensions/omni_ext/omni_ext.c
+++ b/extensions/omni_ext/omni_ext.c
@@ -427,7 +427,8 @@ char *load_extension(char *name, char *version) {
     load_control_file(search.unversioned_match, (void *)&config);
     result = "";
   } else {
-    ereport(ERROR, errmsg("No matching control file found"));
+    ereport(ERROR,
+            errmsg("No matching control file found for name '%s' version '%s'", name, version));
   }
 
   return result;
@@ -473,7 +474,8 @@ bool unload_extension(char *name, char *version) {
     load_control_file(search.unversioned_match, (void *)&config);
     result = true;
   } else {
-    ereport(ERROR, errmsg("No matching control file found"));
+    ereport(ERROR,
+            errmsg("No matching control file found for name '%s' version '%s'", name, version));
   }
   // TODO: free allocated resources (shmem & workers)? or should this be a responsibility
   // of the extension to ensure this is done exactly how they need it?


### PR DESCRIPTION
omni_manifest fails with `No matching control file found` when updating an extension's version using it's install function. omni_ext is getting incorrect extension name for unloading.

Solution: duplicate extension name from alter extension statement to preserve it for later use.

#475 