### PR TITLE
Problem: pg_rewind fails in presence of omni_httpd extension files in postgres data directory

### DIFF
--- a/extensions/omni_httpd/docs/intro.md
+++ b/extensions/omni_httpd/docs/intro.md
@@ -149,4 +149,11 @@ from
 | **query_string** | text                   | Query string               | `NULL`      | 
 |      **headers** | omni_http.http_headers | An array of HTTP headers   | empty array |
 |         **body** | bytea                  | Request body               | `NULL`      |
- 
+
+## Configuration
+
+`omni_httpd` can be configured with the following PostgreSQL configuration variables:
+
+* `omni_httpd.http_workers` to configure the number of http workers, defaults to number of cpus
+* `omni_httpd.temp_dir` to set the temporary directory for `omni_httpd` files like unix domain sockets, defaults
+  to `/tmp`

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -27,6 +27,8 @@ int create_listening_socket(sa_family_t family, in_port_t port, char *address, i
 
 extern int num_http_workers;
 
+extern char *temp_dir;
+
 static const char *OMNI_HTTPD_CONFIGURATION_NOTIFY_CHANNEL = "omni_httpd_configuration";
 
 static const char *OMNI_HTTPD_CONFIGURATION_RELOAD_SEMAPHORE =

--- a/extensions/omni_httpd/tests/create_drop.yml
+++ b/extensions/omni_httpd/tests/create_drop.yml
@@ -10,5 +10,42 @@ tests:
   tests:
   - query: create extension omni_httpd cascade
     commit: true
+
+    # https://github.com/omnigres/omnigres/issues/479
+  - query: select count(*)
+           from pg_ls_dir((select setting from pg_settings where name = 'data_directory'))
+           where pg_ls_dir like 'omni_httpd%'
+    results:
+      - count: 0
   - query: drop extension omni_httpd
     commit: true
+
+- name: temp_dir doesn't exist
+  transaction: false
+  query: alter system set omni_httpd.temp_dir = '/does-not-exist'
+  error:
+    severity: ERROR
+    message: "'/does-not-exist' temp directory does not exist."
+
+- name: temp_dir inside data dir
+  transaction: false
+  #  unable to execute alter system with dynamic value in SQL but this has been tested manually
+  todo: true
+  query: |
+    do
+    $$
+        declare
+            data_dir text;
+        begin
+            select setting
+            into data_dir
+            from pg_settings
+            where name = 'data_directory';
+            
+            execute format('alter system set omni_httpd.temp_dir = ''%s''', data_dir);
+        end;
+    
+    $$ language plpgsql;
+  error:
+    severity: ERROR
+    message: temp directory location should not be inside the data directory


### PR DESCRIPTION

Solution: use temp directory to store omni_httpd unix socket file

#479 