### PR TITLE
Problem: developing tools in Logtalk

### DIFF
--- a/cmake/Logtalk.cmake
+++ b/cmake/Logtalk.cmake
@@ -1,0 +1,75 @@
+function(find_logtalk LOGTALK_VAR SWIPL_VERSION)
+    list(LENGTH ARGN ARGN_LENGTH)
+    if(ARGN_LENGTH GREATER 0)
+        list(GET ARGN 0 LOGTALK_VERSION)
+    else()
+    endif()
+    if(NOT LOGTALK_VERSION)
+        set(LOGTALK_VERSION 3.74.0)
+    endif()
+
+    if(NOT DEFINED LOGTALK_GIT_TAG)
+        string(REPLACE "." "" _LOGTALK_VERSION_DOTLESS ${LOGTALK_VERSION})
+        set(LOGTALK_GIT_TAG lgt${_LOGTALK_VERSION_DOTLESS}stable)
+    endif()
+
+    if(NOT DEFINED LOGTALK_${LOGTALK_VERSION})
+        CPMAddPackage(NAME Logtalk_${LOGTALK_VERSION} GITHUB_REPOSITORY LogtalkDotOrg/logtalk3 VERSION ${LOGTALK_VERSION} GIT_TAG ${LOGTALK_GIT_TAG} DOWNLOAD_ONLY YES)
+
+        if(Logtalk_${LOGTALK_VERSION}_ADDED)
+            set(ENV{LOGTALKHOME} ${Logtalk_${LOGTALK_VERSION}_SOURCE_DIR})
+            set(ENV{LOGTALKUSER} ${Logtalk_${LOGTALK_VERSION}_SOURCE_DIR})
+            set(ENV{PATH} ${CMAKE_CURRENT_BINARY_DIR}/swipl_${SWIPL_VERSION}/bin:$ENV{PATH})
+            add_custom_target(swilgt_${LOGTALK_VERSION}
+                    COMMAND LOGTALKUSER=${Logtalk_${LOGTALK_VERSION}_SOURCE_DIR} LOGTALKHOME=${Logtalk_${LOGTALK_VERSION}_SOURCE_DIR} ${SWIPL_${SWIPL_VERSION}} -s "${Logtalk_${LOGTALK_VERSION}_SOURCE_DIR}/integration/logtalk_swi.pl"
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        endif()
+    endif()
+    set(${LOGTALK_VAR} swilgt_${LOGTALK_VERSION} PARENT_SCOPE)
+    set(${LOGTALK_VAR}_SOURCE_DIR ${Logtalk_${LOGTALK_VERSION}_SOURCE_DIR} PARENT_SCOPE)
+    set(${LOGTALK_VAR}_VERSION ${LOGTALK_VERSION} PARENT_SCOPE)
+endfunction()
+
+
+function(logtalk_qlf LOGTALK_VAR TARGET)
+    set(_optional SETTINGS_BUILD)
+    set(_single NAME LOADER)
+    set(_multi SOURCES)
+    cmake_parse_arguments(_qlf "${_optional}" "${_single}" "${_multi}" ${ARGN})
+    get_target_property(_src ${TARGET} SOURCE_DIR)
+    get_target_property(_bin ${TARGET} BINARY_DIR)
+    get_target_property(_srcs ${TARGET} SOURCES)
+    set(_sources)
+    foreach(_srcn ${_qlf_SOURCES})
+        list(APPEND _sources ${_src}/${_srcn})
+    endforeach()
+    set(_settings ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/settings-build.lgt)
+    set(_extra_srcs)
+    if(_qlf_SETTINGS_BUILD)
+        string(APPEND _settings "${_src}/${_qlf_SETTINGS_BUILD}")
+        list(APPEND _extra_srcs "${_src}/${_qlf_SETTINGS_BUILD}")
+    endif()
+    list(GET _srcs 0 _first_src)
+    target_sources(${TARGET} PRIVATE ${_bin}/app/application)
+    get_filename_component(loader_dir ${_src}/${_qlf_LOADER} DIRECTORY ABSOLUTE)
+    add_custom_command(
+            DEPENDS ${_sources} ${_src}/${_qlf_LOADER} ${_extra_srcs}
+            WORKING_DIRECTORY ${loader_dir}
+            OUTPUT ${_bin}/app/application
+            COMMAND LOGTALKUSER=${${LOGTALK_VAR}_SOURCE_DIR} LOGTALKHOME=${${LOGTALK_VAR}_SOURCE_DIR} PATH=${${LOGTALK_VAR}_SOURCE_DIR}/integration:$ENV{PATH}
+            ${${LOGTALK_VAR}_SOURCE_DIR}/scripts/embedding/swipl/swipl_logtalk_qlf.sh
+            -f save
+            -d ${_bin}/app
+            -s ${_settings}
+            -l ${_src}/${_qlf_LOADER}
+            -c -x
+            # Trigger a rebuild for the target. Not pretty but does the job
+            COMMAND ${CMAKE_COMMAND} -E touch ${_src}/${_first_src})
+
+    add_custom_command(TARGET ${TARGET} POST_BUILD
+            DEPENDS ${_bin}/app/application
+            COMMAND cat $<TARGET_FILE:${TARGET}> ${_bin}/app/application > ${_bin}/_temp
+            COMMAND mv ${_bin}/_temp $<TARGET_FILE:${TARGET}>
+            COMMAND chmod +x $<TARGET_FILE:${TARGET}>)
+
+endfunction()

--- a/cmake/SWIprolog.cmake
+++ b/cmake/SWIprolog.cmake
@@ -1,0 +1,116 @@
+function(find_swipl SWIPL_VAR)
+    list(LENGTH ARGN ARGN_LENGTH)
+    if(ARGN_LENGTH GREATER 0)
+        list(GET ARGN 0 SWIPL_VERSION)
+    else()
+    endif()
+    if(NOT SWIPL_VERSION)
+        set(SWIPL_VERSION 9.3.1)
+    endif()
+    if(NOT DEFINED SWIPL_${SWIPL_VERSION})
+        CPMAddPackage(NAME swiprolog_${SWIPL_VERSION} GITHUB_REPOSITORY SWI-Prolog/swipl-devel VERSION ${SWIPL_VERSION} GIT_TAG V${SWIPL_VERSION}
+                DOWNLOAD_ONLY YES
+                GIT_SUBMODULES packages/http packages/ssl packages/clib packages/sgml packages/zlib packages/readline packages/yaml
+                packages/cpp packages/utf8proc)
+
+        if(swiprolog_${SWIPL_VERSION}_ADDED)
+            execute_process(COMMAND cmake -S ${swiprolog_${SWIPL_VERSION}_SOURCE_DIR} -DSWIPL_STATIC_LIB=ON
+                    -DSWIPL_PACKAGE_LIST=utf8proc\;http\;clib\;readline\;cpp\;yaml
+                    -DSWIPL_STATIC_LIB=ON -DBUILD_TESTING=OFF -DINSTALL_TESTS=OFF
+                    -DINSTALL_DOCUMENTATION=OFF -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/swipl_${SWIPL_VERSION}
+                    -B ${swiprolog_${SWIPL_VERSION}_BINARY_DIR}
+                    RESULT_VARIABLE rc)
+
+            if(NOT rc EQUAL 0)
+                message(FATAL_ERROR "Failed configuring swipl")
+            endif()
+
+            execute_process(COMMAND cmake --build ${swiprolog_${SWIPL_VERSION}_BINARY_DIR} --parallel --target install
+                    RESULT_VARIABLE rc)
+            if(NOT rc EQUAL 0)
+                message(FATAL_ERROR "Failed building swipl")
+            endif()
+
+            set(SWIPL_${SWIPL_VERSION} ${CMAKE_CURRENT_BINARY_DIR}/swipl_${SWIPL_VERSION}/bin/swipl CACHE STRING "swipl")
+        else()
+            find_program(SWIPL_${SWIPL_VERSION} swipl REQUIRED PATHS ${CMAKE_CURRENT_BINARY_DIR}/swipl_${SWIPL_VERSION}/bin NO_DEFAULT_PATH)
+        endif()
+    endif()
+
+    set(${SWIPL_VAR} ${SWIPL_${SWIPL_VERSION}} PARENT_SCOPE)
+    set(${SWIPL_VAR}_VERSION ${SWIPL_VERSION} PARENT_SCOPE)
+
+    execute_process(COMMAND ${SWIPL_${SWIPL_VERSION}} --dump-runtime-variables OUTPUT_VARIABLE swipl_runtime_variables)
+    foreach(line ${swipl_runtime_variables})
+        string(STRIP ${line} line)
+        if(line STREQUAL "")
+            continue()
+        endif()
+        # Find the positions of '=' and the second '\"'
+        string(FIND "${line}" "=" pos_equal)
+        string(FIND "${line}" "\"" pos_quote REVERSE)
+
+        # Extract the variable name and value
+        math(EXPR length_name "${pos_equal}")
+        math(EXPR start_value "${pos_equal} + 2")
+        math(EXPR length_value "${pos_quote} - ${start_value}")
+
+        string(SUBSTRING "${line}" 0 ${length_name} name)
+        string(SUBSTRING "${line}" ${start_value} ${length_value} value)
+
+        set(${SWIPL_VAR}_${name} "${value}" CACHE INTERNAL "Swipl setting")
+    endforeach()
+endfunction()
+
+function(target_link_swipl TARGET SWIPL)
+    # as long as we don't need foreign libraries, we're fine, # but the moment we do,
+    # these static builds don't work.
+    #find_library((${SWIPL_VAR}_LIBSWIPL_STATIC NAMES swipl_static PATHS "${${SWIPL_VAR}_PLLIBDIR}")
+    #    unset(LIBSWIPL_STATIC)
+    find_library(LIBSWIPL NAMES swipl PATHS "${${SWIPL}_PLLIBDIR}" NO_DEFAULT_PATH REQUIRED)
+
+    if(LIBSWIPL_STATIC)
+        set(libswipl swipl_static)
+    else()
+        set(libswipl swipl)
+    endif()
+
+    target_link_libraries(${TARGET} PRIVATE ${libswipl})
+    target_compile_definitions(${TARGET} PRIVATE __SWI_PROLOG __SWI_EMBEDDED_)
+    target_include_directories(${TARGET} PRIVATE "${${SWIPL}_PLBASE}/include")
+    target_link_directories(${TARGET} PRIVATE "${${SWIPL}_PLLIBDIR}")
+
+    if(APPLE)
+        set_target_properties(${TARGET} PROPERTIES INSTALL_RPATH "@loader_path")
+    else()
+        set_target_properties(${TARGET} PROPERTIES INSTALL_RPATH "$ORIGIN")
+    endif()
+
+    if(STATIC)
+        if(APPLE)
+            find_library(CoreFoundation NAMES CoreFoundation)
+            target_link_libraries(${TARGET} PRIVATE ${CoreFoundation})
+            set_target_properties(${TARGET} PROPERTIES ENABLE_EXPORTS ON)
+        endif()
+
+        find_library(libncurses NAMES ncurses REQUIRED)
+        find_library(libz NAMES z REQUIRED)
+        find_library(libm NAMES m REQUIRED)
+
+        target_link_libraries(${TARGET} PRIVATE ${libncurses} ${libz} ${libm})
+    endif()
+
+    if(NOT STATIC)
+        if(IS_SYMLINK ${LIBSWIPL})
+            file(READ_SYMLINK ${LIBSWIPL} LIBSWIPL_)
+            get_filename_component(LIBSWIPL_ ${LIBSWIPL_} NAME)
+        else()
+            get_filename_component(LIBSWIPL_ ${LIBSWIPL} NAME)
+        endif()
+        add_custom_target(copy-${LIBSWIPL_} BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${LIBSWIPL_}
+                COMMAND ${CMAKE_COMMAND} -E copy ${LIBSWIPL} ${CMAKE_CURRENT_BINARY_DIR}/${LIBSWIPL_}
+                DEPENDS ${LIBSWIPL})
+        add_dependencies(${TARGET} copy-${LIBSWIPL_})
+    endif()
+
+endfunction()

--- a/cmake/settings-build.lgt
+++ b/cmake/settings-build.lgt
@@ -1,0 +1,17 @@
+:- initialization((
+        set_logtalk_flag(prolog_loader, [silent(true)]),
+        % be silent except for warnings (set to "off" for final deliverable)
+        set_logtalk_flag(report, warnings),
+        %set_logtalk_flag(report, off),
+        % prevent reloading of embedded code
+        set_logtalk_flag(reload, skip),
+        % optimize performance
+        set_logtalk_flag(optimize, on),
+        % do not save source file data
+        set_logtalk_flag(source_data, off),
+        % lock your entities by default to prevent breaking encapsulation
+        set_logtalk_flag(events, deny),
+        set_logtalk_flag(complements, deny),
+        set_logtalk_flag(dynamic_declarations, deny),
+        set_logtalk_flag(context_switching_calls, deny)
+)).

--- a/misc/logtalk_skeleton/CMakeLists.txt
+++ b/misc/logtalk_skeleton/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(logtalk_skeleton)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../cmake)
+
+include(CPM)
+include(SWIprolog)
+include(Logtalk)
+
+find_swipl(SWIPL)
+find_logtalk(Logtalk ${SWIPL_VERSION})
+
+add_executable(logtalk_skeleton main.c)
+
+target_link_swipl(logtalk_skeleton SWIPL)
+
+logtalk_qlf(Logtalk logtalk_skeleton SOURCES main.lgt LOADER loader.lgt)

--- a/misc/logtalk_skeleton/loader.lgt
+++ b/misc/logtalk_skeleton/loader.lgt
@@ -1,0 +1,1 @@
+:- initialization(logtalk_load([format(loader), main])).

--- a/misc/logtalk_skeleton/main.c
+++ b/misc/logtalk_skeleton/main.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+
+#include <SWI-Prolog.h>
+
+#define PL_require(x)                                                                              \
+  if (!x)                                                                                          \
+  return FALSE
+
+term_t Logtalk(term_t receiver, char *predicate_name, int arity, term_t arg) {
+  // create term for the message
+  functor_t functor = PL_new_functor(PL_new_atom(predicate_name), arity);
+  term_t pred = PL_new_term_ref();
+  PL_require(PL_cons_functor_v(pred, functor, arg));
+
+  // term for ::(receiver, message)
+  functor_t send_functor = PL_new_functor(PL_new_atom("::"), 2);
+  term_t goal = PL_new_term_ref();
+  PL_require(PL_cons_functor(goal, send_functor, receiver, pred));
+
+  return goal;
+}
+
+term_t Logtalk_named(char *object_name, char *predicate_name, int arity, term_t arg) {
+  // create term for the receiver of the message
+  term_t receiver = PL_new_term_ref();
+  PL_put_atom_chars(receiver, object_name);
+
+  return Logtalk(receiver, predicate_name, arity, arg);
+}
+
+int main(int argc, char **argv) {
+  // SWI Prolog
+  char *program = argv[0];
+  char *plav[2] = {program, NULL};
+  if (!PL_initialise(1, plav)) {
+    PL_halt(1);
+  }
+
+  term_t arg; // empty
+  term_t main = Logtalk_named("main", "main", 0, arg);
+  if (PL_call(main, NULL) == FALSE) {
+    printf("Error calling main entrypoint\n");
+  }
+
+  PL_cleanup(PL_CLEANUP_NO_CANCEL);
+}

--- a/misc/logtalk_skeleton/main.lgt
+++ b/misc/logtalk_skeleton/main.lgt
@@ -1,0 +1,7 @@
+:- object(main).
+
+:- public(main/0).
+
+main :- format::format("Hello, world!", []).
+
+:- end_object.


### PR DESCRIPTION
I am a big fan of Prolog/Logtalk and for certain tooling in Omnigres it will deliver great value. However, it's not integrated into our build system. This makes further experimentation a notch harder.

Solution: extract the latest version of the cmake integration

In unpublished experimental work I've already integrated Logtalk and SWI-Prolog. Let's avoid losing this before that experimental work comes to fruition.

I've included necessary CMake files and a simple "hello world" example so we can iterate from there.