### PR TITLE
Problem: CMake cannot pass compiler optimization flags

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -135,9 +135,9 @@ if(NOT DEFINED PG_CONFIG)
         endif()
 
         if(BUILD_TYPE STREQUAL "RelWithDebInfo")
-            set(ENV{CFLAGS} "$ENV{CFLAGS} -O2")
+            set(ENV{CFLAGS} "$ENV{CFLAGS} ${CMAKE_C_FLAGS_RELWITHDEBINFO}")
         elseif(BUILD_TYPE STREQUAL "Release")
-            set(ENV{CFLAGS} "$ENV{CFLAGS} -O2")
+            set(ENV{CFLAGS} "$ENV{CFLAGS} ${CMAKE_C_FLAGS_RELEASE}")
         endif()
 
         execute_process(

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -134,6 +134,12 @@ if(NOT DEFINED PG_CONFIG)
             string(APPEND extra_configure_args " --enable-debug --enable-cassert")
         endif()
 
+        if(BUILD_TYPE STREQUAL "RelWithDebInfo")
+            set(ENV{CFLAGS} "$ENV{CFLAGS} -O2")
+        elseif(BUILD_TYPE STREQUAL "Release")
+            set(ENV{CFLAGS} "$ENV{CFLAGS} -O2")
+        endif()
+
         execute_process(
                 COMMAND bash -c "./configure ${extra_configure_args} --prefix \"${PGDIR_VERSION}/build\" --without-icu --with-ssl=openssl"
                 WORKING_DIRECTORY "${PGDIR_VERSION}/postgresql-${PGVER_ALIAS}"


### PR DESCRIPTION
When using Cmake to compile Omnigres, there is no ability to pass in compiler optimization flags. This is an issue because it can greatly slow down performance for release versions on Omnigres.

Solution: pass CMake's build-type-specific cflags to Postgres
