### PR TITLE
Problem: arm64 docker builds fail on GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,8 @@ jobs:
     #  with:
     #    cosign-release: 'v2.2.0'
 
+      - name: prepare
+        run: mkdir -p /root/.docker/buildx/.bin/0.10.4/
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
```
Download buildx from GitHub Releases
Error: ENOENT: no such file or directory,
  copyfile '/opt/hostedtoolcache/buildx-dl-bin/0.10.4/linux-arm64/docker-buildx' ->
  '/root/.docker/buildx/.bin/0.10.4/linux-arm64/docker-buildx'
```

Solution: try to figure out what happened