### PR TITLE
Problem: Extension scripts workflow output is wrong on pull_request_target event

### DIFF
--- a/.github/workflows/ext-scripts.yml
+++ b/.github/workflows/ext-scripts.yml
@@ -146,7 +146,7 @@ jobs:
             git show ${{ github.event.before }}:../versions.txt > old_versions.txt
           else
             # last commit of target branch of PR
-            git show ${{ github.github.event.pull_request.base.sha }}:../versions.txt > old_versions.txt
+            git show ${{ github.event.pull_request.base.sha }}:../versions.txt > old_versions.txt
           fi
           
           while read -r line; do


### PR DESCRIPTION
The workflow is not creating any extension release files when triggered on pull_request_target event due to incorrect usage of github context.

Solution: Fix it