### PR TITLE
Problem: default_needs_fmgr returns `bool`

### DIFF
--- a/extensions/omni/hook_harness.c
+++ b/extensions/omni/hook_harness.c
@@ -27,10 +27,11 @@ MODULE_FUNCTION void default_check_password_hook(omni_hook_handle *handle, const
                    username, shadow_pass, password_type, validuntil_time, validuntil_null);
 }
 
-MODULE_FUNCTION bool default_needs_fmgr(omni_hook_handle *handle, Oid fn_oid) {
-  return saved_hooks[omni_hook_needs_fmgr] == NULL
-             ? false
-             : ((needs_fmgr_hook_type)saved_hooks[omni_hook_needs_fmgr])(fn_oid);
+MODULE_FUNCTION void default_needs_fmgr(omni_hook_handle *handle, Oid fn_oid) {
+  handle->returns.bool_value =
+      saved_hooks[omni_hook_needs_fmgr] == NULL
+          ? false
+          : ((needs_fmgr_hook_type)saved_hooks[omni_hook_needs_fmgr])(fn_oid);
 }
 
 MODULE_FUNCTION void default_executor_start(omni_hook_handle *handle, QueryDesc *queryDesc,
@@ -110,17 +111,17 @@ MODULE_FUNCTION void reorganize_hooks() {
 
 #define iterate_hooks(HOOK, ...)                                                                   \
   ({                                                                                               \
-    void *ctxs[hook_entry_points.entry_points_count[HOOK]];                                        \
+    void *ctxs[hook_entry_points.entry_points_count[omni_hook_##HOOK]];                            \
     omni_hook_return_value retval = {.ptr_value = NULL};                                           \
-    if (hook_entry_points.entry_points_count[HOOK] > 0)                                            \
-      for (int i = hook_entry_points.entry_points_count[HOOK] - 1; i >= 0; i--) {                  \
-        hook_entry_point *hook = hook_entry_points.entry_points[HOOK] + i;                         \
+    if (hook_entry_points.entry_points_count[omni_hook_##HOOK] > 0)                                \
+      for (int i = hook_entry_points.entry_points_count[omni_hook_##HOOK] - 1; i >= 0; i--) {      \
+        hook_entry_point *hook = hook_entry_points.entry_points[omni_hook_##HOOK] + i;             \
         ctxs[i] = NULL;                                                                            \
         omni_hook_handle handle = {.handle = hook->handle,                                         \
                                    .ctx = ctxs[hook->state_index],                                 \
                                    .next_action = hook_next_action_next,                           \
                                    .returns = retval};                                             \
-        ((HOOK##_t)(hook->fn))(&handle, __VA_ARGS__);                                              \
+        (hook->fn.HOOK)(&handle, __VA_ARGS__);                                                     \
         retval = handle.returns;                                                                   \
         ctxs[i] = handle.ctx;                                                                      \
         switch (handle.next_action) {                                                              \
@@ -135,34 +136,34 @@ MODULE_FUNCTION void reorganize_hooks() {
   })
 
 MODULE_FUNCTION bool omni_needs_fmgr_hook(Oid fn_oid) {
-  return iterate_hooks(omni_hook_needs_fmgr, fn_oid).bool_value;
+  return iterate_hooks(needs_fmgr, fn_oid).bool_value;
 }
 
 MODULE_FUNCTION void omni_check_password_hook(const char *username, const char *shadow_pass,
                                               PasswordType password_type, Datum validuntil_time,
                                               bool validuntil_null) {
-  iterate_hooks(omni_hook_check_password, username, shadow_pass, password_type, validuntil_time,
+  iterate_hooks(check_password, username, shadow_pass, password_type, validuntil_time,
                 validuntil_null);
 }
 
 MODULE_FUNCTION void omni_executor_start_hook(QueryDesc *queryDesc, int eflags) {
   load_pending_modules();
 
-  iterate_hooks(omni_hook_executor_start, queryDesc, eflags);
+  iterate_hooks(executor_start, queryDesc, eflags);
 }
 
 MODULE_FUNCTION void omni_executor_run_hook(QueryDesc *queryDesc, ScanDirection direction,
                                             uint64 count, bool execute_once) {
 
-  iterate_hooks(omni_hook_executor_run, queryDesc, direction, count, execute_once);
+  iterate_hooks(executor_run, queryDesc, direction, count, execute_once);
 }
 
 MODULE_FUNCTION void omni_executor_finish_hook(QueryDesc *queryDesc) {
-  iterate_hooks(omni_hook_executor_finish, queryDesc);
+  iterate_hooks(executor_finish, queryDesc);
 }
 
 MODULE_FUNCTION void omni_executor_end_hook(QueryDesc *queryDesc) {
-  iterate_hooks(omni_hook_executor_end, queryDesc);
+  iterate_hooks(executor_end, queryDesc);
   load_pending_modules();
 }
 
@@ -178,8 +179,8 @@ MODULE_FUNCTION void omni_process_utility_hook(PlannedStmt *pstmt, const char *q
   bool readOnlyTree = false;
 #endif
 
-  iterate_hooks(omni_hook_process_utility, pstmt, queryString, readOnlyTree, context, params,
-                queryEnv, dest, qc);
+  iterate_hooks(process_utility, pstmt, queryString, readOnlyTree, context, params, queryEnv, dest,
+                qc);
 
   // It is critical here to NOT try to rescan modules if we're
   // processing a transaction statement as we may be not having valid invariants for
@@ -207,7 +208,7 @@ static void on_xact_dealloc(void *arg) {
 }
 
 MODULE_FUNCTION void omni_xact_callback_hook(XactEvent event, void *arg) {
-  iterate_hooks(omni_hook_xact_callback, event);
+  iterate_hooks(xact_callback, event);
 
   // Hard-coded single-shot hooks
   // TODO: these are a bit of a hack and we should find ways to get rid of them
@@ -234,6 +235,4 @@ MODULE_FUNCTION void omni_xact_callback_hook(XactEvent event, void *arg) {
   }
 }
 
-MODULE_FUNCTION void omni_emit_log_hook(ErrorData *edata) {
-  iterate_hooks(omni_hook_emit_log, edata);
-}
+MODULE_FUNCTION void omni_emit_log_hook(ErrorData *edata) { iterate_hooks(emit_log, edata); }

--- a/extensions/omni/init.c
+++ b/extensions/omni/init.c
@@ -82,17 +82,20 @@ void _PG_init() {
 
   RegisterXactCallback(omni_xact_callback_hook, NULL);
 
-  void *default_hooks[__OMNI_HOOK_TYPE_COUNT] = {
-      [omni_hook_needs_fmgr] = saved_hooks[omni_hook_needs_fmgr] ? default_needs_fmgr : NULL,
-      [omni_hook_executor_start] = default_executor_start,
-      [omni_hook_executor_run] = default_executor_run,
-      [omni_hook_executor_finish] = default_executor_finish,
-      [omni_hook_executor_end] = default_executor_end,
-      [omni_hook_process_utility] = default_process_utility,
-      [omni_hook_emit_log] = saved_hooks[omni_hook_emit_log] ? default_emit_log : NULL,
-      [omni_hook_check_password] =
-          saved_hooks[omni_hook_check_password] ? default_check_password_hook : NULL,
-      [omni_hook_xact_callback] = NULL,
+  omni_hook_fn default_hooks[__OMNI_HOOK_TYPE_COUNT] = {
+      [omni_hook_needs_fmgr] = {.needs_fmgr =
+                                    saved_hooks[omni_hook_needs_fmgr] ? default_needs_fmgr : NULL},
+      [omni_hook_executor_start] = {.executor_start = default_executor_start},
+      [omni_hook_executor_run] = {.executor_run = default_executor_run},
+      [omni_hook_executor_finish] = {.executor_finish = default_executor_finish},
+      [omni_hook_executor_end] = {.executor_end = default_executor_end},
+      [omni_hook_process_utility] = {.process_utility = default_process_utility},
+      [omni_hook_emit_log] = {.emit_log =
+                                  saved_hooks[omni_hook_emit_log] ? default_emit_log : NULL},
+      [omni_hook_check_password] = {.check_password = saved_hooks[omni_hook_check_password]
+                                                          ? default_check_password_hook
+                                                          : NULL},
+      [omni_hook_xact_callback] = {.xact_callback = NULL},
       NULL};
 
   {
@@ -102,7 +105,7 @@ void _PG_init() {
     for (int type = 0; type < __OMNI_HOOK_TYPE_COUNT; type++) {
       // It is important to use palloc0 here to ensure the first recors in the hook array are
       // calling the original hooks (if present)
-      if (default_hooks[type] != NULL) {
+      if (default_hooks[type].ptr != NULL) {
         hook_entry_point *entry;
         entry = hook_entry_points.entry_points[type] =
             palloc0(sizeof(*hook_entry_points.entry_points[type]));

--- a/extensions/omni/omni.c
+++ b/extensions/omni/omni.c
@@ -497,7 +497,7 @@ static void register_hook(const omni_handle *handle, omni_hook *hook) {
            sizeof(*hook_entry_points.entry_points[hook->type]) * initial_count);
 
     entry_point->handle = handle;
-    entry_point->fn = hook->fn.ptr;
+    entry_point->fn = hook->fn;
     entry_point->name = hook->name;
     entry_point->state_index = hook_entry_points.entry_points_count[hook->type] - 1;
 
@@ -522,7 +522,7 @@ static void register_hook(const omni_handle *handle, omni_hook *hook) {
                 (hook_entry_points.entry_points_count[hook->type] - 1);
 
   entry_point->handle = handle;
-  entry_point->fn = hook->fn.ptr;
+  entry_point->fn = hook->fn;
   entry_point->name = hook->name;
   entry_point->state_index = hook_entry_points.entry_points_count[hook->type] - 1;
 }

--- a/extensions/omni/omni_common.h
+++ b/extensions/omni/omni_common.h
@@ -145,7 +145,7 @@ DECLARE_MODULE_VARIABLE(LWLockPadded *locks);
 
 typedef struct {
   const omni_handle *handle;
-  void *fn;
+  omni_hook_fn fn;
   int state_index;
   char *name;
 } hook_entry_point;
@@ -202,7 +202,7 @@ MODULE_FUNCTION void default_check_password_hook(omni_hook_handle *handle, const
                                                  PasswordType password_type, Datum validuntil_time,
                                                  bool validuntil_null);
 
-MODULE_FUNCTION bool default_needs_fmgr(omni_hook_handle *handle, Oid fn_oid);
+MODULE_FUNCTION void default_needs_fmgr(omni_hook_handle *handle, Oid fn_oid);
 
 MODULE_FUNCTION void default_executor_start(omni_hook_handle *handle, QueryDesc *queryDesc,
                                             int eflags);


### PR DESCRIPTION
This doesn't match the signature in `omni` which has no return value as we're collecting return values in the hook handle.

Solution: change it to `void`
and make it a bit harder to supply wrong signature syntactically by forcing visual alignment of the type names.