### PR TITLE
Problem: no running tests in "next" versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     # one can merge their branch to test-gh-workflows for testing changes of current workflow before merging them to master
     branches: [ "master", "test-gh-workflows" ]
   pull_request_target:
-    branches: [ "master" ]
+    branches: [ "master", "next/*" ]
   schedule:
     - cron: '33 13 * * *'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+## How to send a Pull Request
+
+Send pull requests for specific extensions to the base branches of `next/EXTENSION_NAME`. If one doesn't exist,
+please reach out to us.


### PR DESCRIPTION
Now that we're switching away from ongoing development in `master` to "next" branches to avoid leaking unreleased versions, PRs to the "next" branches aren't checked against in GitHub Actions.

Solution: enable testing of the "next" branches