### PR TITLE
Problem: Extension scripts workflow runs on non-release PRs

### DIFF
--- a/.github/workflows/ext-scripts.yml
+++ b/.github/workflows/ext-scripts.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - versions.txt
   pull_request_target:
-    branches: [ "master", "**" ]
+    branches: [ "master" ]
 
 env:
   CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules


### PR DESCRIPTION
Omnigres extensions can only be released on merge to master so running it for PRs to non master branches doesn't make sense. Any mistakes regarding releases will eventually be caught in PR to master anyways.

Solution: trigger it only on PR to master