### PR TITLE
Problem: Some omnigres extensions fail silently if omni is not shared preloaded

### DIFF
--- a/extensions/omni_httpd/tests/create_drop.yml
+++ b/extensions/omni_httpd/tests/create_drop.yml
@@ -1,8 +1,13 @@
 $schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
-instance:
-  config:
-    shared_preload_libraries: */env/OMNI_SO
-    max_worker_processes: 64
+instances:
+  default:
+    config:
+      shared_preload_libraries: */env/OMNI_SO
+      max_worker_processes: 64
+    default: true
+  no_omni:
+    config:
+      max_worker_processes: 64
 
 tests:
 
@@ -49,3 +54,10 @@ tests:
   error:
     severity: ERROR
     message: temp directory location should not be inside the data directory
+
+- name: create extension omni_httpd fails with no omni
+  instance: no_omni
+  query: create extension omni_httpd cascade
+  error:
+    severity: ERROR
+    message: extension requires omni but omni not found in shared_preload_libraries


### PR DESCRIPTION
Extensions like `omni_httpd` which depend on `libomni` fail silently if omni shared object library is not shared preloaded.

Solution: For extensions depending on `libomni` check if omni is shared preloaded in it's sql script to prevent creating the extension in first place if it's not preloaded.