### PR TITLE
Problem: omnigres docker image fails to run

### DIFF
--- a/docker/initdb-slim/001-settings.sql
+++ b/docker/initdb-slim/001-settings.sql
@@ -1,2 +1,2 @@
 alter system set max_worker_processes = 64;
-alter system set shared_preload_libraries = 'omni';
+alter system set shared_preload_libraries = 'omni--0.1.0.so';

--- a/docker/initdb/001-settings.sql
+++ b/docker/initdb/001-settings.sql
@@ -1,2 +1,2 @@
 alter system set max_worker_processes = 64;
-alter system set shared_preload_libraries = 'omni', 'plrust';
+alter system set shared_preload_libraries = 'omni--0.1.0.so', 'plrust';


### PR DESCRIPTION
Unversioned omni shared object is set in
`shared_preload_libraries` which is no
longer present.

Solution: use versioned `omni--x.y.z.so` instead

This is just a temporary fix as updating
version in sql scripts file each time new
omni version is released is not ideal.