### PR TITLE
Problem: "too many dynamic shared memory segments"

### DIFF
--- a/extensions/omni/init.c
+++ b/extensions/omni/init.c
@@ -188,6 +188,7 @@ static void shmem_hook() {
     shared_info->modules_tab = InvalidDsaPointer;
     shared_info->allocations_tab = InvalidDsaPointer;
     pg_atomic_init_flag(&shared_info->tables_initialized);
+    pg_atomic_init_flag(&shared_info->dsa_initialized);
   }
 
   LWLockRelease(AddinShmemInitLock);

--- a/extensions/omni/omni.c
+++ b/extensions/omni/omni.c
@@ -52,7 +52,7 @@ MODULE_VARIABLE(MemoryContext OmniGUCContext);
 static dsa_area *dsa = NULL;
 
 MODULE_FUNCTION dsa_area *dsa_handle_to_area(dsa_handle handle) {
-  if (handle != dsa_get_handle(dsa)) {
+  if (dsa == NULL || (dsa != NULL && handle != dsa_get_handle(dsa))) {
     if (!dsm_find_mapping(handle)) {
       // It is important to allocate DSA in the top memory context
       // so it doesn't get deallocated when the context we're in is gone
@@ -90,9 +90,11 @@ static inline void initialize_omni_modules() {
                                                .compare_function = dshash_memcmp,
                                                .tranche_id = OMNI_DSA_TRANCHE};
   MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+  LWLockAcquire(&(locks + OMNI_LOCK_MODULE)->lock, LW_EXCLUSIVE);
   if (pg_atomic_test_set_flag(&shared_info->tables_initialized)) {
     // Nobody has initialized modules table yet. And we're under an exclusive lock,
     // so we can do it
+    dsa_area *dsa = dsa_handle_to_area(shared_info->dsa);
     omni_modules = dshash_create(dsa, &module_params, NULL);
     shared_info->modules_tab = dshash_get_hash_table_handle(omni_modules);
     omni_allocations = dshash_create(dsa, &allocation_params, NULL);
@@ -105,6 +107,7 @@ static inline void initialize_omni_modules() {
     omni_allocations =
         dshash_attach(dsa_area, &allocation_params, shared_info->allocations_tab, NULL);
   }
+  LWLockRelease(&(locks + OMNI_LOCK_MODULE)->lock);
   MemoryContextSwitchTo(oldcontext);
 }
 
@@ -138,7 +141,10 @@ static bool ensure_backend_initialized(void) {
 
   LWLockRegisterTranche(OMNI_DSA_TRANCHE, "omni:dsa");
 
-  {
+  locks = GetNamedLWLockTranche("omni");
+  LWLockAcquire(&(locks + OMNI_LOCK_DSA)->lock, LW_EXCLUSIVE);
+
+  if (pg_atomic_test_set_flag(&shared_info->dsa_initialized)) {
     // It is important to allocate DSA in the top memory context
     // so it doesn't get deallocated when the context we're in is gone
     MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
@@ -146,7 +152,10 @@ static bool ensure_backend_initialized(void) {
     MemoryContextSwitchTo(oldcontext);
     dsa_pin(dsa);
     dsa_pin_mapping(dsa);
+    shared_info->dsa = dsa_get_handle(dsa);
   }
+
+  LWLockRelease(&(locks + OMNI_LOCK_DSA)->lock);
 
   {
     // Get `pg_proc` TupleDesc
@@ -154,8 +163,6 @@ static bool ensure_backend_initialized(void) {
     pg_proc_tuple_desc = RelationGetDescr(rel);
     table_close(rel, AccessShareLock);
   }
-
-  locks = GetNamedLWLockTranche("omni");
 
   {
     HASHCTL ctl = {.keysize = sizeof(dsa_handle), .entrysize = sizeof(DSAHandleEntry)};
@@ -326,6 +333,7 @@ static omni_handle_private *load_module(const char *path) {
           uint32 id = pg_atomic_add_fetch_u32(&shared_info->module_counter, 1);
 
           // If not found, prepare the handle
+          dsa_area *dsa = dsa_handle_to_area(shared_info->dsa);
           dsa_pointer ptr = dsa_allocate(dsa, sizeof(*handle));
           handle = (omni_handle_private *)dsa_get_address(dsa, ptr);
           handle->magic = *magic;
@@ -615,7 +623,8 @@ static struct dsa_ref {
   }
   if (!*found) {
     if (action == HASH_ENTER || action == HASH_ENTER_NULL) {
-      alloc->dsa_handle = dsa_get_handle(dsa);
+      alloc->dsa_handle = shared_info->dsa;
+      dsa_area *dsa = dsa_handle_to_area(shared_info->dsa);
       uint32 interrupt_holdoff = InterruptHoldoffCount;
       PG_TRY();
       { alloc->dsa_pointer = dsa_allocate(dsa, size); }
@@ -679,6 +688,7 @@ static void *find_or_allocate_shmem(const omni_handle *handle, const char *name,
                                                   find ? HASH_FIND : HASH_ENTER, found);
   if (!*found) {
     // If just searching, return NULL, otherwise return allocation
+    dsa_area *dsa = dsa_handle_to_area(shared_info->dsa);
     ptr = find ? NULL : dsa_get_address(dsa, ref.pointer);
   } else {
     ptr = dsa_get_address(dsa_handle_to_area(ref.handle), ref.pointer);

--- a/extensions/omni/omni_common.h
+++ b/extensions/omni/omni_common.h
@@ -41,6 +41,7 @@
 typedef struct {
   volatile pg_atomic_uint32 module_counter;
   pg_atomic_flag tables_initialized;
+  pg_atomic_flag dsa_initialized;
   dsa_handle dsa;
   dshash_table_handle modules_tab;
   dshash_table_handle allocations_tab;
@@ -51,6 +52,7 @@ extern omni_shared_info *shared_info;
 typedef enum {
   OMNI_LOCK_MODULE,
   OMNI_LOCK_ALLOCATION,
+  OMNI_LOCK_DSA,
   __omni_num_locks,
 } omni_locks;
 

--- a/extensions/omni/test/tests/dsa.yml
+++ b/extensions/omni/test/tests/dsa.yml
@@ -1,0 +1,2214 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 4
+  init:
+  # We create the extension here
+  - create extension omni_test
+  - create extension omni
+# This is silly, but pg_yregress is not programmable (yet)
+# so we just repeat the same thing a lot of times...name:
+# FIXME: ☝️
+tests:
+
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true
+- query: select 1
+  reset: true


### PR DESCRIPTION
This error is happening after some use of omni_httpd.

Solution: use a single DSA

The crux of the problem:

* Number of DSMs is very limited: https://github.com/postgres/postgres/blob/master/src/backend/storage/ipc/dsm.c#L195-L196
* We pin DSAs in each backend so that other backends can use memory allocated there even if those backends exit
* These numbers run out pretty fast, resulting in the error. A new connection, upon being established, creates a new DSA, therefore making us come closer to the limit.
* The problem here is that we don’t release these DSA/DSMs ever and hit the limits pretty soon as we store pointers

This is unsustainable.

Instead, we now use a single DSA initialized by the first backend and let other backends attach to it. New DSMs will still be created but at a much slower rate.