### PR TITLE
Problem: background worker failure to load old omni

### DIFF
--- a/extensions/omni/init.c
+++ b/extensions/omni/init.c
@@ -43,7 +43,9 @@ void _PG_init() {
   // We only initialize once, as a shared preloaded library.
   if (!process_shared_preload_libraries_in_progress) {
     if (!preloaded) {
-      // Issue a warning if it is not preloaded, as it won't be useful
+      // Issue an error if it is not preloaded, as it won't be functional
+      // (and may be even outright dangerous) to allow calling any function
+      // in it if it was not preloaded.
       ereport(ERROR, errmsg("omni extension has not been preloaded"),
               errhint("`shared_preload_libraries` should list `omni`"));
     }


### PR DESCRIPTION
When starting omni's own background workers when `omni` the extension is installed with a version that is not matching the version preloaded, it'll error out and everything will shut down.

Solution: issue a warning in background workers instead

This is not a [perfect] fix but rather a temporary mitigation.