### PR TITLE
Problem: docker images still sport omni 0.1.1

### DIFF
--- a/docker/initdb-slim/001-settings.sql
+++ b/docker/initdb-slim/001-settings.sql
@@ -1,2 +1,2 @@
 alter system set max_worker_processes = 64;
-alter system set shared_preload_libraries = 'omni--0.1.1.so';
+alter system set shared_preload_libraries = 'omni--0.1.2.so';

--- a/docker/initdb/001-settings.sql
+++ b/docker/initdb/001-settings.sql
@@ -1,2 +1,2 @@
 alter system set max_worker_processes = 64;
-alter system set shared_preload_libraries = 'omni--0.1.1.so', 'plrust';
+alter system set shared_preload_libraries = 'omni--0.1.2.so', 'plrust';


### PR DESCRIPTION
0.1.2, however, contains an important fix.

Solution: switch images to omni 0.1.2