### PR TITLE
Problem: eliminating bugs

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -119,6 +119,8 @@ if(NOT DEFINED PG_CONFIG)
             endif()
         endif()
 
+        set(OLD_CC $ENV{CC})
+
         # Ensure the right OpenSSL gets configured
         if(DEFINED OPENSSL_ROOT_DIR)
             set(OLD_CFLAGS "$ENV{CFLAGS}")
@@ -126,6 +128,21 @@ if(NOT DEFINED PG_CONFIG)
             set(ENV{CFLAGS} "${OLD_CFLAGS} -I ${OPENSSL_ROOT_DIR}/include")
             set(ENV{LDFLAGS} "${OLD_LDLAGS} -L ${OPENSSL_ROOT_DIR}/lib")
         endif()
+
+        if (APPLE)
+            # On macOS, sometimes a directly referenced compiler makefail to work
+            # citing the fact that it can't find the SDK (System library, etc.)
+            # This gets the SDK into the environment
+            execute_process(COMMAND xcrun --sdk macosx --show-sdk-path
+                    OUTPUT_VARIABLE _sdkroot OUTPUT_STRIP_TRAILING_WHITESPACE)
+            message(STATUS ${_sdkroot})
+            set(ENV{SDKROOT} ${_sdkroot})
+        endif ()
+        if (DEFINED CMAKE_C_COMPILER)
+            # This ensure whatever compiler we're using to compile Omnigres, we're going
+            # to use the same for Postgres
+            set(ENV{CC} "${CMAKE_C_COMPILER}")
+        endif ()
 
         if(BUILD_TYPE STREQUAL "RelWithDebInfo")
             string(APPEND extra_configure_args " --enable-debug")
@@ -138,6 +155,8 @@ if(NOT DEFINED PG_CONFIG)
             set(ENV{CFLAGS} "$ENV{CFLAGS} ${CMAKE_C_FLAGS_RELWITHDEBINFO}")
         elseif(BUILD_TYPE STREQUAL "Release")
             set(ENV{CFLAGS} "$ENV{CFLAGS} ${CMAKE_C_FLAGS_RELEASE}")
+        elseif(BUILD_TYPE STREQUAL "Debug")
+            set(ENV{CFLAGS} "$ENV{CFLAGS} ${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer")
         endif()
 
         execute_process(
@@ -193,6 +212,8 @@ if(NOT DEFINED PG_CONFIG)
             set(ENV{CFLAGS} "${OLD_CFLAGS}")
             set(ENV{LDFLAGS} "${OLD_LDLAGS}")
         endif()
+
+        set(ENV{CC} "${OLD_CC}")
 
     endif()
 

--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -217,6 +217,11 @@ function(add_postgresql_extension NAME)
         target_compile_definitions(${_ext_TARGET} PUBLIC "EXT_SCHEMA=\"${_ext_SCHEMA}\"")
     endif()
 
+    if(DEFINED _ext_SOURCES)
+        target_compile_options(${_ext_TARGET} PRIVATE -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer)
+        target_link_options(${_ext_TARGET} BEFORE PUBLIC -fsanitize=undefined PUBLIC -fsanitize=address)
+    endif()
+
     set(_link_flags "${PostgreSQL_SHARED_LINK_OPTIONS}")
 
     foreach(_dir ${PostgreSQL_SERVER_LIBRARY_DIRS})

--- a/pg_yregress/test.c
+++ b/pg_yregress/test.c
@@ -312,7 +312,11 @@ proceed:
         fy_node_mapping_append(test->node, error_key, fy_node_create_scalar(doc, STRLIT("true")));
       } else {
         // Otherwise, specify the error
-        char *errmsg = strdup(PQresultErrorField(result, PG_DIAG_MESSAGE_PRIMARY));
+        char *err = PQresultErrorField(result, PG_DIAG_MESSAGE_PRIMARY);
+        char *errmsg = NULL;
+        if (err != NULL) {
+          errmsg = strdup(err);
+        }
         trim_trailing_whitespace(errmsg);
 
         struct fy_node *error = fy_node_create_scalar(doc, STRLIT(errmsg));
@@ -322,7 +326,11 @@ proceed:
         if (fy_node_is_scalar(existing_error)) {
           fy_node_mapping_append(test->node, error_key, error);
         } else {
-          char *severity = strdup(PQresultErrorField(result, PG_DIAG_SEVERITY));
+          char *sev = PQresultErrorField(result, PG_DIAG_SEVERITY);
+          char *severity = NULL;
+          if (sev != NULL) {
+            severity = strdup(sev);
+          }
           struct fy_node *error_severity = fy_node_create_scalar(doc, STRLIT(severity));
 
           struct fy_node *error_node = fy_node_create_mapping(doc);


### PR DESCRIPTION
Some bugs are not immediately observable. Often not until they exhibit themselves in production.

Solution: start using sanitizers in Debug builds

This will help us observing some of the issues earlier.

Initially, let's enable UBSan and ASan and observe how well will this work.

In order for this to happen, Postgres has to be recompiled with new flags.

Caveat for macOS: leak detector is not enabled with Apple's Clang. However, one can use Homebrew's clang (from the `llvm` package) to enable it:

```
cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang  -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++
```