### PR TITLE
Problem: Omni doesn't have support for planner hook

### DIFF
--- a/extensions/omni/hook_types.h
+++ b/extensions/omni/hook_types.h
@@ -7,4 +7,5 @@ char *omni_hook_types[__OMNI_HOOK_TYPE_COUNT] = {[omni_hook_executor_start] = "e
                                                  [omni_hook_emit_log] = "emit_hook",
                                                  [omni_hook_check_password] = "check_password",
                                                  [omni_hook_xact_callback] = "xact_callback",
+                                                 [omni_hook_planner] = "planner",
                                                  0};

--- a/extensions/omni/init.c
+++ b/extensions/omni/init.c
@@ -7,6 +7,7 @@
 #include <executor/executor.h>
 #include <lib/dshash.h>
 #include <miscadmin.h>
+#include <optimizer/planner.h>
 #include <storage/ipc.h>
 #include <storage/lwlock.h>
 #include <storage/shmem.h>
@@ -73,6 +74,7 @@ void _PG_init() {
   OLD = omni_##NAME##_hook
 
   save_hook(needs_fmgr, needs_fmgr_hook);
+  save_hook(planner, planner_hook);
   save_hook(executor_start, ExecutorStart_hook);
   save_hook(executor_run, ExecutorRun_hook);
   save_hook(executor_finish, ExecutorFinish_hook);
@@ -87,6 +89,7 @@ void _PG_init() {
   omni_hook_fn default_hooks[__OMNI_HOOK_TYPE_COUNT] = {
       [omni_hook_needs_fmgr] = {.needs_fmgr =
                                     saved_hooks[omni_hook_needs_fmgr] ? default_needs_fmgr : NULL},
+      [omni_hook_planner] = {.planner = default_planner},
       [omni_hook_executor_start] = {.executor_start = default_executor_start},
       [omni_hook_executor_run] = {.executor_run = default_executor_run},
       [omni_hook_executor_finish] = {.executor_finish = default_executor_finish},

--- a/extensions/omni/omni_common.h
+++ b/extensions/omni/omni_common.h
@@ -173,6 +173,9 @@ MODULE_FUNCTION void omni_check_password_hook(const char *username, const char *
 
 MODULE_FUNCTION void omni_executor_start_hook(QueryDesc *queryDesc, int eflags);
 
+MODULE_FUNCTION PlannedStmt *omni_planner_hook(Query *parse, const char *query_string,
+                                               int cursorOptions, ParamListInfo boundParams);
+
 MODULE_FUNCTION void omni_executor_run_hook(QueryDesc *queryDesc, ScanDirection direction,
                                             uint64 count, bool execute_once);
 
@@ -205,6 +208,10 @@ MODULE_FUNCTION void default_check_password_hook(omni_hook_handle *handle, const
                                                  bool validuntil_null);
 
 MODULE_FUNCTION void default_needs_fmgr(omni_hook_handle *handle, Oid fn_oid);
+
+MODULE_FUNCTION void default_planner(omni_hook_handle *handle, Query *parse,
+                                     const char *query_string, int cursorOptions,
+                                     ParamListInfo boundParams);
 
 MODULE_FUNCTION void default_executor_start(omni_hook_handle *handle, QueryDesc *queryDesc,
                                             int eflags);

--- a/extensions/omni/test/hooks.c
+++ b/extensions/omni/test/hooks.c
@@ -14,6 +14,11 @@ void xact_callback(omni_hook_handle *handle, XactEvent event) {
   hook_called[omni_hook_xact_callback] = true;
 }
 
+void planner_hook_fn(omni_hook_handle *handle, Query *parse, const char *query_string,
+                     int cursorOptions, ParamListInfo boundParams) {
+  hook_called[omni_hook_planner] = true;
+}
+
 #include "../hook_types.h"
 
 PG_FUNCTION_INFO_V1(was_hook_called);

--- a/extensions/omni/test/hooks.h
+++ b/extensions/omni/test/hooks.h
@@ -7,5 +7,6 @@
 // clang-format on
 
 void xact_callback(omni_hook_handle *handle, XactEvent event);
-
+void planner_hook_fn(omni_hook_handle *handle, Query *parse, const char *query_string,
+                     int cursorOptions, ParamListInfo boundParams);
 #endif // TEST_HOOKS_H

--- a/extensions/omni/test/omni_test.c
+++ b/extensions/omni/test/omni_test.c
@@ -136,6 +136,10 @@ void _Omni_init(const omni_handle *handle) {
                                   .fn = {.xact_callback = xact_callback}};
   handle->register_hook(handle, &xact_callback_hook);
 
+  omni_hook planner_hook = {
+      .name = "planner_hook", .type = omni_hook_planner, .fn = {.planner = planner_hook_fn}};
+  handle->register_hook(handle, &planner_hook);
+
   bool found;
 
   char *dbname = get_database_name(MyDatabaseId);

--- a/extensions/omni/test/tests/hooks_coverage.yml
+++ b/extensions/omni/test/tests/hooks_coverage.yml
@@ -11,3 +11,8 @@ tests:
   query: select omni_test.was_hook_called('xact_callback') as result
   results:
   - result: true
+
+- name: planner_hook
+  query: select omni_test.was_hook_called('planner') as result
+  results:
+  - result: true

--- a/omni/omni/omni_v0.h
+++ b/omni/omni/omni_v0.h
@@ -198,6 +198,9 @@ typedef void (*omni_hook_check_password_t)(omni_hook_handle *handle, const char 
                                            Datum validuntil_time, bool validuntil_null);
 
 typedef void (*omni_hook_needs_fmgr_t)(omni_hook_handle *handle, Oid fn_oid);
+typedef void (*omni_hook_planner_t)(omni_hook_handle *handle, Query *parse,
+                                    const char *query_string, int cursorOptions,
+                                    ParamListInfo boundParams);
 typedef void (*omni_hook_executor_start_t)(omni_hook_handle *handle, QueryDesc *queryDesc,
                                            int eflags);
 typedef void (*omni_hook_executor_run_t)(omni_hook_handle *handle, QueryDesc *queryDesc,
@@ -216,6 +219,7 @@ typedef union {
   omni_hook_emit_log_t emit_log;
   omni_hook_check_password_t check_password;
   omni_hook_needs_fmgr_t needs_fmgr;
+  omni_hook_planner_t planner;
   omni_hook_executor_start_t executor_start;
   omni_hook_executor_run_t executor_run;
   omni_hook_executor_finish_t executor_finish;


### PR DESCRIPTION
Solution: Add support for planner hook with test included.

I merged my fork with the latest and realized the PR needs to go to `next/omni` branch. Figured a better git workflow. Hence, closing the previous PR https://github.com/omnigres/omnigres/pull/527.