### PR TITLE
Problem: h2o_fatal calls abort() by default and cannot be overridden

### DIFF
--- a/cmake/FindH2O.cmake
+++ b/cmake/FindH2O.cmake
@@ -6,6 +6,6 @@ list(APPEND _h2o_options "WITH_MRUBY OFF")
 list(APPEND _h2o_options "DISABLE_LIBUV ON")
 
 cmake_policy(SET CMP0042 NEW)
-CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG 579135a VERSION 2.3.0-579135a OPTIONS "${_h2o_options}")
+CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG cd94190 VERSION 2.3.0-cd94190 OPTIONS "${_h2o_options}")
 set_property(TARGET libh2o PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET libh2o-evloop PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/extensions/omni_httpc/omni_httpc.c
+++ b/extensions/omni_httpc/omni_httpc.c
@@ -180,7 +180,7 @@ static void init() {
       ereport(ERROR, errmsg("failed to bind bind UDP socket"));
     }
     h2o_socket_t *sock = h2o_evloop_socket_create(ctx.loop, fd, H2O_SOCKET_FLAG_DONT_READ);
-    h2o_quic_init_context(&h3ctx.h3, ctx.loop, sock, &h3ctx.quic, NULL,
+    h2o_quic_init_context(&h3ctx.h3, ctx.loop, sock, &h3ctx.quic, NULL, NULL,
                           h2o_httpclient_http3_notify_connection_update, 1, NULL);
   }
 


### PR DESCRIPTION
Solution: h2o newly supports overriding the h2o_fatal error handler by expanding to a function pointer call. Update the h2o version so that omnigres can take advantage of this recent change.

Also update the `h2o_quic_init_context` call in omni_httpc, whose prototype was recently changed to include a new argument, whose value in omnigres is now NULL (#211)

I'm not sure if this PR is a solution to #211, since it does not itself overload the `h2o_fatal` handler, it only makes it possible. This is because the comments of #211 are ambivalent on what the overload should do.