### PR TITLE
Problem: omni_httpd worker sporadically stops listening

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - TBD
+
+### Fixed
+
+* When multiple listeners are present, some listeners may have become
+  unresponsive. [#545](https://github.com/omnigres/omnigres/pull/545)
+
 ## [0.1.1] - 2023-03-22
 
 ### Changed
@@ -20,3 +27,5 @@ Initial release following a few months of iterative development.
 [0.1.0]: [https://github.com/omnigres/omnigres/pull/511]
 
 [0.1.1]: [https://github.com/omnigres/omnigres/pull/522]
+
+[0.1.2]: [https://github.com/omnigres/omnigres/pull/544]

--- a/extensions/omni_httpd/event_loop.c
+++ b/extensions/omni_httpd/event_loop.c
@@ -22,6 +22,13 @@ pthread_cond_t event_loop_resume_cond_ack = PTHREAD_COND_INITIALIZER;
 h2o_multithread_receiver_t event_loop_receiver;
 h2o_multithread_queue_t *event_loop_queue;
 
+// Defines cset_socket
+#define i_val h2o_socket_t *
+#define i_tag socket
+#include <stc/cset.h>
+
+cset_socket paused_listeners;
+
 static size_t requests_in_flight = 0;
 
 typedef enum { MSG_KIND_SEND, MSG_KIND_ABORT, MSG_KIND_PROXY } send_message_kind;
@@ -42,9 +49,6 @@ typedef struct {
     } proxy;
   } payload;
 } send_message_t;
-
-// Implemented in from http_worker.c
-h2o_socket_t *get_server_socket_from_req(h2o_req_t *req);
 
 static void h2o_queue_send(request_message_t *msg, h2o_iovec_t *bufs, size_t bufcnt,
                            h2o_send_state_t state) {
@@ -148,7 +152,10 @@ static void on_message(h2o_multithread_receiver_t *receiver, h2o_linklist_t *mes
     send_message_t *send_msg = (send_message_t *)messages->next;
     request_message_t *reqmsg = send_msg->reqmsg;
     pthread_mutex_lock(&reqmsg->mutex);
-    requests_in_flight--;
+    if (--requests_in_flight == 0) {
+      c_FOREACH(it, cset_socket, paused_listeners) { h2o_socket_read_start(*it.ref, on_accept); }
+      cset_socket_clear(&paused_listeners);
+    }
 
     if (reqmsg->req == NULL) {
       // Connection is gone, bail
@@ -207,6 +214,8 @@ void *event_loop(void *arg) {
   assert(handler_queue != NULL);
   assert(event_loop_queue != NULL);
 
+  paused_listeners = cset_socket_init();
+
   bool running = atomic_load(&worker_running);
   bool reload = atomic_load(&worker_reload);
 
@@ -230,6 +239,16 @@ void *event_loop(void *arg) {
         ;
     }
 
+    {
+      // Ensure we don't have any paused listeners as listeners may be changed upon reload
+      // and sockets may be deallocated. It would be extremely unsafe to do it later as these
+      // records may be gone.
+      // The idea is that if they'll be resumed now, if the system is still busy, they'll
+      // get stopped again.
+      c_FOREACH(it, cset_socket, paused_listeners) { h2o_socket_read_start(*it.ref, on_accept); }
+      cset_socket_clear(&paused_listeners);
+    }
+
     // Make sure request handler no longer waits
     pthread_mutex_lock(&event_loop_mutex);
     event_loop_resumed = false;
@@ -244,6 +263,8 @@ void on_accept(h2o_socket_t *listener, const char *err) {
   if (requests_in_flight > 0) {
     // Don't accept new connections if this instance is busy as we'd likely
     // have to proxy it (or put in the queue if it is not HTTP/2+)
+    h2o_socket_read_stop(listener);
+    cset_socket_push(&paused_listeners, listener);
     return;
   }
   h2o_socket_t *sock;
@@ -294,9 +315,6 @@ int event_loop_req_handler(h2o_handler_t *self, h2o_req_t *req) {
   request_message_t *msg = malloc(sizeof(*msg));
   msg->super = (h2o_multithread_message_t){{NULL}};
   msg->req = req;
-  if (req != NULL) {
-    msg->server_socket = get_server_socket_from_req(req);
-  }
   pthread_mutex_init(&msg->mutex, NULL);
 
   // Track request deallocation

--- a/extensions/omni_httpd/event_loop.c
+++ b/extensions/omni_httpd/event_loop.c
@@ -244,7 +244,6 @@ void on_accept(h2o_socket_t *listener, const char *err) {
   if (requests_in_flight > 0) {
     // Don't accept new connections if this instance is busy as we'd likely
     // have to proxy it (or put in the queue if it is not HTTP/2+)
-    h2o_socket_read_start(listener, NULL);
     return;
   }
   h2o_socket_t *sock;
@@ -265,9 +264,6 @@ void req_dispose(void *ptr) {
   request_message_t **message_ptr = (request_message_t **)ptr;
   request_message_t *message = *message_ptr;
   pthread_mutex_lock(&message->mutex);
-  if (requests_in_flight == 0 && message->server_socket != NULL) {
-    h2o_socket_read_start(message->server_socket, on_accept);
-  }
 
   message->req = NULL;
   pthread_mutex_unlock(&message->mutex);

--- a/extensions/omni_httpd/event_loop.h
+++ b/extensions/omni_httpd/event_loop.h
@@ -62,7 +62,6 @@ typedef struct {
   h2o_multithread_message_t super;
   h2o_req_t *req;
   pthread_mutex_t mutex;
-  h2o_socket_t *server_socket; /*< server socket */
 } request_message_t;
 
 /**

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -909,8 +909,3 @@ release:
 
   return 0;
 }
-
-h2o_socket_t *get_server_socket_from_req(h2o_req_t *req) {
-  listener_ctx *lctx = H2O_STRUCT_FROM_MEMBER(listener_ctx, context, req->conn->ctx);
-  return lctx->socket;
-}


### PR DESCRIPTION
This is manifesting in scenarios like recursive HTTP calls (HTTP handler calling back into the same instance of omni_httpd) and having omni_httpd not receive an opportunity to accept an incoming connection.

Solution: fix a bug in socket read resumption
    
Previously, what we attempted in ae72953f406d8716741f0c24f08b0e51321ca20a was subtly (and critically)
wrong. Specifically, we were trying to resume reading from a socket that was holding the worker busy. 

However, that's not the socket that needs resumption, as we actually need to resume all other sockets that
were, in fact, stopped.
