### PR TITLE
Problem: omni_httpd may crash in SIGUSR2 handler

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -7,6 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.1.3] - TBD
 
+### Fixed
+
+* omni_httpd may crash under certain circumstances during early
+  startup [#551](https://github.com/omnigres/omnigres/pull/551)
+
 ## [0.1.2] - 2023-04-07
 
 ### Fixed
@@ -31,3 +36,5 @@ Initial release following a few months of iterative development.
 [0.1.1]: [https://github.com/omnigres/omnigres/pull/522]
 
 [0.1.2]: [https://github.com/omnigres/omnigres/pull/544]
+
+[0.1.3]: [https://github.com/omnigres/omnigres/pull/550]

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -116,12 +116,12 @@ void http_worker(Datum db_oid) {
   atomic_store(&worker_running, true);
   atomic_store(&worker_reload, true);
 
+  // We call this before we unblock the signals as necessitated by the implementation
   setup_server();
 
   // Block signals except for SIGUSR2 and SIGTERM
   pqsignal(SIGUSR2, sigusr2); // used to reload configuration
   pqsignal(SIGTERM, sigterm); // used to terminate the worker
-  BackgroundWorkerUnblockSignals();
 
   // Start thread that will be servicing `worker_event_loop` and handling all
   // communication with the outside world. Current thread will be responsible for
@@ -129,8 +129,12 @@ void http_worker(Datum db_oid) {
   pthread_t event_loop_thread;
   event_loop_suspended = true;
 
-  event_loop_register_receiver(); // This MUST happen before starting event_loop
+  // This MUST happen before starting event_loop
+  // AND before unblocking signals as signals use this receiver
+  event_loop_register_receiver();
   pthread_create(&event_loop_thread, NULL, event_loop, NULL);
+
+  BackgroundWorkerUnblockSignals();
 
   // Connect worker to the database
   BackgroundWorkerInitializeConnectionByOid(db_oid, InvalidOid, 0);
@@ -561,6 +565,7 @@ static h2o_pathconf_t *register_handler(h2o_hostconf_t *hostconf, const char *pa
   return pathconf;
 }
 
+// This must happen BEFORE signals are unblocked because of handler_receiver setup
 static void setup_server() {
   h2o_hostconf_t *hostconf;
 
@@ -575,6 +580,8 @@ static void setup_server() {
   // Set up event loop for request handler loop
   handler_event_loop = h2o_evloop_create();
   handler_queue = h2o_multithread_create_queue(handler_event_loop);
+
+  // This must happen BEFORE signals are unblocked
   h2o_multithread_register_receiver(handler_queue, &handler_receiver, on_message);
 
   h2o_pathconf_t *pathconf = register_handler(hostconf, "/", event_loop_req_handler);


### PR DESCRIPTION
```
* thread #1, name = 'postgres', stop reason = signal SIGSEGV
  * frame #0: 0x00007f5b5609ae94 libc.so.6`___pthread_mutex_lock(mutex=0x0000000000000010) at pthread_mutex_lock.c:80:23
    frame #1: 0x00007f5b4bf4800e omni_httpd--0.1.2.so`h2o_multithread_send_message(receiver=0x00007f5b4c516320, message=0x0000000000000000) at multithread.c:196:5
    frame #2: 0x00007f5b4bf40038 omni_httpd--0.1.2.so`sigusr2 at http_worker.c:85:3
```

Solution: ensure unblocking signals after the setup

Originally, we unblocked signals before `event_loop_thread` was set up and given an early SIGUSR2, it would fail to work correctly.

Thanks to @rmodpur for discovering the issue