### PR TITLE
Problem: iterating over parsed SQL statements

### DIFF
--- a/extensions/omni_sql/CHANGELOG.md
+++ b/extensions/omni_sql/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - TBD
+
+### Added
+
+* Raw statement parser that preserves statement syntax and
+  location [#554](https://github.com/omnigres/omnigres/pull/554)
+
+## [0.1.0] - 2023-03-05
+
+Initial release following a few months of iterative development.
+
+[Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_sql
+
+[0.1.0]: [https://github.com/omnigres/omnigres/pull/511]
+
+[0.2.0]: [https://github.com/omnigres/omnigres/pull/553]
+

--- a/extensions/omni_sql/migrate/3_raw_statement.sql
+++ b/extensions/omni_sql/migrate/3_raw_statement.sql
@@ -1,0 +1,12 @@
+create type raw_statement as
+(
+    source text,
+    line   int,
+    col    int
+);
+
+create function raw_statements(cstring) returns setof raw_statement
+as
+'MODULE_PATHNAME'
+    language c strict
+               immutable;

--- a/extensions/omni_sql/omni_sql.c
+++ b/extensions/omni_sql/omni_sql.c
@@ -7,6 +7,7 @@
 #include <postgres.h>
 #include <fmgr.h>
 // clang-format on
+#include <miscadmin.h>
 
 #include "omni_sql.h"
 
@@ -93,4 +94,85 @@ Datum is_valid(PG_FUNCTION_ARGS) {
   List *stmts = omni_sql_parse_statement(string);
 
   PG_RETURN_BOOL(omni_sql_is_valid(stmts, NULL));
+}
+
+PG_FUNCTION_INFO_V1(raw_statements);
+
+static inline void find_line_col(char *str, int offset, int *line, int *col) {
+  *line = 1;
+  *col = 1;
+
+  for (int i = 0; i < offset; i++) {
+    if (str[i] == '\0') {
+      return;
+    }
+    if (str[i] == '\n') {
+      (*line)++;
+      *col = 1;
+    } else {
+      (*col)++;
+    }
+  }
+}
+
+static inline int find_non_whitespace(char *str) {
+  int offset = 0;
+
+  while (str[offset]) {
+    if (!isspace((unsigned char)str[offset])) {
+      return offset;
+    }
+    offset++;
+  }
+
+  // If only whitespace, use it as is (but this shouldn't happen, there's no statement!)
+  return 0;
+}
+
+Datum raw_statements(PG_FUNCTION_ARGS) {
+  if (PG_ARGISNULL(0)) {
+    ereport(ERROR, errmsg("statements can't be NULL"));
+  }
+
+  ReturnSetInfo *rsinfo = (ReturnSetInfo *)fcinfo->resultinfo;
+  rsinfo->returnMode = SFRM_Materialize;
+
+  MemoryContext per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
+  MemoryContext oldcontext = MemoryContextSwitchTo(per_query_ctx);
+
+  Tuplestorestate *tupstore = tuplestore_begin_heap(false, false, work_mem);
+  rsinfo->setResult = tupstore;
+
+  char *statement = PG_GETARG_CSTRING(0);
+
+  List *stmts = omni_sql_parse_statement(statement);
+
+  ListCell *lc;
+  foreach (lc, stmts) {
+    switch (nodeTag(lfirst(lc))) {
+    case T_RawStmt: {
+      RawStmt *raw_stmt = lfirst_node(RawStmt, lc);
+      int line, col;
+      int actual_start = find_non_whitespace(statement + raw_stmt->stmt_location);
+      find_line_col(statement, raw_stmt->stmt_location + actual_start, &line, &col);
+      Datum values[3] = {
+          PointerGetDatum(
+              raw_stmt->stmt_len == 0
+                  ? cstring_to_text(statement + raw_stmt->stmt_location + actual_start)
+                  : cstring_to_text_with_len(statement + raw_stmt->stmt_location + actual_start,
+                                             raw_stmt->stmt_len)),
+          Int32GetDatum(line), Int32GetDatum(col)};
+      bool isnull[3] = {false, false, false};
+      tuplestore_putvalues(tupstore, rsinfo->expectedDesc, values, isnull);
+      break;
+    }
+    default:
+      break;
+    }
+  };
+
+  tuplestore_donestoring(tupstore);
+
+  MemoryContextSwitchTo(oldcontext);
+  PG_RETURN_NULL();
 }

--- a/extensions/omni_sql/tests/omni_sql/raw_statements.yml
+++ b/extensions/omni_sql/tests/omni_sql/raw_statements.yml
@@ -1,0 +1,27 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_sql cascade
+
+tests:
+
+- query: select *
+         from omni_sql.raw_statements('')
+  results: [ ]
+
+- query: select *
+         from omni_sql.raw_statements('Select True')
+  results:
+  - source: Select True
+    line: 1
+    col: 1
+
+- query: select *
+         from omni_sql.raw_statements(E'Select True;\n select 1')
+  results:
+  - source: Select True
+    line: 1
+    col: 1
+  - source: select 1
+    line: 2
+    col: 2 # intentional


### PR DESCRIPTION
Basically, if we try to use `omni_sql.statement` to parse a multiple statement expression (`select 1; select 2`) we end up with de-parsed multiple statement expression we can't split.

This prevents us from splitting source files into individual statements.

Solution: introduce "raw statement" parsing

A raw statement is the original source of the statement with its location in the original string (line and col, as offsets are not practically useful).

Using `raw_statements` function one can split a string into multiple statements, while retaining their original formatting and location.

Now, for any further processing, the obtain source can be converted into a `omni_sql.statement`.