### PR TITLE
Problem: omni_httpd crashes if a desired role is not available

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -10,7 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * omni_httpd may crash under certain circumstances during early
-  startup [#551](https://github.com/omnigres/omnigres/pull/551)
+  startup [#551](https://github.com/omnigres/omnigres/pull/551), [#556](https://github.com/omnigres/omnigres/pull/556)
 
 ## [0.1.2] - 2023-04-07
 

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -355,8 +355,8 @@ void http_worker(Datum db_oid) {
               Form_pg_authid rform = (Form_pg_authid)GETSTRUCT(roleTup);
               role_id = rform->oid;
               role_superuser = rform->rolsuper;
+              ReleaseSysCache(roleTup);
             }
-            ReleaseSysCache(roleTup);
           }
 
           const cvec_fd_fd_value *fd = cvec_fd_fd_at(&fds, index);


### PR DESCRIPTION
```
* thread #1, name = 'postgres', stop reason = signal SIGSEGV
  * frame #0: 0x000062280afab8c2 postgres`ReleaseCatCache(tuple=0x0000000000000000) at catcache.c:1461:2
    frame #1: 0x000062280afc9253 postgres`ReleaseSysCache(tuple=0x0000000000000000) at syscache.c:868:2
    frame #2: 0x00007f9d14b40b7f omni_httpd--0.1.2.so`http_worker(db_oid=16610) at http_worker.c:359:25
    frame #3: 0x000062280ad04375 postgres`StartBackgroundWorker at bgworker.c:861:2
```

Solution: avoid releasing the cache if role's tuple is invalid