### PR TITLE
Problem: deleted omni_vfs local_fs mount

### DIFF
--- a/extensions/omni_vfs/local_fs.c
+++ b/extensions/omni_vfs/local_fs.c
@@ -127,6 +127,10 @@ static char *get_mount_path(Datum fs_id) {
   if (rc != SPI_OK_SELECT) {
     ereport(ERROR, errmsg("fetching mount failed"), errdetail("%s", SPI_result_code_string(rc)));
   }
+  if (SPI_tuptable->numvals == 0) {
+    ereport(ERROR, errmsg("fetching mount failed"),
+            errdetail("missing information in omni_vfs.local_fs_mounts"));
+  }
 
   TupleDesc tupdesc = SPI_tuptable->tupdesc;
   HeapTuple tuple = SPI_tuptable->vals[0];

--- a/extensions/omni_vfs/tests/deleted.yml
+++ b/extensions/omni_vfs/tests/deleted.yml
@@ -1,0 +1,27 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_vfs cascade
+
+# This particular test is a regression test that ensure if between obtaining the `local_fs`
+# and using it, the record of it is gone, we don't crash and properly error out
+
+tests:
+
+- name: create a local filesystem
+  # We save it so we can avoid recreating it to test this regression
+  query: create table fs_info as (select omni_vfs.local_fs('.') as fs)
+  commit: true
+
+- name: destroy the backend information
+  query: delete
+         from omni_vfs.local_fs_mounts
+  commit: true
+
+- name: try accessing the filesystem
+  query: select *
+         from omni_vfs.list((select fs from fs_info), '.')
+  error:
+    severity: ERROR
+    message: fetching mount failed
+    detail: missing information in omni_vfs.local_fs_mounts

--- a/extensions/omni_vfs/tests/local_fs.yml
+++ b/extensions/omni_vfs/tests/local_fs.yml
@@ -22,6 +22,8 @@ tests:
     select * from omni_vfs.list(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), '')
     order by name
   results:
+  - name: deleted.yml
+    kind: file
   - name: empty
     kind: dir
   - name: local_fs.yml
@@ -46,6 +48,8 @@ tests:
     select * from omni_vfs.list_recursively(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), '.')
     order by name
   results:
+  - name: deleted.yml
+    kind: file
   - name: empty
     kind: dir
   - name: empty/.keepme


### PR DESCRIPTION
When local_fs information is deleted from `local_fs_mounts`, omni_vfs would crash. This is not great!

Solution: ensure it checks if there's at least one record and error out otherwise.

Most likely, the original code was built on assumption that there's always going to be a value available in this table because it will always be preceded by `omni_vfs.local_fs()` function call. But that's actually not true.

Kudos to @rmodpur for spotting this.