### PR TITLE
Problem: missing version PR link in omni_sql changelog

### DIFF
--- a/extensions/omni_sql/CHANGELOG.md
+++ b/extensions/omni_sql/CHANGELOG.md
@@ -30,3 +30,5 @@ Initial release following a few months of iterative development.
 
 [0.2.0]: [https://github.com/omnigres/omnigres/pull/553]
 
+[0.2.1]: [https://github.com/omnigres/omnigres/pull/561]
+


### PR DESCRIPTION
This makes it harder to track where 0.2.1 arrived.

Solution: add the link to the changelog