### PR TITLE
Problem: omni module might get loaded more than once

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -11,6 +11,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Planner hook support [#537](https://github.com/omnigres/omnigres/pull/537)
 
+### Fixed
+
+* In some cases, extension modules might be loaded more than once [#563](https://github.com/omnigres/omnigres/pull/563)
+
 ## [0.1.2] - 2023-03-23
 
 ### Fixed

--- a/extensions/omni/test/tests/tests.yml
+++ b/extensions/omni/test/tests/tests.yml
@@ -14,6 +14,13 @@ tests:
   results:
   - is_backend_initialized: true
 
+- name: omni is loaded once
+  query: select count(*)
+         from omni.modules
+         where path like '%/omni--%'
+  results:
+  - count: 1
+
 - name: module is automatically registered
   query: select
              count(*)


### PR DESCRIPTION
Solution: make sure path key always has trailing zeroes for the hash function to return the same result.

Multiple loading happened because in some cases the trailing data past NUL was arbitrary but the hash table always hashes keys up to PATH_MAX.