### PR TITLE
Problem: sometimes omni module may not get unloaded

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -13,7 +13,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-* In some cases, extension modules might be loaded more than once [#563](https://github.com/omnigres/omnigres/pull/563)
+* In some cases, extension modules might be loaded more than once [#563](https://github.com/omnigres/omnigres/pull/563),
+  or fail to unload [#564](https://github.com/omnigres/omnigres/pull/564)
 
 ## [0.1.2] - 2023-03-23
 

--- a/extensions/omni/omni.c
+++ b/extensions/omni/omni.c
@@ -1017,7 +1017,9 @@ void request_bgworker_termination(const omni_handle *handle, omni_bgworker_handl
 MODULE_FUNCTION void unload_module(omni_handle_private *phandle, bool missing_ok) {
   LWLockAcquire(&(locks + OMNI_LOCK_MODULE)->lock, LW_EXCLUSIVE);
   bool found = false;
-  ModuleEntry *module = (ModuleEntry *)dshash_find_or_insert(omni_modules, phandle->path, &found);
+  char path[PATH_MAX] = {0};
+  memcpy(path, phandle->path, strlen(phandle->path));
+  ModuleEntry *module = (ModuleEntry *)dshash_find_or_insert(omni_modules, path, &found);
   if (!found) {
     LWLockRelease(&(locks + OMNI_LOCK_MODULE)->lock);
     if (!missing_ok) {


### PR DESCRIPTION
Solution: ensure to use a key that is hashed stably

Similarly to d84378ee08f75f77b0760117145c9cfbbbe1b974, we may be using an unstably hashed key.