### PR TITLE
Problem: schema_diff rules are ambiguous

### DIFF
--- a/extensions/omni_schema/td/README.md
+++ b/extensions/omni_schema/td/README.md
@@ -1,0 +1,25 @@
+# Technical Decisions
+
+The documents in this folder serve as a reference for important technical decisions made in the design and
+implementation of schema diff feature of omni_schema.
+
+Code and tests are highly encouraged to refer to particular technical decisions.
+
+Technical decisions are identified by their unique codes and are never retired from the list for the reasons of tracking
+past decisions. If a new decision overrides an old one, both have to be cross-linked. They can be renamed but the
+identifier code should not change.
+
+Technical decisions can also be withdrawn (but not removed for historical reasons) if they are found to be incorrect,
+ineffective, or counter-effective.
+
+Any explanation for how the schema diff behaves should be traceable to these decisions.
+
+## SDR: Schema Diff Rules
+
+Rules that govern schema diff feature of omni_schema.
+
+| TD                         | Description                     |
+|----------------------------|---------------------------------|
+| [SDR_0001.md](SDR_0001.md) | Create/Delete table             |
+| [SDR_0002.md](SDR_0002.md) | Create/Delete column in a table |
+| [SDR_0003.md](SDR_0003.md) | Change in column attribute      |

--- a/extensions/omni_schema/td/SDR_0001.md
+++ b/extensions/omni_schema/td/SDR_0001.md
@@ -1,0 +1,49 @@
+# Create and delete table
+
+## Create table
+
+Create a table if it's missing in old schema but present in new one.
+
+```postgresql
+-- old schema
+
+-- new schema
+create table t
+(
+    i int
+);
+```
+
+## Delete table
+
+Delete a table if it's missing in new schema but present in old one.
+
+```postgresql
+-- old schema
+create table t
+(
+    i int
+);
+
+-- new schema
+```
+
+## Ambiguity
+
+Can't differentiate between rename of a table and create/delete of table. The following
+will be interpreted as delete of `t1` and create of `t2` according to the above rules but the intention may be to rename
+the table from `t1` to `t2`.
+
+```postgresql
+-- old schema
+create table t1
+(
+    i int
+);
+
+-- new schema
+create table t2
+(
+    i int
+);
+```

--- a/extensions/omni_schema/td/SDR_0002.md
+++ b/extensions/omni_schema/td/SDR_0002.md
@@ -1,0 +1,67 @@
+# Create/Delete column in a table
+
+## Create a column
+
+Create a column in the table if a new schema has an additional column
+compared to old one.
+
+```postgresql
+-- old version
+create table t
+(
+    i int
+);
+
+-- new version
+create table t
+(
+    i int,
+    j int
+);
+```
+
+## Delete a column
+
+Delete a column if old schema has an additional column compared to
+new one.
+
+```postgresql
+-- old version
+create table t
+(
+    i int,
+    j int
+);
+
+-- new version
+create table t
+(
+    i int
+);
+```
+
+## Ambiguity
+
+Create and delete of a column is straightforward if it's the last
+column of the table.
+
+But doing it somewhere in the middle of a table is ambiguous with rename of a column.
+The following could mean rename of `j` to `k` and add a new column `j` or adding a new
+column `k` between `i` and `j`.
+
+```postgresql
+-- old version
+create table t
+(
+    i int,
+    j int
+);
+
+-- new version
+create table t
+(
+    i int,
+    k int,
+    j int
+);
+```

--- a/extensions/omni_schema/td/SDR_0003.md
+++ b/extensions/omni_schema/td/SDR_0003.md
@@ -1,0 +1,43 @@
+# Change in column attribute
+
+If the number of columns is same in both old and new schema, match the columns
+by their ordinal position to detect any changes in their attributes (name, type, default values, constraints, etc).
+
+The following changes the name of column `i` and type of column `j`
+
+```postgresql
+-- old version
+create table t
+(
+    i int,
+    j int
+);
+
+-- new version
+create table t
+(
+    k int,
+    j bigint
+);
+```
+
+## Ambiguity
+
+The following is detected as rename of columns `i` and `j` to `j` and `i` respectively but it could also be
+interpreted as changing the order of columns within a table.
+
+```postgresql
+-- old version
+create table t
+(
+    i int,
+    j int
+);
+
+-- new version
+create table t
+(
+    j int,
+    i int
+);
+```


### PR DESCRIPTION
Given two schemas old and new, there are multiple
ways to reach new schema from old each implying a
different intent.

Solution: Create technical descriptions for the
rules to document the intention behind each rule.