### PR TITLE
Problem: building docker images fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG DEBIAN_VER_PG=bookworm
 # Build parallelism
 ARG BUILD_PARALLEL_LEVEL
 # plrust version
-ARG PLRUST_VERSION=1.2.6
+ARG PLRUST_VERSION=1.2.8
 
 # Base builder image
 FROM debian:${DEBIAN_VER}-slim AS builder
@@ -74,7 +74,7 @@ RUN . "$HOME/.cargo/env" && \
 WORKDIR /var/lib/postgresql
 RUN git clone https://github.com/tcdi/plrust.git plrust && cd plrust && git checkout v${PLRUST_VERSION}
 RUN . "$HOME/.cargo/env" && cd plrust/plrustc && ./build.sh && mv ../build/bin/plrustc ~/.cargo/bin && cd ..
-RUN . "$HOME/.cargo/env" && cd plrust/plrust && cargo install cargo-pgrx --locked
+RUN . "$HOME/.cargo/env" && cd plrust/plrust && cargo install cargo-pgrx --version 0.11.0 --locked
 USER root
 RUN PG_VER=${PG%.*} && apt-get install -y postgresql-server-dev-${PG_VER}
 RUN chown -R postgres /usr/share/postgresql /usr/lib/postgresql


### PR DESCRIPTION
```
error: failed to compile `cargo-pgrx v0.11.4`, intermediate artifacts can be found at `/tmp/cargo-installpit9R4`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
package `clap v4.5.4` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.72.0
```

Solution: pin `cargo-pgrx` version to one that works on Rust 1.72

https://github.com/tcdi/plrust/issues/410

Upgrade plrust to 1.2.8 while at it.