### PR TITLE
Problem: differences between minor Postgres versions

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -10,6 +10,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 * Additional metadata information in `omni.modules`  [#574](https://github.com/omnigres/omnigres/pull/574)
+* Warn if omni-enabled module has been built against a different major/minor version of Postgres.
+  Differences between minor versions may present subtle
+  incompatibilities. [#573](https://github.com/omnigres/omnigres/pull/573)
 
 ## [0.1.3] - 2023-04-16
 

--- a/extensions/omni/init.c
+++ b/extensions/omni/init.c
@@ -34,6 +34,8 @@ void procoid_syscache_callback(Datum arg, int cacheid, uint32 hashvalue) {
 
 extern void deinitialize_backend(int code, Datum arg);
 
+MODULE_VARIABLE(int ServerVersionNum);
+
 /**
  * Shared preload initialization.
  */
@@ -156,6 +158,14 @@ void _PG_init() {
 
   xact_oneshot_callbacks = NIL;
   after_xact_oneshot_callbacks = NIL;
+
+  ServerVersionNum = pg_strtoint32(GetConfigOption("server_version_num", false, false));
+
+  if (ServerVersionNum != PG_VERSION_NUM) {
+    ereport(WARNING, errmsg("omni has been compiled against %d.%d, but running on %d.%d",
+                            PG_VERSION_NUM / 10000, PG_VERSION_NUM % 100, ServerVersionNum / 10000,
+                            ServerVersionNum % 100));
+  }
 }
 
 /**

--- a/extensions/omni/omni.c
+++ b/extensions/omni/omni.c
@@ -550,6 +550,14 @@ MODULE_FUNCTION void load_pending_modules() {
               }
             }
 
+            // Check the target Postgres version
+            if (handle->magic.revision >= 7 && handle->magic.pg_version != ServerVersionNum) {
+              ereport(WARNING,
+                      errmsg("omni has been compiled against %d.%d, but running on %d.%d",
+                             handle->magic.pg_version / 10000, handle->magic.pg_version % 100,
+                             ServerVersionNum / 10000, ServerVersionNum % 100));
+            }
+
             void (*init_fn)(const omni_handle *) = dlsym(dlhandle, "_Omni_init");
             if (init_fn != NULL) {
               init_fn(&handle->handle);

--- a/extensions/omni/omni_common.h
+++ b/extensions/omni/omni_common.h
@@ -271,4 +271,6 @@ struct xact_oneshot_callback {
 DECLARE_MODULE_VARIABLE(List *xact_oneshot_callbacks);
 DECLARE_MODULE_VARIABLE(List *after_xact_oneshot_callbacks);
 
+DECLARE_MODULE_VARIABLE(int32 ServerVersionNum);
+
 #endif // OMNI_COMMON_H

--- a/omni/omni/omni_v0.h
+++ b/omni/omni/omni_v0.h
@@ -55,12 +55,13 @@ typedef struct {
   uint16_t version; // interface version
   uint8_t revision; // version's backward compatible revision (number, but shown as letter 'A','B'
                     // to distinguish for Major.Minor. Version 0 allows for breaking revisions.
+  uint32_t pg_version; // Postgres version it is compiled against
 } omni_magic;
 
 StaticAssertDecl(sizeof(omni_magic) <= UINT16_MAX, "omni_magic should fit into 16 bits");
 
 #define OMNI_INTERFACE_VERSION 0
-#define OMNI_INTERFACE_REVISION 6
+#define OMNI_INTERFACE_REVISION 7
 
 typedef struct omni_handle omni_handle;
 
@@ -93,7 +94,8 @@ void _Omni_deinit(const omni_handle *handle);
 #define OMNI_MAGIC                                                                                 \
   static omni_magic __Omni_magic = {.size = sizeof(omni_magic),                                    \
                                     .version = OMNI_INTERFACE_VERSION,                             \
-                                    .revision = OMNI_INTERFACE_REVISION};                          \
+                                    .revision = OMNI_INTERFACE_REVISION,                           \
+                                    .pg_version = PG_VERSION_NUM};                                 \
   omni_magic *_Omni_magic() {                                                                      \
     if (_omni_module_information.name == NULL) {                                                   \
       ereport(WARNING, errmsg("missing module name"));                                             \


### PR DESCRIPTION
Most of the time, extensions compiled for one minor version should work on another, but that's not universally true. There are some changes between different minor versions that may make the extensions behave incorrectly or (potentially) cause an abnormality.

Solution: make `omni` module loader issue warnings when it encounters extensions compiled for a different version of Postgres.

There's an important implication of this change: we need to change how we ship the builds of our extensions. We should probably run tests against all minor revisions, too.