### PR TITLE
Problem: sporadic failure of redirect test in omni_httpc

### DIFF
--- a/extensions/omni_httpc/CHANGELOG.md
+++ b/extensions/omni_httpc/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.1.1] - TBD
 
+# Fixed
+
+* Fixed sporadic failures in tests [#579](https://github.com/omnigres/omnigres/pull/579)
+
 ## [0.1.0] - 2023-03-05
 
 Initial release following a few months of iterative development.

--- a/extensions/omni_httpc/tests/redirect.yml
+++ b/extensions/omni_httpc/tests/redirect.yml
@@ -7,7 +7,7 @@ instance:
     - set session omni_httpd.init_port = 0
     - create extension omni_httpd cascade
     - create extension omni_httpc cascade
-    - call omni_httpd.wait_for_configuration_reloads(1)
+    - call omni_httpd.wait_for_configuration_reloads(2)
     - |
       update omni_httpd.handlers
       set query = $$


### PR DESCRIPTION
Solution: ensure it's clearing the reconfiguration correctly

This is not perfect, as it is obscure and undocumented knowledge, but this is how it works right now.

The installation of extensions generates two configuration changes, and we need to clear those before we can ensure the last useful configuration change is made before we test it.