### PR TITLE
Problem: segfault during omni_httpd.handlers update

### DIFF
--- a/extensions/omni_sql/CHANGELOG.md
+++ b/extensions/omni_sql/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - TBD
+
+### Fixed
+
+* Query validation might not work in presence of a post_parse_analyze hook
+  [#582](https://github.com/omnigres/omnigres/pull/582)
+
 ## [0.2.1] - 2024-04-14
 
 ### Fixed

--- a/extensions/omni_sql/tests/omni_sql/post_parse_analyze_hook.yml
+++ b/extensions/omni_sql/tests/omni_sql/post_parse_analyze_hook.yml
@@ -1,0 +1,18 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    # This introduces a post_parse_analyze hook
+    shared_preload_libraries: pg_stat_statements
+  init:
+  # For reproducing the bug
+  - create extension omni_httpd cascade
+
+tests:
+
+- name: try induce the bug
+  query: |
+    update omni_httpd.handlers
+    set query = $sql$
+    WITH plaintext AS (SELECT omni_httpd.http_response('Hello, World!', headers := ARRAY[omni_http.http_header('date', to_char(now(), 'Dy, DD Mon YYYY HH24:MI:SS OF'))]) FROM request WHERE request.path = '/plaintext') SELECT * FROM plaintext
+    $sql$
+  commit: true


### PR DESCRIPTION
This happens with `pg_stat_statements` is loaded:

```
TRAP: failed Assert("len_to_wrt >= 0"), File: "pg_stat_statements.c", Line: 2708, PID: 15393
0   postgres                            0x0000000100f370f4 ExceptionalCondition + 236
1   pg_stat_statements.dylib            0x0000000101532234 generate_normalized_query + 328
2   pg_stat_statements.dylib            0x0000000101531950 pgss_store + 440
3   pg_stat_statements.dylib            0x000000010152db18 pgss_post_parse_analyze + 484
4   postgres                            0x0000000100829fa4 parse_analyze_fixedparams + 256
5   omni_httpd--0.1.2.so                0x000000010bda22d4 omni_sql_is_valid + 408
6   omni_httpd--0.1.2.so                0x000000010bc6d884 handlers_query_validity_trigger + 512
7   postgres                            0x000000010097cb5c ExecCallTriggerFunc + 700
8   postgres                            0x0000000100984a44 AfterTriggerExecute + 2052
9   postgres                            0x000000010098185c afterTriggerInvokeEvents + 1068
10  postgres                            0x0000000100981eec AfterTriggerFireDeferred + 220
11  postgres                            0x0000000100785a58 CommitTransaction + 320
12  postgres                            0x0000000100785410 CommitTransactionCommand + 212
13  postgres                            0x0000000100cf668c finish_xact_command + 32
14  postgres                            0x0000000100cf41a8 exec_simple_query + 1536
15  postgres                            0x0000000100cf3228 PostgresMain + 2448
16  postgres                            0x0000000100be6ae4 report_fork_failure_to_client + 0
17  postgres                            0x0000000100be3dec BackendStartup + 520
18  postgres                            0x0000000100be10c8 ServerLoop + 432
19  postgres                            0x0000000100bdfc2c PostmasterMain + 6564
20  postgres                            0x0000000100a695ac startup_hacks + 0
21  dyld                                0x0000000191bd60e0 start + 2360
```

Solution: ensure we don't call hooks during query validation

This prevents pg_stat_statements from being invoked – but I still don't have a good idea why exactly does it fail.

The test case capturing the bug as observed but it hasn't been reduced to a minimally reproducing case.

Ultimately, this is a bandaid fix. Can we do better?