### PR TITLE
Problem: using `pg_proc` to detect extensions

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -13,6 +13,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Warn if omni-enabled module has been built against a different major/minor version of Postgres.
   Differences between minor versions may present subtle
   incompatibilities. [#573](https://github.com/omnigres/omnigres/pull/573)
+* Support for function-less native extensions [#586](https://github.com/omnigres/omnigres/pull/586)
 
 ## [0.1.4] - 2023-06-28
 

--- a/extensions/omni/hook_harness.c
+++ b/extensions/omni/hook_harness.c
@@ -233,6 +233,12 @@ static void on_xact_dealloc(void *arg) {
 MODULE_FUNCTION void omni_xact_callback_hook(XactEvent event, void *arg) {
   iterate_hooks(xact_callback, event);
 
+  // In the event of a rollback, ensure we review the list of extensions
+  // as we may have created an extension during a transaction and it may be gone now.
+  if (event == XACT_EVENT_ABORT) {
+    backend_force_reload = true;
+  }
+
   // Hard-coded single-shot hooks
   // TODO: these are a bit of a hack and we should find ways to get rid of them
 

--- a/extensions/omni/init.c
+++ b/extensions/omni/init.c
@@ -28,10 +28,6 @@ static shmem_startup_hook_type saved_shmem_startup_hook;
 static void shmem_request();
 static void shmem_hook();
 
-void procoid_syscache_callback(Datum arg, int cacheid, uint32 hashvalue) {
-  backend_force_reload = true;
-}
-
 extern void deinitialize_backend(int code, Datum arg);
 
 MODULE_VARIABLE(int ServerVersionNum);
@@ -146,10 +142,6 @@ void _PG_init() {
     RegisterBackgroundWorker(&master_worker);
   }
 
-  // This function may result in a FATAL error if we hit the limit of
-  // syscache callbacks (`MAX_SYSCACHE_CALLBACKS`, 64). However, since we're in
-  // postmaster: 1) it is okay to crash here 2) it is much less likely to happen at this time.
-  CacheRegisterSyscacheCallback(PROCOID, procoid_syscache_callback, Int8GetDatum(0));
   backend_force_reload = true;
 
   OmniGUCContext = AllocSetContextCreate(TopMemoryContext, "omni:guc", ALLOCSET_DEFAULT_SIZES);

--- a/extensions/omni/omni.c
+++ b/extensions/omni/omni.c
@@ -4,6 +4,7 @@
 // clang-format on
 #include <access/heapam.h>
 #include <access/table.h>
+#include <catalog/pg_extension.h>
 #include <catalog/pg_language.h>
 #include <catalog/pg_proc.h>
 #include <commands/user.h>
@@ -43,6 +44,7 @@ MODULE_VARIABLE(omni_handle_private *module_handles);
 MODULE_VARIABLE(LWLockPadded *locks);
 
 static TupleDesc pg_proc_tuple_desc;
+static TupleDesc pg_extension_tuple_desc;
 MODULE_VARIABLE(List *initialized_modules);
 
 MODULE_VARIABLE(int OMNI_DSA_TRANCHE);
@@ -162,6 +164,13 @@ static bool ensure_backend_initialized(void) {
     // Get `pg_proc` TupleDesc
     Relation rel = table_open(ProcedureRelationId, AccessShareLock);
     pg_proc_tuple_desc = RelationGetDescr(rel);
+    table_close(rel, AccessShareLock);
+  }
+
+  {
+    // Get `pg_extension` TupleDesc
+    Relation rel = table_open(ExtensionRelationId, AccessShareLock);
+    pg_extension_tuple_desc = RelationGetDescr(rel);
     table_close(rel, AccessShareLock);
   }
 
@@ -433,35 +442,37 @@ static omni_handle_private *load_module(const char *path,
   return result;
 }
 
-static List *consider_probin(HeapTuple tp) {
-  Form_pg_proc proc = (Form_pg_proc)GETSTRUCT(tp);
+static List *consider_ext(HeapTuple tp) {
+  Form_pg_extension ext = (Form_pg_extension)GETSTRUCT(tp);
   List *loaded = NIL;
-  if (proc->prolang == ClanguageId) {
-    // If it is a module implemented in C, we can start looking into whether this is an Omni module
-    bool isnull;
-    Datum probin = heap_getattr(tp, Anum_pg_proc_probin, pg_proc_tuple_desc, &isnull);
-    if (!isnull) {
-      char *path = substitute_libpath_macro(text_to_cstring(DatumGetTextPP(probin)));
-      char key[PATH_MAX] = {0};
-      strcpy(key, path);
-      pfree(path);
+  bool isnull;
+  Datum extver_datum =
+      heap_getattr(tp, Anum_pg_extension_extversion, pg_extension_tuple_desc, &isnull);
+  if (!isnull) {
+    char *extver = text_to_cstring(DatumGetTextPP(extver_datum));
+    char *pathname = get_extension_module_pathname(NameStr(ext->extname), extver);
+    if (pathname == NULL) {
+      return loaded;
+    }
+    char *path = substitute_libpath_macro(pathname);
+    char key[PATH_MAX] = {0};
+    strcpy(key, path);
+    pfree(path);
 
-      bool warning_on_omni_mismatch = true;
+    bool warning_on_omni_mismatch = true;
+    // If the tuple is added in current transaction, if the version is mismatched, it should
+    // be an error, otherwise, a warning.
+    //
+    // Otherwise, it is impossible to successfully load previously-installed version to proceed
+    // further to upgrade to the correct version.
+    if (TransactionIdIsValid(GetCurrentTransactionIdIfAny()) &&
+        TransactionIdEquals(HeapTupleHeaderGetXmin(tp->t_data), GetCurrentTransactionIdIfAny())) {
+      warning_on_omni_mismatch = false;
+    }
 
-      // If the tuple is added in current transaction, if the version is mismatched, it should
-      // be an error, otherwise, a warning.
-      //
-      // Otherwise, it is impossible to successfully load previously-installed version to proceed
-      // further to upgrade to the correct version.
-      if (TransactionIdIsValid(GetCurrentTransactionIdIfAny()) &&
-          TransactionIdEquals(HeapTupleHeaderGetXmin(tp->t_data), GetCurrentTransactionIdIfAny())) {
-        warning_on_omni_mismatch = false;
-      }
-
-      omni_handle_private *handle = load_module(key, warning_on_omni_mismatch);
-      if (handle != NULL) {
-        loaded = list_append_unique_ptr(loaded, handle);
-      }
+    omni_handle_private *handle = load_module(key, warning_on_omni_mismatch);
+    if (handle != NULL) {
+      loaded = list_append_unique_ptr(loaded, handle);
     }
   }
   return loaded;
@@ -471,22 +482,25 @@ MODULE_FUNCTION void load_pending_modules() {
   if (!ensure_backend_initialized()) {
     return;
   }
-
   if (IsTransactionState() && backend_force_reload) {
     backend_force_reload = false;
-    Relation rel = table_open(ProcedureRelationId, RowExclusiveLock);
-    TableScanDesc scan = table_beginscan_catalog(rel, 0, NULL);
     List *loaded_modules = NIL;
-    for (;;) {
-      HeapTuple tup = heap_getnext(scan, ForwardScanDirection);
-      if (tup == NULL)
-        break;
-      loaded_modules = list_concat_unique_ptr(loaded_modules, consider_probin(tup));
+
+    {
+      // Consider pg_extension
+      Relation rel = table_open(ExtensionRelationId, RowExclusiveLock);
+      TableScanDesc scan = table_beginscan_catalog(rel, 0, NULL);
+      for (;;) {
+        HeapTuple tup = heap_getnext(scan, ForwardScanDirection);
+        if (tup == NULL)
+          break;
+        loaded_modules = list_concat_unique_ptr(loaded_modules, consider_ext(tup));
+      }
+      if (scan->rs_rd->rd_tableam->scan_end) {
+        scan->rs_rd->rd_tableam->scan_end(scan);
+      }
+      table_close(rel, RowExclusiveLock);
     }
-    if (scan->rs_rd->rd_tableam->scan_end) {
-      scan->rs_rd->rd_tableam->scan_end(scan);
-    }
-    table_close(rel, RowExclusiveLock);
 
     static omni_handle_private *self = NULL;
     {

--- a/extensions/omni/omni_common.h
+++ b/extensions/omni/omni_common.h
@@ -273,4 +273,5 @@ DECLARE_MODULE_VARIABLE(List *after_xact_oneshot_callbacks);
 
 DECLARE_MODULE_VARIABLE(int32 ServerVersionNum);
 
+MODULE_FUNCTION char *get_extension_module_pathname(const char *name, const char *version);
 #endif // OMNI_COMMON_H

--- a/extensions/omni/test/CMakeLists.txt
+++ b/extensions/omni/test/CMakeLists.txt
@@ -35,7 +35,18 @@ add_postgresql_extension(
         TESTS OFF)
 
 
+add_postgresql_extension(
+        no_fun
+        SCHEMA omni_test
+        PRIVATE ON
+        RELOCATABLE false
+        SOURCES no_fun.c
+        TESTS_REQUIRE omni
+        VERSION 1)
+
+
 target_link_libraries(omni_test libomni)
 target_link_libraries(omni_test_v2 libomni)
+target_link_libraries(no_fun libomni)
 
 #add_dependencies(omni_test omni)

--- a/extensions/omni/test/no_fun.c
+++ b/extensions/omni/test/no_fun.c
@@ -1,0 +1,33 @@
+#include <limits.h>
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+#include <commands/dbcommands.h>
+#include <executor/spi.h>
+#include <miscadmin.h>
+#include <storage/latch.h>
+#include <storage/lwlock.h>
+#include <utils/builtins.h>
+#if PG_MAJORVERSION_NUM >= 14
+#include <utils/wait_event.h>
+#else
+#include <pgstat.h>
+#endif
+
+#include <omni/omni_v0.h>
+
+#include "hooks.h"
+
+PG_MODULE_MAGIC;
+OMNI_MAGIC;
+
+OMNI_MODULE_INFO(.name = "no_fun", .version = EXT_VERSION,
+                 .identity = "18d79a47-d48d-489d-b7d5-c414a9ccb0d1");
+
+void _Omni_init(const omni_handle *handle) {
+  SPI_connect();
+  SPI_execute("create table if not exists public.no_fun ()", false, 0);
+  SPI_finish();
+}

--- a/extensions/omni/test/tests/no_fun/test.yml
+++ b/extensions/omni/test/tests/no_fun/test.yml
@@ -1,0 +1,14 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+  init:
+  # We create the extension here
+  - create extension no_fun
+
+tests:
+
+- name: _Omni_init() gets called
+  query: select *
+         from no_fun
+  results: [ ]


### PR DESCRIPTION
We detect extensions through references of C-language functions in `pg_proc`.

This generally works for extensions that expose some functions, but doesn't work for those that just do some work on initialization (background worker startup, etc.)

Solution: switch to `pg_extension` to detect extensions directly

One potential downside of this approach is that we won't support extensions with more than one shared object.
