### PR TITLE
Problem: omni_httpd looping infinitely

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -12,6 +12,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * omni_httpd may crash under certain circumstances during early
   startup [#551](https://github.com/omnigres/omnigres/pull/551), [#556](https://github.com/omnigres/omnigres/pull/556)
 
+* omni_httpd master and its workers loop infinitely when postgres `max_worker_processes` is less than `omni_httpd.http_workers`.
+  [#587](https://github.com/omnigres/omnigres/pull/587).
+
 ## [0.1.2] - 2024-04-07
 
 ### Fixed

--- a/extensions/omni_httpd/docs/intro.md
+++ b/extensions/omni_httpd/docs/intro.md
@@ -154,6 +154,6 @@ from
 
 `omni_httpd` can be configured with the following PostgreSQL configuration variables:
 
-* `omni_httpd.http_workers` to configure the number of http workers, defaults to number of cpus
+* `omni_httpd.http_workers` to configure the number of http workers. It defaults to the number of cpus and adjusts if this is higher than what [max_worker_processes](https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-MAX-WORKER-PROCESSES) allows.
 * `omni_httpd.temp_dir` to set the temporary directory for `omni_httpd` files like unix domain sockets, defaults
   to `/tmp`

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -166,6 +166,11 @@ void _Omni_init(const omni_handle *handle) {
 #ifdef _SC_NPROCESSORS_ONLN
   default_num_http_workers = sysconf(_SC_NPROCESSORS_ONLN);
 #endif
+  // considering the omni_httpd master worker and the "omni startup" worker used by omni TODO:
+  // revisit once omni_workers is set.
+  int threshold = max_worker_processes - 2;
+  if (default_num_http_workers > threshold)
+    default_num_http_workers = threshold;
 
   omni_guc_variable guc_num_http_workers = {
       .name = "omni_httpd.http_workers",

--- a/extensions/omni_httpd/tests/limited_max_workers.yml
+++ b/extensions/omni_httpd/tests/limited_max_workers.yml
@@ -1,0 +1,23 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 3
+  init:
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - call omni_httpd.wait_for_configuration_reloads(2);
+
+tests:
+- name: should respond successfully
+  query: |
+    select
+      status,
+      error
+    from
+      omni_httpc.http_execute(
+        omni_httpc.http_request('http://127.0.0.1:' || (select effective_port from omni_httpd.listeners) || '/')
+      );
+  results:
+    - status: 200
+      error: null


### PR DESCRIPTION
omni_httpd master and its workers loop infinitely when postgres `max_worker_processes` is 8 (the default).

This happens because:

- `omni_httpd.http_workers` defaults to the number of cores (16 in this case).
- The `RegisterDynamicBackgroundWorker` call fails because there are no background worker slots available (limited by `max_worker_processes`).
- The httpd master gets stuck busy-waiting for all workers to start their loops [1].
- The workers get stuck retrying the EAGAIN result of their socket [2].

Solution: handle the failed `RegisterDynamicBackgroundWorker` result.

This function returns false when the background worker can't start.

[1]: https://github.com/omnigres/omnigres/blob/9c2bcc6c9aa804a6b7e209a02d218449342aa1a7/extensions/omni_httpd/master_worker.c#L523
[2]: https://github.com/omnigres/omnigres/blob/9c2bcc6c9aa804a6b7e209a02d218449342aa1a7/extensions/omni_httpd/http_worker.c#L626