### PR TITLE
Problem: using other extensions in `make psql_EXT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ To build and run Omnigres, you would need:
 ```shell
 cmake -S . -B build
 cmake --build build --parallel
-make psql_<COMPONENT_NAME> # for example, `psql_omni_containers`
+make -j psql_<COMPONENT_NAME> # for example, `psql_omni_containers`
 ```
 
 ### Troubleshooting

--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -583,7 +583,7 @@ ${PG_CTL} stop -D  \"$PSQLDB\" -m smart
         add_custom_target(psql_${_ext_TARGET}
                 WORKING_DIRECTORY "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/.."
                 COMMAND ${CMAKE_CURRENT_BINARY_DIR}/psql_${_ext_TARGET})
-        add_dependencies(psql_${_ext_TARGET} ${_ext_TARGET} omni)
+        add_dependencies(psql_${_ext_TARGET} ${_ext_TARGET} prepare omni)
     endif()
 
     if(PG_REGRESS)


### PR DESCRIPTION
For example, in a a new environment, `make psql_omni_httpd` won't bring other extensions, requiring `make psql_omni_other_ext`.

Solution: prepare all extensions when using one

This is a bit slower, so now `make -j psql_EXT` is recommended.