### PR TITLE
Problem: cmake TARGET libh2o is unused

### DIFF
--- a/cmake/FindH2O.cmake
+++ b/cmake/FindH2O.cmake
@@ -7,5 +7,4 @@ list(APPEND _h2o_options "DISABLE_LIBUV ON")
 
 cmake_policy(SET CMP0042 NEW)
 CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG 579135a VERSION 2.3.0-579135a OPTIONS "${_h2o_options}")
-set_property(TARGET libh2o PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET libh2o-evloop PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Using DISABLE_LIBUV as done on `cmake/FindH2O.cmake`:

```
list(APPEND _h2o_options "DISABLE_LIBUV ON")
```

Will not produce the libh2o library according to:

- https://github.com/h2o/h2o/blob/16b13eee8ad7895b4fe3fcbcabee53bd52782562/CMakeLists.txt#L728-L730
- https://github.com/h2o/h2o/blob/16b13eee8ad7895b4fe3fcbcabee53bd52782562/CMakeLists.txt#L814-L816

Solution: remove the libh2o TARGET