### PR TITLE
Problem: impossible to establish presence of omni

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Differences between minor versions may present subtle
   incompatibilities. [#573](https://github.com/omnigres/omnigres/pull/573)
 * Support for function-less native extensions [#586](https://github.com/omnigres/omnigres/pull/586)
+* `omni_is_present()` to detect if omni has been preloaded [#605](https://github.com/omnigres/omnigres/pull/605)
 
 ## [0.1.4] - 2023-06-28
 

--- a/extensions/omni/init.c
+++ b/extensions/omni/init.c
@@ -36,6 +36,14 @@ MODULE_VARIABLE(int ServerVersionNum);
  * Shared preload initialization.
  */
 void _PG_init() {
+  {
+    // Establish the presence marker
+    void **rendezvous = find_rendezvous_variable("omni(loaded)");
+    static struct _omni_rendezvous_var_t rendezvous_var = {.magic = "0MNI", .version = EXT_VERSION};
+    rendezvous_var.library_path = get_omni_library_name();
+    *rendezvous = &rendezvous_var;
+  }
+
   memset(saved_hooks, 0, sizeof(saved_hooks));
   // This signifies if this library has indeed been preloaded
   static bool preloaded = false;

--- a/extensions/omni/test/migrate/1.sql
+++ b/extensions/omni/test/migrate/1.sql
@@ -108,3 +108,8 @@ create function was_hook_called(text) returns boolean
     language c
     volatile as
 'MODULE_PATHNAME';
+
+create function omni_present_test() returns boolean
+    language c
+    volatile as
+'MODULE_PATHNAME';

--- a/extensions/omni/test/omni_test.c
+++ b/extensions/omni/test/omni_test.c
@@ -27,6 +27,14 @@ OMNI_MAGIC;
 OMNI_MODULE_INFO(.name = "omni_test", .version = EXT_VERSION,
                  .identity = "ed0aaa35-54c6-426e-a69d-2c74a836053b");
 
+static bool omni_loaded = false;
+
+void _PG_init() { omni_loaded = omni_is_present(); }
+
+PG_FUNCTION_INFO_V1(omni_present_test);
+
+Datum omni_present_test(PG_FUNCTION_ARGS) { PG_RETURN_BOOL(omni_loaded); }
+
 static bool initialized = false;
 
 static char *hello_message;

--- a/extensions/omni/test/tests/tests.yml
+++ b/extensions/omni/test/tests/tests.yml
@@ -48,3 +48,8 @@ tests:
   - query: select current_setting('doesnotexist')
     error: unrecognized configuration parameter "doesnotexist"
   - select 1
+
+- name: omni_is_present
+  query: select omni_test.omni_present_test() as loaded
+  results:
+  - loaded: true

--- a/omni/omni/omni_v0.h
+++ b/omni/omni/omni_v0.h
@@ -463,4 +463,36 @@ typedef struct omni_handle {
 
 } omni_handle;
 
+/**
+ * @brief Semi-private rendezvous / informational type for omni loader
+ */
+struct _omni_rendezvous_var_t {
+  // Magic header
+  char magic[4];
+  // Version of omni
+  const char *version;
+  // Omni's dynamic shared Library file
+  const char *library_path;
+};
+
+/**
+ * @brief Detect if omni has been loaded
+ *
+ * Prior to version 0.2.0, omni's presence will not be detected this way and this function will
+ * always return false.
+ */
+static inline bool omni_is_present() {
+  void **omni = find_rendezvous_variable("omni(loaded)");
+  // If not set, it hasn't been loaded (or it is older than 0.2.0)
+  if (*omni == NULL) {
+    return false;
+  }
+  struct _omni_rendezvous_var_t *value = (struct _omni_rendezvous_var_t *)*omni;
+  // Magic has to match
+  if (strncmp(value->magic, "0MNI", sizeof(value->magic)) != 0) {
+    return false;
+  }
+  return true;
+}
+
 #endif // OMNI_H


### PR DESCRIPTION
This is problematic for some extensions because they can't detect whether omni has been preloaded in `_PG_init`, causing them to be loaded successfully even though they may not be actually operational.

This may shift the need to check whether `_Omni_init` has been called in exported functions, which is adding checks for every invocation and is error-prone (it is easy to forget to do so)

Solution: establish a "marker" that omni is loaded

This is done through a rendezvous variable. Relatively low-key way to do so and it can be then checked in extension's `_PG_init` and if omni is required for operations, it can error out.