### PR TITLE
Problem: Dockerfile still referencing 16.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.5
 
 # Version of PostgreSQL
-ARG PG=16.3
+ARG PG=16.4
 # Build type
 ARG BUILD_TYPE=RelWithDebInfo
 # User name to be used for builder


### PR DESCRIPTION
We already use 16.4 in our build system

Solution: keep it up to date