### PR TITLE
Problem: omni_httpd leaks memory on every request

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -21,7 +21,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   startup [#551](https://github.com/omnigres/omnigres/pull/551), [#556](https://github.com/omnigres/omnigres/pull/556)
 
 * omni_httpd master and its workers loop infinitely when postgres `max_worker_processes` is less than `omni_httpd.http_workers`.
-  [#587](https://github.com/omnigres/omnigres/pull/587).
+  [#587](https://github.com/omnigres/omnigres/pull/587)
+
+* omni_httpd workers leaking memory on every request [#610](https://github.com/omnigres/omnigres/pull/610)
 
 ## [0.1.2] - 2024-04-07
 


### PR DESCRIPTION
Simple observation under load proves that, and further exploration showed (on macOS, using `leaks` tool) a 96-byte leak on every request.

Solution: ensure request message structures are always freed (and their mutexes destroyed)

Current architecture is a little bit complicated, and it shows. The crux of the problem was that `request_message_t` messages are allocated using `malloc` but they were never really freed upon proper finalization of the request. We did track request deallocation but only to null it out in the message to signal that the request is gone. We are now freeing the message too, if the request has completed.

We did not attach the message to the request's pool because that would be a circular dependency (it would be gone if the request is gone)