### PR TITLE
Problem: FlyCI macOS runners shutting down next month

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,18 +28,18 @@ jobs:
     strategy:
       matrix:
         pgver: [ 16, 15, 14, 13 ]
-        os: [ warp-ubuntu-latest-x64-4x, flyci-macos-large-latest-m1 ]
+        os: [ warp-ubuntu-latest-x64-4x, warp-macos-14-arm64-6x ]
         build_type: [Debug, Release]
         exclude:
-        - os: flyci-macos-large-latest-m1
+        - os: warp-macos-14-arm64-6x
           pgver: 15
-        - os: flyci-macos-large-latest-m1
+        - os: warp-macos-14-arm64-6x
           pgver: 14
-        - os: flyci-macos-large-latest-m1
+        - os: warp-macos-14-arm64-6x
           pgver: 13
-        - os: flyci-macos-large-latest-m1
+        - os: warp-macos-14-arm64-6x
           pgver: 12
-        - os: flyci-macos-large-latest-m1
+        - os: warp-macos-14-arm64-6x
           pgver: 11
       fail-fast: false
 

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -18,7 +18,7 @@ on:
         options:
         - ubuntu-latest
         - warp-ubuntu-latest-x64-4x
-        - flyci-macos-large-latest-m1
+        - warp-macos-14-arm64-6x
         - warp-ubuntu-latest-arm64-2x
         - warp-ubuntu-latest-arm64-4x
         - macos-13

--- a/.github/workflows/ext-scripts.yml
+++ b/.github/workflows/ext-scripts.yml
@@ -26,14 +26,14 @@ jobs:
     strategy:
       matrix:
         pgver: [ 16, 15, 14, 13 ]
-        os: [ { name: ubuntu, image: warp-ubuntu-latest-x64-4x, arch: x86-64 }, { name: macos, image: flyci-macos-large-latest-m1, arch: arm } ]
+        os: [ { name: ubuntu, image: warp-ubuntu-latest-x64-4x, arch: x86-64 }, { name: macos, image: warp-macos-14-arm64-6x, arch: arm } ]
         build_type: [ Release ]
         exclude:
-          - os: { name: macos, image: flyci-macos-large-latest-m1, arch: arm }
+        - os: { name: macos, image: warp-macos-14-arm64-6x, arch: arm }
             pgver: 15
-          - os: { name: macos, image: flyci-macos-large-latest-m1, arch: arm }
+        - os: { name: macos, image: warp-macos-14-arm64-6x, arch: arm }
             pgver: 14
-          - os: { name: macos, image: flyci-macos-large-latest-m1, arch: arm }
+        - os: { name: macos, image: warp-macos-14-arm64-6x, arch: arm }
             pgver: 13
       fail-fast: false
 


### PR DESCRIPTION
See the announcement:
https://flyci.net/blohttpsg/flyci-discontinue-macos-runners

Solution: switch to WarpBuild's runners