### PR TITLE
Problem: omni_httpd handler crash on error

### DIFF
--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -855,7 +855,10 @@ static int handler(request_message_t *msg) {
 cleanup:
 
   // Ensure portal is not attached to any snapshot
-  ForgetPortalSnapshots();
+  while (ActiveSnapshotSet()) {
+    PopActiveSnapshot();
+  }
+  execution_portal->portalSnapshot = NULL;
   // Ensure we no longer have an active portal
   ActivePortal = false;
 

--- a/extensions/omni_httpd/tests/portal_cleanup.yml
+++ b/extensions/omni_httpd/tests/portal_cleanup.yml
@@ -1,0 +1,36 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 64
+  init:
+  - set session omni_httpd.no_init = true
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - create extension omni_sql
+  - call omni_httpd.wait_for_configuration_reloads(1)
+  - insert into omni_httpd.listeners (address, port)
+    values ('127.0.0.1', 0)
+  - call omni_httpd.wait_for_configuration_reloads(1)
+  - |
+    create or replace function omni_httpd.handler(int, omni_httpd.http_request) returns omni_httpd.http_outcome
+        language plpgsql as
+    $$
+    begin
+        perform omni_sql.execute(' 2');
+        return null;
+    end;
+    $$
+
+tests:
+- name: ensure it doesn't crash
+  query: |
+    with response as (select *
+                      from omni_httpc.http_execute(
+                              omni_httpc.http_request('http://127.0.0.1:' ||
+                                                      (select effective_port from omni_httpd.listeners where port = 0) ||
+                                                      '/')))
+    select response.status
+    from response
+  results:
+  - status: 500


### PR DESCRIPTION
Specifically, happens when a query is evaluated through `omni_sql.execute`:

```sql
 create or replace function omni_httpd.handler(int, omni_httpd.http_request) returns omni_httpd.http_outcome
        language plpgsql as
    $$
    begin
        perform omni_sql.execute(' 2');
        return null;
    end;
    $$
```

```
2024-08-15 17:46:43.414 PDT [52473] DETAIL:  syntax error at or near "2": (null)
2024-08-15 17:46:43.414 PDT [52473] ERROR:  portal snapshots (1) did not account for all active snapshots (3)
2024-08-15 17:46:43.415 PDT [52454] LOG:  background worker "omni_httpd worker" (PID 52473) exited with exit code 1
```

Solution: clean up snapshots and portal manually

This way, we don't get the error and it proceeds normally. We are essentially trying to replicate what `ForgetPortalSnapshots()` is doing, but I am still might be missing something.