### PR TITLE
Problem: omni_sql.execute returns wrong results on multiple statements

### DIFF
--- a/extensions/omni_sql/CHANGELOG.md
+++ b/extensions/omni_sql/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - TBD
+
+## Fixed
+
+* `execute` will now handle multiple statements correctly [#616](https://github.com/omnigres/omnigres/pull/616)
+
+## Changed
+
+* `is_returning_statement` supports multiple statements [#616](https://github.com/omnigres/omnigres/pull/616)
+
 ## [0.3.1] - 2024-08-05
 
 ### Fixed
@@ -61,4 +71,6 @@ Initial release following a few months of iterative development.
 [0.3.0]: [https://github.com/omnigres/omnigres/pull/596]
 
 [0.3.1]: [https://github.com/omnigres/omnigres/pull/601]
+
+[0.3.2]: [https://github.com/omnigres/omnigres/pull/615]
 

--- a/extensions/omni_sql/lib.c
+++ b/extensions/omni_sql/lib.c
@@ -191,26 +191,22 @@ done:
  */
 bool omni_sql_is_returning_statement(List *stmts) {
 
-  if (list_length(stmts) != 1) {
+  int len = list_length(stmts);
+  if (len == 0) {
     return false;
   }
 
-  ListCell *lc;
-  foreach (lc, stmts) {
-    Node *stmt = lfirst_node(RawStmt, lc)->stmt;
-    switch (nodeTag(stmt)) {
-    case T_SelectStmt:
-      return true;
-    case T_UpdateStmt:
-      return list_length(castNode(UpdateStmt, stmt)->returningList) > 0;
-    case T_InsertStmt:
-      return list_length(castNode(InsertStmt, stmt)->returningList) > 0;
-    case T_DeleteStmt:
-      return list_length(castNode(DeleteStmt, stmt)->returningList) > 0;
-    default:
-      return false;
-    }
+  Node *stmt = (len == 1 ? (linitial_node(RawStmt, stmts)) : (llast_node(RawStmt, stmts)))->stmt;
+  switch (nodeTag(stmt)) {
+  case T_SelectStmt:
+    return true;
+  case T_UpdateStmt:
+    return list_length(castNode(UpdateStmt, stmt)->returningList) > 0;
+  case T_InsertStmt:
+    return list_length(castNode(InsertStmt, stmt)->returningList) > 0;
+  case T_DeleteStmt:
+    return list_length(castNode(DeleteStmt, stmt)->returningList) > 0;
+  default:
+    return false;
   }
-
-  return false;
 }

--- a/extensions/omni_sql/src/execute.sql
+++ b/extensions/omni_sql/src/execute.sql
@@ -17,7 +17,7 @@ begin
             if not rec.last then
                 execute rec.stmt;
             else
-                for retrec in select omni_sql.execute_parameterized(stmt, parameters, types) val
+                for retrec in select omni_sql.execute_parameterized(rec.stmt, parameters, types) val
                     loop
                         stmt_row := to_jsonb(retrec.val);
                         return next;

--- a/extensions/omni_sql/tests/omni_sql/execute.yml
+++ b/extensions/omni_sql/tests/omni_sql/execute.yml
@@ -142,3 +142,11 @@ tests:
     results:
     - stmt_row:
         i: 1
+
+- name: multiple statements
+  query: select *
+         from omni_sql.execute('select 1 ; select 2 as b')
+  results:
+  - stmt_row:
+      b: 2
+

--- a/extensions/omni_sql/tests/omni_sql/is_returning_statement.yml
+++ b/extensions/omni_sql/tests/omni_sql/is_returning_statement.yml
@@ -32,3 +32,11 @@ tests:
 - query: select omni_sql.is_returning_statement('delete from tab returning i')
   results:
   - is_returning_statement: true
+
+- query: select omni_sql.is_returning_statement('select 1 ; select 2')
+  results:
+  - is_returning_statement: true
+
+- query: select omni_sql.is_returning_statement('select 1 ; update tab set a = 1')
+  results:
+  - is_returning_statement: false


### PR DESCRIPTION
For example:

```
select omni_sql.execute('select 1; select 2');
   execute
-------------
 {"rows": 1}
```

Solution: ensure `execute` _actually_ iterates over statements

While at it, add support for multiple statements to `is_returning_statement` for completeness.