### PR TITLE
Problem: calling SQL-language omni_httpd.handler

### DIFF
--- a/extensions/omni_httpd/tests/sql_handler.yml
+++ b/extensions/omni_httpd/tests/sql_handler.yml
@@ -1,0 +1,50 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+
+# This test was built in response to a bug where handlers that can't be atomic where crashing Postgres,
+# specifically, when calling SQL functions. They needed an active snapshot, and we didn't have one for them.
+# Let's ensure we test against this scenario.
+
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 64
+  init:
+  - set session omni_httpd.no_init = true
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - call omni_httpd.wait_for_configuration_reloads(1)
+  - insert into omni_httpd.listeners (address, port)
+    values ('127.0.0.1', 0)
+  - call omni_httpd.wait_for_configuration_reloads(1)
+  - create table if not exists test
+    (
+        val int
+    )
+  - |
+    create or replace function omni_httpd.handler(int, omni_httpd.http_request) returns omni_httpd.http_outcome
+        language sql as
+    $$
+    with insertion as (insert into test (val) values (1) returning val)
+    select omni_httpd.http_response(val::text)
+    from insertion
+    $$
+
+tests:
+- name: smoke test
+  tests:
+  - query: |
+      with response as (select *
+                        from omni_httpc.http_execute(
+                                omni_httpc.http_request('http://127.0.0.1:' ||
+                                                        (select effective_port from omni_httpd.listeners where port = 0) ||
+                                                        '/')))
+      select response.status,
+             convert_from(response.body, 'utf-8') as body
+      from response
+    results:
+    - status: 200
+      body: 1
+  - query: select *
+           from test
+    results:
+    - val: 1


### PR DESCRIPTION
If this function is defined as a SQL function, it will fail with the violation of assertion for presence of an active snapshot, as they require these.

Solution: ensure we always have a snapshot to operate in

This requires a kludge for non-atomic functions implemented in languages like PL/pgSQL if they use SPI. SPI tries to check if portals account for all active snapshots. But having no portal, they don't, resulting in this failure:

```
portal snapshots (0) did not account for all active snapshots (1)
```