### PR TITLE
Problem: failing to build Omnigres on macOS

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -280,10 +280,7 @@ if(PostgreSQL_FOUND)
         "${_pg_pkglibdir}"
         CACHE STRING "PostgreSQL package library directory")
 
-    find_program(
-            PG_BINARY postgres
-            HINTS ${_pg_bindir}
-            PATH_SUFFIXES bin)
+    set(PG_BINARY ${_pg_bindir}/postgres)
 
     if(NOT PG_BINARY)
         message(FATAL_ERROR "Could not find postgres binary")


### PR DESCRIPTION
Having this problem:

```
Undefined symbols for architecture arm64:
  "_AllocSetContextCreateInternal", referenced from:
      _switch_to_new in libpgaug_test.c.o
      _switch_back_to_old in libpgaug_test.c.o
      _switch_back_to_old_with_return_ in libpgaug_test.c.o
      _switch_when_finalizing in libpgaug_test.c.o
```

Solution: ensure to always use configured or supplied Postgres

Apparently, on macOS, cmake's find_program could pick up things like `/Applications/postgres.app/Contents/MacOS/Postgres` even when `CMAKE_FIND_APPBUNDLE` is set to `NEVER` :shrug:

So, construct the path to `postgres` manually instead.