### PR TITLE
Problem: fixed size type handling on omni_var (🚀 omni_var 0.2.1)

### DIFF
--- a/extensions/omni_var/CHANGELOG.md
+++ b/extensions/omni_var/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2024-08-19
+
+### Fixed
+
+* Fixed size types not passed by value were not handled correctly [#619](https://github.com/omnigres/omnigres/pull/619])
+
 ## [0.2.0] - 2024-07-05
 
 ### Added
@@ -20,3 +26,5 @@ Initial release following a few months of iterative development.
 [0.1.0]: [https://github.com/omnigres/omnigres/pull/511]
 
 [0.2.0]: [https://github.com/omnigres/omnigres/pull/589]
+
+[0.2.1]: [https://github.com/omnigres/omnigres/pull/619]

--- a/extensions/omni_var/tests/session_variables.yml
+++ b/extensions/omni_var/tests/session_variables.yml
@@ -131,6 +131,10 @@ tests:
     results:
     - get_session: (1,2)
 
+- name: storing and retrieving non-datum-sized variable
+  query: select omni_var.set_session('omni_session.session', gen_random_uuid())
+         from generate_series(1, 100)
+
 - name: subtransactions are not respected
   reset: true
   steps:

--- a/extensions/omni_var/tests/txn_variables.yml
+++ b/extensions/omni_var/tests/txn_variables.yml
@@ -115,6 +115,10 @@ tests:
     results:
     - get: (1,2)
 
+- name: storing and retrieving non-datum-sized variable
+  query: select omni_var.set('omni_session.session', gen_random_uuid())
+         from generate_series(1, 100)
+
 - name: subtransactions are respected
   steps:
   - select omni_var.set('test', 1)


### PR DESCRIPTION
Behavior of setting and retrieving variables of types like `uuid` is undefined: segfault, error, garbage, and normal.

Solution: ensure we handle fixed-size values correctly