### PR TITLE
Problem: `cookies` function does too much

### DIFF
--- a/extensions/omni_web/CHANGELOG.md
+++ b/extensions/omni_web/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.1] - TBD
+## [0.2.0] - TBD
+
+### Added
+
+* `cookie_get` function to retrieve a single cookie [#623](https://github.com/omnigres/omnigres/pull/623])
 
 ### Fixed
 
@@ -19,4 +23,4 @@ Initial release following a few months of iterative development.
 
 [0.1.0]: [https://github.com/omnigres/omnigres/pull/511]
 
-[0.1.1]: [https://github.com/omnigres/omnigres/pull/621]
+[0.2.0]: [https://github.com/omnigres/omnigres/pull/621]

--- a/extensions/omni_web/migrate/6_cookie_get.sql
+++ b/extensions/omni_web/migrate/6_cookie_get.sql
@@ -1,0 +1,1 @@
+/*{% include "../src/cookie_get.sql" %}*/

--- a/extensions/omni_web/src/cookie_get.sql
+++ b/extensions/omni_web/src/cookie_get.sql
@@ -1,0 +1,21 @@
+create or replace function cookie_get(cookies text, cookie_name text)
+    returns text
+    strict
+    immutable
+    language plpgsql
+as
+$$
+declare
+    cookie text;
+begin
+    foreach cookie in array string_to_array
+                            (cookies, '; '
+                            )
+        loop
+            if split_part(cookie, '=', 1) = cookie_name then
+                return split_part(cookie, '=', 2);
+            end if;
+        end loop;
+    return null;
+end;
+$$;

--- a/extensions/omni_web/tests/cookies.yml
+++ b/extensions/omni_web/tests/cookies.yml
@@ -14,3 +14,15 @@ tests:
     value: u32t4o3tb3gg43
   - name: _gat
     value: 1
+
+- name: getting a cookie by name
+  query: select omni_web.cookie_get('PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1'::text,
+                                    'csrftoken') as value;
+  results:
+  - value: u32t4o3tb3gg43
+
+- name: getting a cookie by name (null)
+  query: select omni_web.cookie_get('PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1'::text,
+                                    'crftoken') as value;
+  results:
+  - value: null


### PR DESCRIPTION
Listing all cookies is useful, and we can filter them, but often times we just need to get one cookie by name.

Solution: designate a function for that