### PR TITLE
Problem: omni_id is limited to integers

### DIFF
--- a/extensions/omni_id/CHANGELOG.md
+++ b/extensions/omni_id/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.0] - TBD
 
+### Added
+
+* Support for UUID-based IDs [#625](https://github.com/omnigres/omnigres/pull/625)
+
 ## [0.2.0] - 2024-08-04
 
 ### Changed

--- a/extensions/omni_id/docs/identity_type.md
+++ b/extensions/omni_id/docs/identity_type.md
@@ -62,13 +62,13 @@ select identity_type('user_id');
 -- user_id
 ```
 
-You can also select a different backing integer type (`smallint`, `int`) and a few sequence-related options.
+You can also select a different base integer type (`smallint`, `int`) and a few sequence-related options.
 
 |            Parameter | Type    | Description                                                                                                    |
 |---------------------:|---------|----------------------------------------------------------------------------------------------------------------|
-|               *type* | regtype | Backing type. `bigint` by default. `int` and `smallint` permitted, as well as their aliases                    |
+|               *type* | regtype | Base type. `bigint` by default. `int` and `smallint` permitted, as well as their aliases, and `uuid`           |
 |           *sequence* | text    | Sequence name. Equal to `<type>_seq` by default                                                                |
-|    *create_sequence* | boolean | Should sequence be created? True by default                                                                    |
+|    *create_sequence* | boolean | Should sequence be created? True by default. Meaningless for `uuid` base type.                                 |
 |          *increment* | bigint  | Sequence increment. Default set to 1                                                                           |
 |           *minvalue* | bigint  | Minimum value a sequence can generate. Default set to 1                                                        |
 |           *maxvalue* | bigint  | Maximum value a sequence can generate. Default set to the maximum of the underlying type                       |
@@ -77,6 +77,7 @@ You can also select a different backing integer type (`smallint`, `int`) and a f
 |        *constructor* | text    | Name of the constructor function                                                                               |
 | *create_constructor* | boolean | Should constructor be created? True by default                                                                 |
 |    *operator_schema* | boolean | Schema to create operators in. `public` by default                                                             |
+|            *nextval* | regproc | If not null, use this function (no arguments, returning base type) to make `<type>_nextval()`                  |
 
 `identity_type` will also create helper functions for the sequence: `<type>_nextval()`, `<type>_currval()`
 and `<type>_setval(<type>, bool)`

--- a/extensions/omni_id/tests/id.yml
+++ b/extensions/omni_id/tests/id.yml
@@ -4,6 +4,8 @@ instance:
   - create extension omni_id
   - select identity_type('my_id')
   - select identity_type('my_id1')
+  - select identity_type('my_uuid', type => 'uuid', nextval => 'gen_random_uuid')
+  - select identity_type('my_uuid1', type => 'uuid')
 
 tests:
 
@@ -53,3 +55,13 @@ tests:
   - query: select my_id_currval()
     results:
     - my_id_currval: 3
+
+- name: uuid typing
+  query: select my_uuid(gen_random_uuid()) = my_uuid1(gen_random_uuid())
+  error: "operator does not exist: my_uuid = my_uuid1"
+
+- name: uuid nextval
+  query: select my_uuid_nextval() is not null not_null, pg_typeof(my_uuid_nextval()) as typ
+  results:
+  - not_null: true
+    typ: my_uuid


### PR DESCRIPTION
Some use UUIDs for identifiers. They can be useful to obscure the volumes of records.

Solution: add support for UUID base type