### PR TITLE
Problem: omni_httpd does not support WebSockets

### DIFF
--- a/cmake/FindH2O.cmake
+++ b/cmake/FindH2O.cmake
@@ -4,7 +4,14 @@ include(CheckCSourceCompiles)
 set(_h2o_options)
 list(APPEND _h2o_options "WITH_MRUBY OFF")
 list(APPEND _h2o_options "DISABLE_LIBUV ON")
+# This is to make h2o find WSLAY
+list(APPEND _h2o_options "CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}")
+
+find_package(WSLAY REQUIRED)
 
 cmake_policy(SET CMP0042 NEW)
 CPMAddPackage(NAME h2o GIT_REPOSITORY https://github.com/h2o/h2o GIT_TAG 579135a VERSION 2.3.0-579135a OPTIONS "${_h2o_options}")
 set_property(TARGET libh2o-evloop PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+add_dependencies(libh2o wslay)
+add_dependencies(libh2o-evloop wslay)

--- a/cmake/FindWSLAY.cmake
+++ b/cmake/FindWSLAY.cmake
@@ -1,0 +1,10 @@
+include(CPM)
+
+CPMAddPackage(NAME wslay GIT_REPOSITORY https://github.com/tatsuhiro-t/wslay GIT_TAG 0e7d106 VERSION 0e7d106
+        OPTIONS "WSLAY_CONFIGURE_INSTALL OFF")
+
+set(WSLAY_INCLUDE_DIRS "${wslay_SOURCE_DIR}/lib/include")
+set(WSLAY_INCLUDE_DIR "${wslay_SOURCE_DIR}/lib/include")
+set(WSLAY_LIBRARY_DIRS "${wslay_BINARY_DIR}/lib")
+set(WSLAY_LIBRARIES "wslay")
+set(WSLAY_FOUND ON)

--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 * Multi-transactional handlers [#609](https://github.com/omnigres/omnigres/pull/556)
+* Experimental WebSocket support [#628](https://github.com/omnigres/omnigres/pull/628)
 
 ### Changed
 

--- a/extensions/omni_httpd/event_loop.h
+++ b/extensions/omni_httpd/event_loop.h
@@ -2,7 +2,10 @@
 #define OMNI_HTTPD_EVENT_LOOP_H
 
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdbool.h>
+
+#include <wslay/wslay.h>
 
 /**
  * This event loop handles incoming connections
@@ -56,16 +59,56 @@ extern h2o_multithread_receiver_t event_loop_receiver;
 extern h2o_multithread_queue_t *event_loop_queue;
 
 /**
+ * UUID for the purpsoe of WebSocket identification
+ */
+typedef unsigned char websocket_uuid_t[16];
+
+/**
  * `worker_event_loop` envelopes incoming HTTP requests into this data type
  */
 typedef struct {
-  h2o_multithread_message_t super;
+  //  h2o_multithread_message_t super;
   h2o_req_t *req;
   pthread_mutex_t mutex;
+  const char *ws_client_key;
+  struct wslay_event_on_msg_recv_arg websocket_message;
+  websocket_uuid_t ws_uuid;
+  pid_t process;
 } request_message_t;
 
+typedef struct {
+  h2o_multithread_message_t super;
+  enum {
+    handler_message_http,
+    handler_message_websocket_open,
+    handler_message_websocket_close,
+    handler_message_websocket_message
+  } type;
+  union {
+    struct {
+      request_message_t msg;
+      bool websocket_upgrade;
+    } http;
+    struct {
+      websocket_uuid_t uuid;
+    } websocket_open;
+    struct {
+      websocket_uuid_t uuid;
+    } websocket_close;
+    struct {
+      websocket_uuid_t uuid;
+      enum {
+        websocket_text_message,
+        websocket_binary_message,
+      } opcode;
+      uint8_t *message;
+      size_t message_len;
+    } websocket_message;
+  } payload;
+} handler_message_t;
+
 /**
- * Main thread's event loop receives `request_message_t` messages using this receiver
+ * Main thread's event loop receives `handler_message_t` messages using this receiver
  */
 extern h2o_multithread_receiver_t handler_receiver;
 
@@ -90,6 +133,8 @@ h2o_accept_ctx_t *listener_accept_ctx(h2o_socket_t *listener);
  */
 void on_accept(h2o_socket_t *listener, const char *err);
 
+void on_accept_ws_unix(h2o_socket_t *listener, const char *err);
+
 /**
  * `worker_event_loop` should be setup to use this handler
  * @param self
@@ -113,12 +158,18 @@ void h2o_queue_send_inline(request_message_t *msg, const char *body, size_t len)
 void h2o_queue_abort(request_message_t *msg);
 
 /**
- * Request aborting the connection
+ * Request proxying
  * @param msg request message
  * @param url target URL
  * @param preserve_host whether Host header should be preserved
  */
 void h2o_queue_proxy(request_message_t *msg, char *url, bool preserve_host);
+
+/**
+ * Request upgrade to WebSocket
+ * @param msg request message
+ */
+void h2o_queue_upgrade_to_websocket(request_message_t *msg);
 
 /**
  * Registers event loop receiver. Must be done prior to starting
@@ -129,5 +180,11 @@ void h2o_queue_proxy(request_message_t *msg, char *url, bool preserve_host);
  * TODO: redesign event_loop <-> http_worker interaction to simplify this
  */
 void event_loop_register_receiver();
+
+/**
+ * Prepares a UNIX domain socket for WebSocket producer/consumer
+ */
+int websocket_unix_domain_socket(websocket_uuid_t *uuid, struct sockaddr_un *server_addr,
+                                 bool producer);
 
 #endif // OMNI_HTTPD_EVENT_LOOP_H

--- a/extensions/omni_httpd/http_worker.h
+++ b/extensions/omni_httpd/http_worker.h
@@ -132,7 +132,7 @@ static cvec_fd_fd accept_fds(char *socket_name);
  */
 #define REQUEST_PLAN_HEADERS 4
 
-static int handler(request_message_t *msg);
+static int handler(handler_message_t *msg);
 
 static h2o_evloop_t *handler_event_loop;
 

--- a/extensions/omni_httpd/migrate/8_websocket.sql
+++ b/extensions/omni_httpd/migrate/8_websocket.sql
@@ -1,0 +1,85 @@
+-- Basic implementation
+create function websocket_handler(int, uuid, http_request) returns bool
+    language plpgsql as
+$$
+    begin
+        return false;
+    end;
+$$;
+
+comment on function websocket_handler(int, uuid, http_request) is $$
+This function responds to WebSocket upgrade attempts. If it returns anything but true, the connection is rejected.
+
+Can't be deleted but can be replaced.
+$$;
+
+
+create function websocket_on_open(uuid) returns void
+    language plpgsql as
+$$
+begin
+end;
+$$;
+
+comment on function websocket_on_open(uuid) is $$
+This function is called when WebSocket connection is open.
+
+Can't be deleted but can be replaced.
+$$;
+
+comment on function websocket_handler(int, uuid, http_request) is $$
+This function responds to WebSocket upgrade attempts. If it returns anything but true, the connection is rejected.
+
+Can't be deleted but can be replaced.
+$$;
+
+
+create function websocket_on_close(uuid) returns void
+    language plpgsql as
+$$
+begin
+end;
+$$;
+
+comment on function websocket_on_close(uuid) is $$
+This function is called when WebSocket connection is close.
+
+Can't be deleted but can be replaced.
+$$;
+
+create function websocket_on_message(uuid, bytea) returns void
+    language plpgsql as
+$$
+begin
+end;
+$$;
+
+create function websocket_on_message(uuid, text) returns void
+    language plpgsql as
+$$
+begin
+end;
+$$;
+
+
+comment on function websocket_on_message(uuid, bytea) is $$
+This function handles WebSocket binary messages.
+
+Can't be deleted but can be replaced.
+$$;
+
+comment on function websocket_on_message(uuid, text) is $$
+This function handles WebSocket text messages.
+
+Can't be deleted but can be replaced.
+$$;
+
+create function websocket_send(uuid, text) returns void
+    language c as
+'MODULE_PATHNAME',
+'websocket_send_text';
+
+create function websocket_send(uuid, bytea) returns void
+    language c as
+'MODULE_PATHNAME',
+'websocket_send_bytea';

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -28,6 +28,7 @@
 #include <postmaster/interrupt.h>
 #endif
 #include <commands/async.h>
+#include <common/hashfn.h>
 #include <storage/latch.h>
 #include <tcop/utility.h>
 #include <utils/builtins.h>
@@ -37,6 +38,7 @@
 #include <utils/jsonb.h>
 #include <utils/memutils.h>
 #include <utils/snapmgr.h>
+#include <utils/uuid.h>
 
 #if PG_MAJORVERSION_NUM >= 14
 
@@ -57,6 +59,7 @@
 
 #include <omni_sql.h>
 
+#include "event_loop.h"
 #include "fd.h"
 #include "omni_httpd.h"
 
@@ -426,3 +429,81 @@ Datum unload(PG_FUNCTION_ARGS) {
   ereport(WARNING, errmsg("unload has been deprecated and is a no-op now"));
   PG_RETURN_VOID();
 }
+
+typedef struct {
+  pg_uuid_t uuid;
+  int fd;
+  uint32 hash;
+  uint32 status;
+} SocketHashEntry;
+
+static inline uint32 sh_uuid_hash(struct sockethash_hash *tb, const pg_uuid_t uuid) {
+  return hash_bytes(uuid.data, sizeof(uuid.data));
+}
+
+static inline bool sh_uuid_eq(struct sockethash_hash *tb, const pg_uuid_t a, const pg_uuid_t b) {
+  return memcmp(a.data, b.data, UUID_LEN) == 0;
+}
+
+#define SH_PREFIX sockethash
+#define SH_ELEMENT_TYPE SocketHashEntry
+#define SH_KEY_TYPE pg_uuid_t
+#define SH_KEY uuid
+#define SH_HASH_KEY(tb, key) sh_uuid_hash(tb, key)
+#define SH_EQUAL(tb, a, b) sh_uuid_eq(tb, a, b)
+#define SH_SCOPE static
+#define SH_STORE_HASH
+#define SH_GET_HASH(tb, a) a->hash
+#define SH_DECLARE
+#define SH_DEFINE
+#include <lib/simplehash.h>
+
+Datum websocket_send(PG_FUNCTION_ARGS, int8 kind) {
+  if (PG_ARGISNULL(0)) {
+    ereport(ERROR, errmsg("socket can't be null"));
+  }
+  if (PG_ARGISNULL(1)) {
+    ereport(ERROR, errmsg("data can't be null"));
+  }
+
+  static sockethash_hash *sockethash = NULL;
+  if (sockethash == NULL) {
+    sockethash = sockethash_create(TopMemoryContext, 8192, NULL);
+  }
+  pg_uuid_t *uuid = PG_GETARG_UUID_P(0);
+  struct varlena *payload = PG_GETARG_VARLENA_PP(1);
+
+  bool found;
+  SocketHashEntry *entry = sockethash_insert(sockethash, *uuid, &found);
+  if (!found) {
+    struct sockaddr_un server_addr;
+    entry->fd = websocket_unix_domain_socket(&uuid->data, &server_addr, false);
+
+    // Connect to the server
+    if (connect(entry->fd, (struct sockaddr *)&server_addr, sizeof(struct sockaddr_un)) < 0) {
+      char *s = strerror(errno);
+      ereport(ERROR, errmsg("connect %s", s));
+    }
+  }
+  int client_fd = entry->fd;
+
+  // Send a message to the server
+  struct {
+    int8_t kind;
+    size_t length;
+  } __attribute__((packed)) msg = {.kind = kind, .length = VARSIZE_ANY_EXHDR(payload)};
+  if (send(client_fd, &msg, sizeof(msg), 0) < 0) {
+    ereport(ERROR, errmsg("send"));
+  }
+  if (send(client_fd, VARDATA_ANY(payload), msg.length, 0) < 0) {
+    ereport(ERROR, errmsg("send"));
+  }
+
+  PG_RETURN_VOID();
+}
+
+PG_FUNCTION_INFO_V1(websocket_send_text);
+Datum websocket_send_text(PG_FUNCTION_ARGS) { return websocket_send(fcinfo, 0); }
+
+PG_FUNCTION_INFO_V1(websocket_send_bytea);
+Datum websocket_send_bytea(PG_FUNCTION_ARGS) { return websocket_send(fcinfo, 1); }


### PR DESCRIPTION
This is a major problem for anything remotely interesting these days.

Solution: devise the first version of WebSocket handling

Current approach definitely has deficiencies. For example, using UNIX domain sockets can be problematic here. It's good that sending a message to UNIX domain socket is directly connecting us with the consumer (the networking thread) thus ensuring that we are not simply buffering the messages. But if, for some reason, the consumer is not reading, it'll block us.

An even bigger problem is that we currently won't try to send messages to any other worker and will simply schedule messages for the current buffer. It's okay for the initial prototype, but won't scale well.