### PR TITLE
Add a script and a dockerfile to build RPM pkgs for amd64 & arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ devenv.local.nix
 
 # python
 __pycache__
+
+# pkgs
+*.rpm

--- a/pkgs/mkpkgs
+++ b/pkgs/mkpkgs
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# NOTE: You'll possibly need to create a arm64 or amd64 buildx container first
+# if you are on another architecture.
+#
+# `docker buildx create --platform linux/arm64 --use`
+# `docker buildx inspect <name of container> --bootstrap`
+# `docker buildx ls` should show it running & ready for arm64
+
+set -eux
+
+ARCH=${ARCH:-linux/arm64,linux/amd64}
+POSTGRES_VER=${POSTGRES_VER:-16}
+
+# FIND THE ROOT GIT DIRECTORY
+DIR=$(git rev-parse --show-toplevel "$(dirname "$0")"|head -n 1)
+
+# ITERATION FOR THE PACKAGES
+ITERATION=${ITERATION:-1}
+
+# GIT REVISION OF SOURCE
+REVISION=${REVISION:-"$(git rev-parse --short HEAD)"}
+
+# BULID FOR REDHAT.
+for arch in ${ARCH/,/ }; do
+    # NOTE: I have this building architectures sequentially because I'm on a
+    # laptop. On a beefy CI machine, it might be better to do this in one pass
+    # maxing the machine with parallel builds like the following example:
+    # `docker buildx build --platform linux/amd64,linux/arm64 --push`
+    ROCKY_IMAGE_NAME="omnigres:rocky-9-pgdg${POSTGRES_VER}-${arch/linux\/}-$REVISION-$ITERATION"
+    ROCKY_CONTAINER_NAME="${ROCKY_IMAGE_NAME/:/-}-$(cut -c1-6 <(cat /proc/*/*/*/uuid||uuidgen))" ;# WORKS ON LINUX & MACOS
+    docker buildx build \
+           --progress plain \
+           --platform "$arch" \
+           --build-arg POSTGRES_VER="$POSTGRES_VER" \
+           --build-arg ITERATION="$ITERATION" \
+           --tag "$ROCKY_IMAGE_NAME" \
+           --file "${DIR}/pkgs/rocky.dockerfile" \
+           --load \
+           "$DIR"
+    trap '{
+        docker stop "$ROCKY_CONTAINER_NAME"  >/dev/null 2>&1 || true
+        docker rm   "$ROCKY_CONTAINER_NAME"  >/dev/null 2>&1 || true
+    }' EXIT
+    docker run --platform "$arch" -d --name "$ROCKY_CONTAINER_NAME" "$ROCKY_IMAGE_NAME" tail -f /dev/null
+    docker cp "$ROCKY_CONTAINER_NAME":/pkgs "$DIR/"
+done

--- a/pkgs/mkrpms
+++ b/pkgs/mkrpms
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -eux
+
+pgpkg="postgresql$POSTGRES_VER"
+
+cat </build/artifacts.txt | while IFS= read -r line; do
+    pkg="$(echo "$line"|awk -F'=' '{print $1}')"
+    vers="$(echo "$line"|cut -d'#' -f1|awk -F'=' '{print $2}')"
+    deps="--depends $pgpkg"
+    for d in $(echo "$line"|awk -F'#' '{print $2}'|tr ',' ' ') ; do
+        n="$(echo "$d"|awk -F'=' '{print $1}')"
+        v="$(echo "$d"|awk -F'=' '{print $2}')"
+        case $n in \
+            dblink|pgcrypto)
+                n="$pgpkg-contrib" ; v='*' ;;
+            plpy*)
+                n="$pgpkg-plpython3" ; v='*' ;;
+        esac
+        if [ "$v" = "*" ]; then
+            deps="$deps --depends '$n'"
+        else
+            deps="$deps --depends '$n >= $v'"
+        fi
+    done
+    tmp="$(mktemp -d)"
+    mkdir -p "$tmp/lib"
+    mkdir -p "$tmp/share/extension"
+    cp "/build/packaged/$pkg"--*.so        "$tmp/lib/" && arch=native || arch=all
+    cp "/build/packaged/extension/$pkg".*  "$tmp/share/extension/" || true
+    cp "/build/packaged/extension/$pkg"--* "$tmp/share/extension/" || true
+    eval "${GEM_HOME}/bin/fpm" \
+         --input-type dir \
+         --output-type rpm \
+         --architecture "$arch" \
+         --name "$pkg" \
+         --version "$vers" \
+         --iteration "$ITERATION" \
+         --prefix "/usr/pgsql-$POSTGRES_VER/" \
+         --chdir "$tmp" \
+         "$deps" \
+         .
+done

--- a/pkgs/rocky.dockerfile
+++ b/pkgs/rocky.dockerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1.5
+
+ARG REDHAT_VER=9
+
+FROM rockylinux:${REDHAT_VER} AS builder-rocky
+
+ARG ARCH=x86_64
+ARG POSTGRES_VER=16
+ARG REDHAT_VER
+
+# UPDATE
+RUN dnf update -y
+
+# SUDO IS USEFUL IF YOU WANT TO RUN AS YOUR OWN HOST'S USER & NOT ROOT
+# E.G. `docker run -i -t --rm --user $(id -u):100 -v $PWD:/omni <image>`
+# THIS WILL POP YOU INTO A CONTAINER WHERE YOU ARE 'redhat' IN THE GROUP
+# 'users'. AND THE FILES YOU TOUCH/WRITE IN /omni WILL BE OWNED BY THE SAME
+# USER ID AS YOUR HOST.
+RUN dnf install -y sudo
+RUN echo 'redhat ALL=(ALL) NOPASSWD: ALL' | tee /etc/sudoers.d/redhat
+RUN useradd -g users -m redhat
+
+# POSTGRES
+RUN dnf install -y \
+    https://download.postgresql.org/pub/repos/yum/reporpms/EL-${REDHAT_VER}-$(uname -m)/pgdg-redhat-repo-latest.noarch.rpm
+RUN dnf --enablerepo=crb install -y \
+    postgresql${POSTGRES_VER}-contrib \
+    postgresql${POSTGRES_VER}-devel \
+    postgresql${POSTGRES_VER}-plpython3 \
+    postgresql${POSTGRES_VER}-server
+
+# DEPS
+RUN yum groupinstall -y "Development Tools"
+RUN dnf --enablerepo=crb install -y \
+    cmake \
+    doxygen \
+    nc \
+    openssl-devel \
+    perl-CPAN \
+    python3-devel
+
+# FPM
+RUN dnf install -y ruby ruby-devel rubygems squashfs-tools
+ENV GEM_HOME=/usr/local
+RUN gem install fpm
+
+ARG ITERATION=1
+
+COPY ./ /omni
+WORKDIR /build
+
+# BUILD
+ENV PATH /usr/pgsql-${POSTGRES_VER}/bin:${PATH}
+RUN cmake -DPG_CONFIG=$(which pg_config) -DOPENSSL_CONFIGURED=1 /omni
+RUN make -j all
+RUN make package_extensions
+
+WORKDIR /pkgs
+
+# PACKAGING
+RUN /omni/pkgs/mkrpms
+
+# TEST INSTALL
+RUN rpm -ivh *.rpm


### PR DESCRIPTION
This commit adds the ability to easily produce RPMs for Omnigres on any capable machine with Docker installed. Please review the ./pkgs/mkpkgs script for notes on setup. Then just call ./pkgs/mkpkgs at the command line. If you only want one archiecture then call `ARCH=linux/arm64 ./pkgs/mkpkgs`.

Please provide as much criticism as you like. I'll fixup commits and rebase.

The build machine setup for this has been exercising this script. Try it yourself if you like.