### PR TITLE
Problem: omni_httpd underallocated memory for proxying

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -25,6 +25,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * omni_httpd workers leaking memory on every request [#610](https://github.com/omnigres/omnigres/pull/610)
 
+* omni_httpd underallocated memory when proxying, can lead to undefined
+  behavior [#630](https://github.com/omnigres/omnigres/pull/630)
+
 ## [0.1.2] - 2024-04-07
 
 ### Fixed

--- a/extensions/omni_httpd/event_loop.c
+++ b/extensions/omni_httpd/event_loop.c
@@ -185,8 +185,7 @@ static void on_message(h2o_multithread_receiver_t *receiver, h2o_linklist_t *mes
       overrides->use_proxy_protocol = false;
       overrides->proxy_preserve_host = proxy.preserve_host;
       overrides->forward_close_connection = true;
-      overrides->upstream =
-          (h2o_url_t *)h2o_mem_alloc_pool(&req->pool, sizeof(*overrides->upstream), 1);
+      overrides->upstream = (h2o_url_t *)h2o_mem_alloc_pool(&req->pool, h2o_url_t, 1);
 
       h2o_url_parse(&req->pool, proxy.url, strlen(proxy.url), overrides->upstream);
 


### PR DESCRIPTION
This is because it uses `h2o_mem_alloc_pool` API incorrectly there.

Solution: use it correctly

Supply the type, not the size