### PR TITLE
Fix Omni Seq's include of PostgreSQL 16's server header

### DIFF
--- a/extensions/omni_seq/id.h
+++ b/extensions/omni_seq/id.h
@@ -34,7 +34,7 @@
 #include <utils/builtins.h>
 #if PG_MAJORVERSION_NUM >= 16
 #include "port/pg_bswap.h"
-#include "server/varatt.h"
+#include <varatt.h>
 #endif
 
 #define make_name__(name, prefix_len, val_len, suffix) name##_##prefix_len##_##val_len##suffix


### PR DESCRIPTION
Problem:

Compiling on Ubuntu Noble LTS against PGDG PostgreSQL 16 is broken.

Solution:

FindPostgreSQL cmake file already includes both client & server include directories. All we have to do is include the header we want without being specific about the path. This works with both RedHat and on Ubuntu PGDG packages. Server headers are a separate package on Ubuntu.

Closes #631 