### PR TITLE
Problem: `regproc[edure]` have limited usefulness

### DIFF
--- a/extensions/omni/test/tests/upgrade_extra_deps.yml
+++ b/extensions/omni/test/tests/upgrade_extra_deps.yml
@@ -10,7 +10,7 @@ instance:
   - create extension omni_test version '1' cascade
   - create extension omni
   # We use omni_types to test how dependencies are upgraded
-  - create extension omni_types
+  - create extension omni_types cascade
 
 tests:
 

--- a/extensions/omni_types/CHANGELOG.md
+++ b/extensions/omni_types/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.0] - TBD
 
+### Added
+
+* Function signature types [#634](https://github.com/omnigres/omnigres/pull/634])
+
 ### Fixed
 
 * Sum types will be now included into `pg_dump`-produced dumps [#636](https://github.com/omnigres/omnigres/pull/636])

--- a/extensions/omni_types/CMakeLists.txt
+++ b/extensions/omni_types/CMakeLists.txt
@@ -10,11 +10,16 @@ enable_testing()
 
 find_package(PostgreSQL REQUIRED)
 
+if (${PostgreSQL_VERSION_STRING} MATCHES "PostgreSQL 13.*")
+    set(requirements omni_polyfill) # for trim_array
+endif ()
+
 add_postgresql_extension(
         omni_types
         SCHEMA omni_types
         RELOCATABLE false
-        SOURCES omni_types.c unit.c sum_type.c
+        SOURCES omni_types.c unit.c sum_type.c funsig_type.c
+        REQUIRES ${requirements}
 )
 
 add_library(libomnitypes INTERFACE)

--- a/extensions/omni_types/README.md
+++ b/extensions/omni_types/README.md
@@ -3,3 +3,4 @@
 This extension provides advanced tooling for typing in Postgres:
 
 * [Sum types](https://docs.omnigres.org/omni_types/sum_types/)
+* [Function signature types](https://docs.omnigres.org/omni_types/function_signature_types/)

--- a/extensions/omni_types/docs/function_signature_types.md
+++ b/extensions/omni_types/docs/function_signature_types.md
@@ -47,6 +47,15 @@ With the type defined, one can cast a function name into it. It will return a `s
 select 'length'::sig
 ```
 
+If no function is matching the signature captured by the type, this will fail with an error. If this is undesirable,
+`<TYPE>_conforming_function(text)` can be used instead:
+
+```postgresql
+with funcs as (select sig_confirming_function(name::text) as f from names)
+select funcs
+where f is not null;
+```
+
 ## Calling a function
 
 Function signature types can be called (and it is one of its primary benefits!) by using an auto-generated `call_<NAME>`
@@ -56,4 +65,3 @@ function:
 select call_sig('length', 'hello')
 -- returns 5 as this is what `length(text)` would return
 ```
-

--- a/extensions/omni_types/docs/function_signature_types.md
+++ b/extensions/omni_types/docs/function_signature_types.md
@@ -1,0 +1,59 @@
+# Function Signature Types
+
+Function signature types are essentially a way to type functions with a specific arguments and return type signature.
+Whereas `regproc` and `regprocedure` denote that the type is a function or a procedure, the type itself does not convey
+its signature. This limits their usefulness.
+
+Function signature types, on the other hand, can be used to call functions that match the signature.
+
+## Defining a function signature type
+
+To define such a type, use `omni_types.function_signature_type(name, ...signature)`:
+
+```postgresql
+select omni_types.function_signature_type('sig', 'text', 'int')
+```
+
+In the above example, it will define type `sig` that denotes a function that takes `text` and returns `int` (the last
+element in the variadic `signature` argument is the return type)
+
+| *Parameter* | *Type*           | *Description*                                            |
+|------------:|------------------|----------------------------------------------------------|
+|      *name* | name             | Name of the newly created type                           |
+| *signature* | variadic regtype | Signature of the function. Last value is the return type |
+
+Calling the function with the same arguments will return the same type without attempting to recreate it, if the
+signatures match. Otherwise, an error will occur.
+
+### Defining a signature from a prototype
+
+One can also define a function signature type by using an existing function as a prototype
+with `omni_types.function_signature_type(name, function)`:
+
+```postgresql
+select omni_types.function_signature_type_of('sig', 'length(text)')
+```
+
+| *Parameter* | *Type* | *Description*                                                                  |
+|------------:|--------|--------------------------------------------------------------------------------|
+|      *name* | name   | Name of the newly created type                                                 |
+|      *func* | text   | Name (`pg_backend_pid`) or argument signature (`length(text)`) of the function |
+
+## Casting to a function signature type
+
+With the type defined, one can cast a function name into it. It will return a `sig` type successfully if it matches:
+
+```postgresql
+select 'length'::sig
+```
+
+## Calling a function
+
+Function signature types can be called (and it is one of its primary benefits!) by using an auto-generated `call_<NAME>`
+function:
+
+```postgresql
+select call_sig('length', 'hello')
+-- returns 5 as this is what `length(text)` would return
+```
+

--- a/extensions/omni_types/funsig_type.c
+++ b/extensions/omni_types/funsig_type.c
@@ -1,0 +1,160 @@
+/**
+ * @file funsig_type.c
+ *
+ */
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+#include <access/heapam.h>
+#include <access/htup_details.h>
+#include <access/table.h>
+#include <catalog/namespace.h>
+#include <catalog/pg_cast.h>
+#include <catalog/pg_collation.h>
+#include <catalog/pg_language.h>
+#include <catalog/pg_proc.h>
+#include <catalog/pg_type.h>
+#include <commands/typecmds.h>
+#include <executor/spi.h>
+#include <miscadmin.h>
+#include <utils/array.h>
+#include <utils/builtins.h>
+#include <utils/fmgroids.h>
+#include <utils/lsyscache.h>
+#include <utils/syscache.h>
+
+#include "sum_type.h"
+
+PG_FUNCTION_INFO_V1(function_signature_in);
+
+Datum function_signature_in(PG_FUNCTION_ARGS) {
+  char *input = PG_GETARG_CSTRING(0);
+
+  // Get the type that we need to return
+  Oid typeoid = get_func_rettype(fcinfo->flinfo->fn_oid);
+
+  // Find matching record in our table
+  Oid types = get_relname_relid("function_signature_types", get_namespace_oid("omni_types", false));
+  Relation rel = table_open(types, AccessShareLock);
+  TupleDesc tupdesc = RelationGetDescr(rel);
+  TableScanDesc scan = table_beginscan_catalog(rel, 0, NULL);
+  Oid matching_function = InvalidOid;
+  for (;;) {
+    HeapTuple tup = heap_getnext(scan, ForwardScanDirection);
+    // The end
+    if (tup == NULL)
+      break;
+
+    bool isnull;
+    // Matching type
+    // TODO: search by index
+    if (typeoid == DatumGetObjectId(heap_getattr(tup, 1, tupdesc, &isnull))) {
+
+      AnyArrayType *arguments = DatumGetAnyArrayP(heap_getattr(tup, 2, tupdesc, &isnull));
+
+      // If argument lengths are not matching, move on
+      int nargs = ArrayGetNItems(AARR_NDIM(arguments), AARR_DIMS(arguments));
+
+      List *names = list_make1(makeString(input));
+      FuncCandidateList candidates = FuncnameGetCandidates(names, nargs, NIL, false, false,
+#if PG_MAJORVERSION_NUM > 13
+                                                           false,
+#endif
+                                                           true);
+
+      while (candidates) {
+        // Iterate through arguments
+        ArrayIterator it = array_create_iterator((ArrayType *)arguments, 0, NULL);
+
+        Datum elem;
+        // Iterate through argument types
+        int i = 0;
+        while (array_iterate(it, &elem, &isnull)) {
+          if (isnull) {
+            continue;
+          }
+          if (DatumGetObjectId(elem) != candidates->args[i]) {
+            goto done_iter;
+          }
+          i++;
+        }
+        // Get return types of the looked up function
+        HeapTuple proc_tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(candidates->oid));
+        Assert(HeapTupleIsValid(proc_tuple));
+        Form_pg_proc proc_struct = (Form_pg_proc)GETSTRUCT(proc_tuple);
+        Oid function_ret_type = proc_struct->prorettype;
+        ReleaseSysCache(proc_tuple);
+
+        if (function_ret_type != DatumGetObjectId(heap_getattr(tup, 3, tupdesc, &isnull))) {
+          goto done_iter;
+        }
+
+        matching_function = candidates->oid;
+      done_iter:
+        array_free_iterator(it);
+        if (OidIsValid(matching_function)) {
+          break;
+        }
+        candidates = candidates->next;
+      }
+    }
+  }
+  if (scan->rs_rd->rd_tableam->scan_end) {
+    scan->rs_rd->rd_tableam->scan_end(scan);
+  }
+  table_close(rel, AccessShareLock);
+  if (!OidIsValid(matching_function)) {
+    MemoryContext oldcontext = CurrentMemoryContext;
+    PG_TRY();
+    { DirectFunctionCall1(regprocin, CStringGetDatum(input)); }
+    PG_CATCH();
+    {
+      int errcode = geterrcode();
+      MemoryContextSwitchTo(oldcontext);
+      if (errcode != ERRCODE_AMBIGUOUS_FUNCTION) {
+        PG_RE_THROW();
+      } else {
+        FlushErrorState();
+      }
+    }
+    PG_END_TRY();
+    ereport(ERROR, errmsg("function \"%s\" does not match the signature of the type", input));
+  }
+  PG_RETURN_OID(matching_function);
+}
+
+PG_FUNCTION_INFO_V1(invoke);
+
+Datum invoke(PG_FUNCTION_ARGS) {
+  if (PG_ARGISNULL(0)) {
+    ereport(ERROR, errmsg("Can't invoke a NULL function"));
+  }
+
+  FmgrInfo flinfo;
+  MemoryContext oldcontext = CurrentMemoryContext;
+  PG_TRY();
+  { fmgr_info(PG_GETARG_OID(0), &flinfo); }
+  PG_CATCH();
+  {
+    MemoryContextSwitchTo(oldcontext);
+    FlushErrorState();
+    ereport(ERROR, errmsg("function does not exist"));
+  }
+  PG_END_TRY();
+
+  LOCAL_FCINFO(fcinfo1, FUNC_MAX_ARGS); // FIXME: space-inefficient
+
+  InitFunctionCallInfoData(*fcinfo1, &flinfo, fcinfo->nargs - 1, fcinfo->fncollation,
+                           fcinfo->context, fcinfo->resultinfo);
+
+  for (short i = 0; i < fcinfo->nargs - 1; i++) {
+    fcinfo1->args[i] = fcinfo->args[i + 1];
+    if (fcinfo1->flinfo->fn_strict && fcinfo1->args[i].isnull) {
+      PG_RETURN_NULL();
+    }
+  }
+
+  return FunctionCallInvoke(fcinfo1);
+}

--- a/extensions/omni_types/funsig_type.c
+++ b/extensions/omni_types/funsig_type.c
@@ -28,10 +28,8 @@
 
 #include "sum_type.h"
 
-PG_FUNCTION_INFO_V1(function_signature_in);
+static Datum function_signature_search(PG_FUNCTION_ARGS, char *input, bool missing_as_null) {
 
-Datum function_signature_in(PG_FUNCTION_ARGS) {
-  char *input = PG_GETARG_CSTRING(0);
   Node *escontext = fcinfo->context;
 
   // Get the type that we need to return
@@ -88,9 +86,6 @@ Datum function_signature_in(PG_FUNCTION_ARGS) {
           }
           i++;
         }
-        if (i == 0) {
-          break;
-        }
         // Get return types of the looked up function
         HeapTuple proc_tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(candidates->oid));
         Assert(HeapTupleIsValid(proc_tuple));
@@ -124,124 +119,34 @@ Datum function_signature_in(PG_FUNCTION_ARGS) {
     {
       int errcode = geterrcode();
       MemoryContextSwitchTo(oldcontext);
-      if (errcode != ERRCODE_AMBIGUOUS_FUNCTION) {
+      if (!missing_as_null && errcode != ERRCODE_AMBIGUOUS_FUNCTION) {
         PG_RE_THROW();
       } else {
         FlushErrorState();
       }
     }
     PG_END_TRY();
-    ereport(ERROR, errmsg("function \"%s\" does not match the signature of the type", input));
+    if (!missing_as_null) {
+      ereport(ERROR, errmsg("function \"%s\" does not match the signature of the type", input));
+    } else {
+      PG_RETURN_NULL();
+    }
   }
   PG_RETURN_OID(matching_function);
+}
+
+PG_FUNCTION_INFO_V1(function_signature_in);
+
+Datum function_signature_in(PG_FUNCTION_ARGS) {
+  char *input = PG_GETARG_CSTRING(0);
+  return function_signature_search(fcinfo, input, false);
 }
 
 PG_FUNCTION_INFO_V1(conforming_function);
 
 Datum conforming_function(PG_FUNCTION_ARGS) {
   char *input = text_to_cstring(PG_GETARG_TEXT_PP(0));
-  Node *escontext = fcinfo->context;
-
-  // Get the type that we need to return
-  Oid typeoid = get_func_rettype(fcinfo->flinfo->fn_oid);
-
-  // Find matching record in our table
-  Oid types = get_relname_relid("function_signature_types", get_namespace_oid("omni_types", false));
-  Relation rel = table_open(types, AccessShareLock);
-  TupleDesc tupdesc = RelationGetDescr(rel);
-  TableScanDesc scan = table_beginscan_catalog(rel, 0, NULL);
-  Oid matching_function = InvalidOid;
-  for (;;) {
-    HeapTuple tup = heap_getnext(scan, ForwardScanDirection);
-    // The end
-    if (tup == NULL)
-      break;
-
-    bool isnull;
-    // Matching type
-    // TODO: search by index
-    if (typeoid == DatumGetObjectId(heap_getattr(tup, 1, tupdesc, &isnull))) {
-
-      AnyArrayType *arguments = DatumGetAnyArrayP(heap_getattr(tup, 2, tupdesc, &isnull));
-
-      // If argument lengths are not matching, move on
-      int nargs = ArrayGetNItems(AARR_NDIM(arguments), AARR_DIMS(arguments));
-
-      List *names = stringToQualifiedNameList(input
-#if PG_MAJORVERSION_NUM > 15
-                                              ,
-                                              escontext
-#endif
-      );
-
-      FuncCandidateList candidates = FuncnameGetCandidates(names, nargs, NIL, false, false,
-#if PG_MAJORVERSION_NUM > 13
-                                                           false,
-#endif
-                                                           true);
-
-      while (candidates) {
-        // Iterate through arguments
-        ArrayIterator it = array_create_iterator((ArrayType *)arguments, 0, NULL);
-
-        Datum elem;
-        // Iterate through argument types
-        int i = 0;
-        while (array_iterate(it, &elem, &isnull)) {
-          if (isnull) {
-            continue;
-          }
-          if (DatumGetObjectId(elem) != candidates->args[i]) {
-            goto done_iter;
-          }
-          i++;
-        }
-        if (i == 0) {
-          PG_RETURN_NULL();
-        }
-        // Get return types of the looked up function
-        HeapTuple proc_tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(candidates->oid));
-        Assert(HeapTupleIsValid(proc_tuple));
-        Form_pg_proc proc_struct = (Form_pg_proc)GETSTRUCT(proc_tuple);
-        Oid function_ret_type = proc_struct->prorettype;
-        ReleaseSysCache(proc_tuple);
-
-        if (function_ret_type != DatumGetObjectId(heap_getattr(tup, 3, tupdesc, &isnull))) {
-          goto done_iter;
-        }
-
-        matching_function = candidates->oid;
-      done_iter:
-        array_free_iterator(it);
-        if (OidIsValid(matching_function)) {
-          break;
-        }
-        candidates = candidates->next;
-      }
-    }
-  }
-  if (scan->rs_rd->rd_tableam->scan_end) {
-    scan->rs_rd->rd_tableam->scan_end(scan);
-  }
-  table_close(rel, AccessShareLock);
-  if (!OidIsValid(matching_function)) {
-    MemoryContext oldcontext = CurrentMemoryContext;
-    PG_TRY();
-    { DirectFunctionCall1(regprocin, CStringGetDatum(input)); }
-    PG_CATCH();
-    {
-      int errcode = geterrcode();
-      MemoryContextSwitchTo(oldcontext);
-      //      if (errcode != ERRCODE_AMBIGUOUS_FUNCTION) {
-      //        PG_RE_THROW();
-      //      } else {
-      FlushErrorState();
-      //      }
-    }
-    PG_END_TRY();
-    PG_RETURN_NULL();
-  }
-  PG_RETURN_OID(matching_function);
+  return function_signature_search(fcinfo, input, true);
 }
 
 PG_FUNCTION_INFO_V1(invoke);

--- a/extensions/omni_types/migrate/3_function_signature_type.sql
+++ b/extensions/omni_types/migrate/3_function_signature_type.sql
@@ -1,0 +1,12 @@
+create table function_signature_types
+(
+    typ       regtype primary key unique,
+    arguments regtype[] not null,
+    return    regtype   not null
+);
+
+select pg_catalog.pg_extension_config_dump('function_signature_types', '');
+
+/*{% include "../src/function_signature_type_of.sql" %}*/
+
+/*{% include "../src/function_signature_type.sql" %}*/

--- a/extensions/omni_types/src/function_signature_type.sql
+++ b/extensions/omni_types/src/function_signature_type.sql
@@ -16,7 +16,6 @@ begin
                 existing_sig regtype[];
             begin
                 existing_sig := trim_array(array_append(rec.arguments, rec.return), 0);
-                raise notice '%', array_eq(existing_sig, signature);
                 if not array_eq(existing_sig, signature) then
                     raise exception 'cannot redefine % as its signature % does not match %', name, existing_sig, signature;
                 else

--- a/extensions/omni_types/src/function_signature_type.sql
+++ b/extensions/omni_types/src/function_signature_type.sql
@@ -1,0 +1,93 @@
+create function function_signature_type(name name,
+                                        variadic signature regtype[]
+) returns regtype
+    language plpgsql
+as
+$$
+declare
+    ret_type           regtype;
+    omni_types_library text;
+    rec record;
+begin
+
+    for rec in select typ, arguments, return from omni_types.function_signature_types where typ::name = name
+        loop
+            declare
+                existing_sig regtype[];
+            begin
+                existing_sig := trim_array(array_append(rec.arguments, rec.return), 0);
+                raise notice '%', array_eq(existing_sig, signature);
+                if not array_eq(existing_sig, signature) then
+                    raise exception 'cannot redefine % as its signature % does not match %', name, existing_sig, signature;
+                else
+                    return rec.typ;
+                end if;
+            end;
+        end loop;
+
+    -- Resolve omni_types module
+    select probin
+    into omni_types_library
+    from pg_proc
+             inner join pg_namespace on pg_proc.pronamespace = pg_namespace.oid and pg_namespace.nspname = 'omni_types'
+    where proname = 'unit_in';
+
+    -- Define the shell of the type
+    execute format('create type %I;', name);
+
+    -- Make sure the commands below don't produce these messages:
+    -- NOTICE:  return type a is only a shell
+    -- NOTICE:  argument type a is only a shell
+    -- NOTICE:  argument type a is only a shell
+    -- NOTICE:  return type a is only a shell
+    --
+    -- (they are annoying and unnecessary)
+    set local client_min_messages = warning;
+
+    -- Define in/out send/recv before we actually define the type
+
+    execute format('create function %I(cstring) returns %I language c as %L, %L immutable strict', name || '_in',
+                   name,
+                   omni_types_library, 'function_signature_in');
+
+    execute format('create function %I(%I) returns cstring language internal as %L immutable strict', name || '_out',
+                   name,
+                   'regprocedureout');
+
+    execute format('create function %I(%I) returns bytea language internal as %L immutable',
+                   name || '_send', name,
+                   'regproceduresend');
+    execute format('create function %I(internal) returns %I language internal as %L immutable',
+                   name || '_recv', name,
+                   'regprocedurerecv');
+
+    -- Resume notices disabled above
+    reset client_min_messages;
+
+    -- Finally, define the type
+    execute format(
+            'create type %I ( internallength = %s, input = %I, output = %I, send = %I, receive = %I, like = oid, storage = plain)',
+            name, (select typlen from pg_type where typname = 'oid'), name || '_in', name || '_out', name || '_send',
+            name || '_recv'
+            );
+
+    -- Register the type
+    ret_type := signature[cardinality(signature)];
+    insert into omni_types.function_signature_types (typ, arguments, return)
+    values (name::regtype, trim_array(signature, 1), ret_type);
+
+    -- Define casts out of the type
+    execute format('create cast (%I as regproc) without function', name);
+    execute format('create cast (%I as regprocedure) without function', name);
+    execute format('create cast (%I as oid) without function', name);
+
+    -- Define caller function
+    execute format('create function %I(%I %s) returns %s language c as %L, %L', 'call_' || name, name,
+                   case
+                       when cardinality(signature) = 1 then ''
+                       else ', ' || concat_ws(', ', variadic trim_array(signature, 1)) end,
+                   ret_type, omni_types_library, 'invoke');
+
+    return name::regtype;
+end;
+$$;

--- a/extensions/omni_types/src/function_signature_type.sql
+++ b/extensions/omni_types/src/function_signature_type.sql
@@ -80,6 +80,11 @@ begin
     execute format('create cast (%I as regprocedure) without function', name);
     execute format('create cast (%I as oid) without function', name);
 
+    -- Define conformance test function
+    execute format('create function %3$I(text) returns %1$I language c as %2$L, ''conforming_function''',
+                   name,
+                   omni_types_library, name || '_conforming_function');
+
     -- Define caller function
     execute format('create function %I(%I %s) returns %s language c as %L, %L', 'call_' || name, name,
                    case

--- a/extensions/omni_types/src/function_signature_type_of.sql
+++ b/extensions/omni_types/src/function_signature_type_of.sql
@@ -1,0 +1,25 @@
+create function function_signature_type_of(name name, func text)
+    returns regtype
+    language plpgsql
+as
+$$
+declare
+    result regtype;
+    proc   regprocedure;
+begin
+    begin
+        proc = func::regprocedure;
+    exception
+        when others then
+            proc = func::regproc;
+    end;
+    select omni_types.function_signature_type(name, variadic
+                                              trim_array(
+                                                      array_append(pg_proc.proargtypes::oid[], pg_proc.prorettype)::regtype[],
+                                                      0))
+    from pg_proc
+    where oid = proc
+    into result;
+    return result;
+end;
+$$;

--- a/extensions/omni_types/tests/function_signature_type.yml
+++ b/extensions/omni_types/tests/function_signature_type.yml
@@ -90,3 +90,24 @@ tests:
   - select omni_types.function_signature_type('sig', 'text', 'int')
   - query: select omni_types.function_signature_type('sig', 'int', 'text')
     error: cannot redefine sig as its signature {text,integer} does not match {integer,text}
+
+- name: converting schema-qualified type
+  steps:
+  - query: select omni_types.function_signature_type('sig', 'text', 'int')
+    results:
+    - function_signature_type: sig
+  - query: select 'pg_catalog.length'::sig
+    results:
+    - sig: length(text)
+
+- name: conforming function
+  steps:
+  - query: select omni_types.function_signature_type('sig', 'text', 'int')
+    results:
+    - function_signature_type: sig
+  - query: select sig_conforming_function('pg_catalog.length') as f
+    results:
+    - f: length(text)
+  - query: select sig_conforming_function('pg_catalog.no_such_function') as f
+    results:
+    - f: null

--- a/extensions/omni_types/tests/function_signature_type.yml
+++ b/extensions/omni_types/tests/function_signature_type.yml
@@ -1,0 +1,92 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_types cascade
+
+tests:
+- name: smoke test
+  steps:
+  - query: select omni_types.function_signature_type('sig', 'text', 'int')
+    results:
+    - function_signature_type: sig
+  - query: select 'length'::sig::regprocedure = 'length(text)'::regprocedure as result
+    results:
+    - result: true
+  - name: converts to oid
+    query: select 'length'::sig::oid = 'length(text)'::regprocedure::oid as result
+    results:
+    - result: true
+  - name: converts to regproc
+    query: select 'length'::sig::regproc = 'length(text)'::regprocedure::regproc as result
+    results:
+    - result: true
+  - query: select call_sig('length', 'hello')
+    results:
+    - call_sig: 5
+  - name: ensure calling strict functions works
+    query: select call_sig('length', null)
+    results:
+    - call_sig: null
+
+- name: smoke test for zero-arity function
+  steps:
+  - query: select omni_types.function_signature_type('sig', 'int')
+    results:
+    - function_signature_type: sig
+  - query: select 'pg_backend_pid'::sig::regprocedure = 'pg_backend_pid()'::regprocedure as result
+    results:
+    - result: true
+  - query: select call_sig('pg_backend_pid') = pg_backend_pid() as result
+    results:
+    - result: true
+
+- name: can't convert something that doesn't match
+  steps:
+  - select omni_types.function_signature_type('sig', 'text', 'int')
+  - query: select 'pg_backend_pid'::sig
+    error: function "pg_backend_pid" does not match the signature of the type
+
+- name: can't convert something that doesn't match and has multiple candidates
+  steps:
+  - select omni_types.function_signature_type('sig', 'int', 'int')
+  - query: select 'length'::sig
+    error: function "length" does not match the signature of the type
+
+- name: can't convert something that doesn't exist
+  steps:
+  - select omni_types.function_signature_type('sig', 'text', 'int')
+  - query: select 'does_not_exist'::sig
+    error: function "does_not_exist" does not exist
+
+- name: convert NULL?
+  steps:
+  - select omni_types.function_signature_type('sig', 'text', 'int')
+  - query: select null::sig as result
+    results:
+    - result: null
+
+- name: call function that no longer exists
+  steps:
+  - |
+    create function f(int) returns int
+        language sql as
+    $$
+    select 1
+    $$
+  - select omni_types.function_signature_type_of('sig', 'f(int)')
+  - create table funs as (select 'f'::sig as f)
+  - drop function f(int)
+  - query: select call_sig(f, 0)
+           from funs
+    error: function does not exist
+
+- name: redefining the type without changing it
+  steps:
+  - select omni_types.function_signature_type('sig', 'text', 'int')
+  - select omni_types.function_signature_type('sig', 'text', 'int')
+
+- name: redefining the type and changing it
+  steps:
+  - select omni_types.function_signature_type('sig', 'text', 'int')
+  - query: select omni_types.function_signature_type('sig', 'int', 'text')
+    error: cannot redefine sig as its signature {text,integer} does not match {integer,text}


### PR DESCRIPTION
Sure, they denote that an OID is a function/procedure, and, in case of `regprocedure`, that function has certain arguments.

But the type itself does not convey the signature, which makes it not possible for us to call these function.

Solution: design "function signature types"

This type is also an OID but we also store information about its full signature and we validate on casts that the functions match the entire signature.

These makes these types represent the actual function signature, making them callable. One can compose them into interfaces through composite types.

---

Missing:

- [x] tests
- [x] documentation
- [x] extconfig (make sure the types will be dumped)