### PR TITLE
Problem: some functionality is not available on older Postgres (🚀 omni_polyfill 0.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Below is the current list of components being worked on, experimented with and d
 | [omni_txn](extensions/omni_txn/README.md)                                                   | :white_check_mark: First release candidate   | Transaction management                                |
 | [omni_python](extensions/omni_python/README.md)                                             | :ballot_box_with_check: Initial prototype    | First-class Python Development Experience             |
 | [omni_os](extensions/omni_os/README.md)                                                     | :ballot_box_with_check: Initial prototype    | Access to the operating system                        |
+| [omni_polyfill](extensions/omni_polyfill/README.md)                                         | :white_check_mark: First release             | Provides polyfills for older versions of Postgres     |
 | omni_git                                                                                    | :lab_coat: Early experiments (unpublished)   | Postgres Git client                                   |
 | omni_reactive                                                                               | :spiral_calendar: Haven't started yet        | Reactive queries                                      |
 

--- a/extensions/omni_polyfill/CHANGELOG.md
+++ b/extensions/omni_polyfill/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-08-23
+
+### Added
+
+* `trim_array` [#635](https://github.com/omnigres/omnigres/pull/635)
+
+[Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_polyfill
+
+[0.1.0]: [https://github.com/omnigres/omnigres/pull/635]

--- a/extensions/omni_polyfill/CMakeLists.txt
+++ b/extensions/omni_polyfill/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(omni_types)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
+
+include(CPM)
+include(CTest)
+
+enable_testing()
+
+find_package(PostgreSQL REQUIRED)
+
+add_postgresql_extension(
+        omni_polyfill
+        SOURCES omni_polyfill.c arrays.c
+)

--- a/extensions/omni_polyfill/README.md
+++ b/extensions/omni_polyfill/README.md
@@ -1,0 +1,3 @@
+# omni_polyfill
+
+This extension provides functions from newer Postgres versions to the older ones.

--- a/extensions/omni_polyfill/arrays.c
+++ b/extensions/omni_polyfill/arrays.c
@@ -1,0 +1,56 @@
+/**
+ * @file arrays.c
+ *
+ */
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+#include <utils/array.h>
+#include <utils/lsyscache.h>
+
+#if PG_MAJORVERSION_NUM < 14
+// `trim_array` has been extracted from Postgres. It is licensed under the terms of PostgreSQL
+// license.
+PG_FUNCTION_INFO_V1(trim_array);
+/*
+ * Trim the last N elements from an array by building an appropriate slice.
+ * Only the first dimension is trimmed.
+ */
+Datum trim_array(PG_FUNCTION_ARGS) {
+  ArrayType *v = PG_GETARG_ARRAYTYPE_P(0);
+  int n = PG_GETARG_INT32(1);
+  int array_length = (ARR_NDIM(v) > 0) ? ARR_DIMS(v)[0] : 0;
+  int16 elmlen;
+  bool elmbyval;
+  char elmalign;
+  int lower[MAXDIM];
+  int upper[MAXDIM];
+  bool lowerProvided[MAXDIM];
+  bool upperProvided[MAXDIM];
+  Datum result;
+
+  /* Per spec, throw an error if out of bounds */
+  if (n < 0 || n > array_length)
+    ereport(ERROR, (errcode(ERRCODE_ARRAY_ELEMENT_ERROR),
+                    errmsg("number of elements to trim must be between 0 and %d", array_length)));
+
+  /* Set all the bounds as unprovided except the first upper bound */
+  memset(lowerProvided, false, sizeof(lowerProvided));
+  memset(upperProvided, false, sizeof(upperProvided));
+  if (ARR_NDIM(v) > 0) {
+    upper[0] = ARR_LBOUND(v)[0] + array_length - n - 1;
+    upperProvided[0] = true;
+  }
+
+  /* Fetch the needed information about the element type */
+  get_typlenbyvalalign(ARR_ELEMTYPE(v), &elmlen, &elmbyval, &elmalign);
+
+  /* Get the slice */
+  result = array_get_slice(PointerGetDatum(v), 1, upper, lower, upperProvided, lowerProvided, -1,
+                           elmlen, elmbyval, elmalign);
+
+  PG_RETURN_DATUM(result);
+}
+#endif

--- a/extensions/omni_polyfill/docs/polyfills.md
+++ b/extensions/omni_polyfill/docs/polyfills.md
@@ -1,0 +1,5 @@
+# Polyfills
+
+## Polyfilled functions
+
+* [trim_array](https://www.postgresql.org/docs/current/functions-array.html)

--- a/extensions/omni_polyfill/migrate/1_arrays.sql
+++ b/extensions/omni_polyfill/migrate/1_arrays.sql
@@ -1,0 +1,15 @@
+do
+$$
+    declare
+        major_version int;
+    begin
+        major_version := split_part(current_setting('server_version'), '.', 1)::int;
+        if major_version < 14 then
+            create function trim_array(anyarray, integer) returns anyarray
+                immutable parallel safe
+                language c as
+            'MODULE_PATHNAME';
+            comment on function trim_array(anyarray, integer) is 'remove last N elements of array';
+        end if;
+    end;
+$$

--- a/extensions/omni_polyfill/mkdocs.yml
+++ b/extensions/omni_polyfill/mkdocs.yml
@@ -1,0 +1,2 @@
+INHERIT: ../../mkdocs.base.yml
+site_name: omni_polyfill

--- a/extensions/omni_polyfill/omni_polyfill.c
+++ b/extensions/omni_polyfill/omni_polyfill.c
@@ -1,0 +1,11 @@
+/**
+ * @file omni_polyfill.c
+ *
+ */
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
+PG_MODULE_MAGIC;

--- a/extensions/omni_polyfill/tests/arrays.yml
+++ b/extensions/omni_polyfill/tests/arrays.yml
@@ -1,0 +1,10 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_polyfill cascade
+
+tests:
+
+- query: select trim_array(array [1,2,3]::int[], 1) = array [1,2] res
+  results:
+  - res: true

--- a/versions.txt
+++ b/versions.txt
@@ -9,6 +9,7 @@ omni_json=0.1.0
 omni_manifest=0.1.0
 omni_mimetypes=0.1.0
 omni_os=0.1.0
+omni_polyfill=0.1.0
 omni_python=0.1.0
 omni_schema=0.2.0
 omni_seq=0.1.0


### PR DESCRIPTION
This time it is `trim_array` (available on Postgres 14+), but we're still supporting Postgres 13.

Solution: copy `trim_array` into the new `omni_polyfill` extension