### PR TITLE
Problem: sum types will not be included into pg_dump

### DIFF
--- a/extensions/omni_types/CHANGELOG.md
+++ b/extensions/omni_types/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.0] - TBD
 
+### Fixed
+
+* Sum types will be now included into `pg_dump`-produced dumps [#636](https://github.com/omnigres/omnigres/pull/636])
+
 ## [0.1.1] - 2024-08-19
 
 ### Fixed

--- a/extensions/omni_types/migrate/3_sum_type_extconfig.sql
+++ b/extensions/omni_types/migrate/3_sum_type_extconfig.sql
@@ -1,0 +1,1 @@
+select pg_catalog.pg_extension_config_dump('sum_types', '');


### PR DESCRIPTION
Solution: include `omni_types.sum_types` table into extconfig