### PR TITLE
Problem: failing to compile omni_seq in some cases

### DIFF
--- a/extensions/omni_seq/CHANGELOG.md
+++ b/extensions/omni_seq/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.1.1] - TBD
 
+### Fixed
+
+* Avoid failing to build in some setups [#637](https://github.com/omnigres/omnigres/pull/637])
+
 ## [0.1.0] - 2024-03-05
 
 Initial release following a few months of iterative development.

--- a/extensions/omni_seq/id.h
+++ b/extensions/omni_seq/id.h
@@ -34,7 +34,7 @@
 #include <utils/builtins.h>
 #if PG_MAJORVERSION_NUM >= 16
 #include "port/pg_bswap.h"
-#include "server/varatt.h"
+#include <varatt.h>
 #endif
 
 #define make_name__(name, prefix_len, val_len, suffix) name##_##prefix_len##_##val_len##suffix


### PR DESCRIPTION
In particular, compiling on Ubuntu Noble LTS against PGDG PostgreSQL 16 is failing with an error (not being able to find a header file)

Solution: adjust referenced header location

FindPostgreSQL cmake file already includes both client & server include directories. All we have to do is include the header we want without being specific about the path. This works with both RedHat and on Ubuntu PGDG packages. Server headers are a separate package on Ubuntu.