### PR TITLE
Problem: identity type functions are not parallel safe

### DIFF
--- a/extensions/omni_id/CHANGELOG.md
+++ b/extensions/omni_id/CHANGELOG.md
@@ -10,6 +10,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * Identity type functions made strict to avoid crashes on NULLs [#645](https://github.com/omnigres/omnigres/pull/645)
+* Identity type functions made parallel safe as their underlying
+  implementations [#646](https://github.com/omnigres/omnigres/pull/646)
 
 ## [0.3.0] - 2024-08-28
 

--- a/extensions/omni_id/src/identity_type.sql
+++ b/extensions/omni_id/src/identity_type.sql
@@ -63,16 +63,17 @@ begin
 
     -- Define in/out send/recv before we actually define the type
     -- (piggying back on the underlying type)
-    execute format('create function %I(cstring) returns %I language internal as %L immutable strict', name || '_in',
+    execute format('create function %I(cstring) returns %I language internal as %L immutable strict parallel safe',
+                   name || '_in',
                    name,
                    (case when type_name = 'uuid' then 'uuid_in' else type_name || 'in' end));
-    execute format('create function %I(%I) returns cstring language internal as %L immutable strict',
+    execute format('create function %I(%I) returns cstring language internal as %L immutable strict parallel safe',
                    name || '_out', name,
                    (case when type_name = 'uuid' then 'uuid_out' else type_name || 'out' end));
-    execute format('create function %I(%I) returns bytea language internal as %L immutable strict',
+    execute format('create function %I(%I) returns bytea language internal as %L immutable strict parallel safe',
                    name || '_send', name,
                    (case when type_name = 'uuid' then 'uuid_send' else type_name || 'send' end));
-    execute format('create function %I(internal) returns %I language internal as %L immutable strict',
+    execute format('create function %I(internal) returns %I language internal as %L immutable strict parallel safe',
                    name || '_recv', name,
                    (case when type_name = 'uuid' then 'uuid_recv' else type_name || 'recv' end));
 
@@ -100,7 +101,8 @@ begin
                             ('<>', 'ne')) operators(op, name)
         loop
             -- Define the function, again piggying back on the underlying type
-            execute format('create function %I(%2$I, %2$I) returns boolean language internal as %L immutable strict',
+            execute format(
+                    'create function %I(%2$I, %2$I) returns boolean language internal as %L immutable strict parallel safe',
                            name || '_' || rec.name, name,
                            (case when type_name = 'uuid' then 'uuid_' else type_name end) || rec.name);
 
@@ -114,7 +116,7 @@ begin
         end loop;
 
     -- Define a `cmp` function (again, piggy back on the underlying type)
-    execute format('create function %I(%I,%2$I) returns int language internal as %3$L immutable strict',
+    execute format('create function %I(%I,%2$I) returns int language internal as %3$L immutable strict parallel safe',
                    name || '_cmp', name,
                    (case when type_name = 'uuid' then 'uuid_cmp' else 'bt' || type_name || 'cmp' end));
 
@@ -194,7 +196,7 @@ begin
         end if;
 
         execute format(
-                'create function %1$I(value %2$I) returns %3$I language sql as $sql$ select value::%4$I.%3$I $sql$ immutable strict',
+                'create function %1$I(value %2$I) returns %3$I language sql as $sql$ select value::%4$I.%3$I $sql$ immutable strict parallel safe',
                 constructor, type_name, name, ns);
 
     end if;


### PR DESCRIPTION
Or so do the signatures say! This prevents parallelization optimizations.

Solution: mark them `parallel safe` as their underlying functions