### PR TITLE
Problem: authenticating users (🚀 omni_auth 0.1.0)

### DIFF
--- a/extensions/omni_auth/CHANGELOG.md
+++ b/extensions/omni_auth/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-09-25
+
+Initial release
+
+[Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_auth
+
+[0.1.0]: [https://github.com/omnigres/omnigres/pull/649]

--- a/extensions/omni_auth/CMakeLists.txt
+++ b/extensions/omni_auth/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(omni_json)
+
+include(CTest)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
+
+enable_testing()
+
+find_package(PostgreSQL REQUIRED)
+
+add_postgresql_extension(
+        omni_auth
+        SCHEMA omni_auth
+        REQUIRES omni_types omni_id pgcrypto btree_gist
+        RELOCATABLE false)

--- a/extensions/omni_auth/README.md
+++ b/extensions/omni_auth/README.md
@@ -1,0 +1,3 @@
+# omni_session
+
+Basic session management.

--- a/extensions/omni_auth/docs/basics.md
+++ b/extensions/omni_auth/docs/basics.md
@@ -1,0 +1,39 @@
+# Basics
+
+This extension provides primitives for building authentication systems.
+
+Currently supported authentication methods:
+
+* [Password](password.md)
+
+## Authentication Subject
+
+Authentication subject is a provisional term for subject of authentication, such as user.
+
+Note, however, that we treat it a bit more broadly. For example, an unrecognized identifier (such as login
+or e-mail) can also be an authentication subject. This way we can track attempts to authenticate against
+a non-existent user.
+
+This can also be useful in the context where we are doing an authentication for a user that does not yet exist,
+especially in the context of third-party OAuth authentications-as-signups.
+
+## High-level Interface
+
+### Authentication
+
+`omni_auth.authenticate(Authenticator, authentication_subject_id)` function, dispatched over `Authenticator` types,
+returns a value of an `Authentication` type that implements `omni_auth.successful_authentication` (see below)
+
+Implementations:
+
+* [Password](password.md#authenticating)
+
+### Successful Authentication
+
+`omni_auth.successful_authentication(Authentication)` returns a boolean that signifies success of authentication.
+
+Implementation
+
+* [Password](password.md#authenticating)
+
+

--- a/extensions/omni_auth/docs/password.md
+++ b/extensions/omni_auth/docs/password.md
@@ -1,0 +1,78 @@
+# Password Authentication
+
+Features:
+
+* Hash-based verification (**bcrypt**, _more algorithms pending_)
+* Password authentication attempt audit trail
+* Temporal password management
+
+## Password Credentials
+
+`omni_auth.password_credentials` table is a temporally-enabled table that contains hashed passwords
+for [authentication subjects](basics.md#authentication-subject).
+
+For every given `authentication_subject_id` there may be _zero_ or _one_ `hashed_password` for any non-overlapping
+timestamp-period. The latest valid value is denoted by `valid_at` that includes current timestamp.
+
+## Setting a password
+
+Considering the temporality of passwords, `omni_auth` provides a function that encapsulates the complexity of managing
+passwords. It will:
+
+* create a new password if none is available
+* make "current" password a "historic" one by setting its validity until the validity of the new one
+* validate that the old password is matching, if supplied
+* ensure that the new password has the same upper bound of validity as the "current" one
+* allow to specify the validity period for the new password explicitly
+
+The most common scenario is to set a password
+
+```postgresql
+select omni_auth.set_password(authentication_subject_id, password, [old_password])
+```
+
+|                     Parameter | Type                                | Description                                                                               |
+|------------------------------:|-------------------------------------|-------------------------------------------------------------------------------------------|
+| **authentication_subject_id** | omni_auth.authentication_subject_id | Authentication Subject ID to set password for                                             |
+|                  **password** | omni_auth.password                  | New password to set                                                                       |
+|              **old_password** | omni_auth.password                  | Old password to check against (optional)                                                  |
+|                **valid_from** | timestamptz                         | New password should be valid from, inclusive (optional)                                   |
+|               **valid_until** | timestamptz                         | New password should be valid until, exclusive (optional, default `statement_timestamp()`) |
+|         **hashing_algorithm** | omni_auth.hashing_algorithm         | Hashing algorithm for the new password (optional, using the default one)                  |
+|               **work_factor** | int                                 | Hashing algorithm work factor (optional)                                                  |
+
+## Authenticating
+
+To attempt authentication with a given password for an authentication subject, use the following function
+
+```postgresql
+select omni_auth.authenticate(password, authentication_subject_id, [as_of])
+```
+
+It will return a record of the `omni_auth.password_authentications` type, which can be verified for success using
+[`omni_auth.successful_authentication()`](basics.md#successful-authentication).
+
+!!! tip "Temporal authentication"
+
+    `as_of` parameter (of `timestamptz` type) can be used to authenticate against a password that could have been
+    available at that point in time.
+
+## Hashed Password
+
+`omni_auth.hash_password` provides a facility to create values of the `omni_auth.hashed_password` type which is used
+in the [`omni_auth.password_credentials` table](#password-credentials). This is typically not needed if [
+`omni_auth.set_password`](#setting-a-password) is used.
+
+### Work Factor Calibration
+
+OWASP recommends that the hashing function takes about a second for a balance of usability and security aspects.
+However, on different computers, different work factors may result in different timing. To address this, `omni_auth`
+provides a materialized view `omni_auth.password_work_factor_timings` (unpopulated at first) that will provide timings
+for supported algorithms for different work factors (by default capped at 1.5 seconds).
+
+`omni_auth` attempts to set sensible defaults in absence of populated data in `omni_auth.password_work_factor_timings`,
+but it can be modified using the following variables:
+
+|                    Variable name | Description                                 |
+|---------------------------------:|---------------------------------------------|
+| **omni_auth.bcrypt_work_factor** | **bcrypt** work factor (defaults to **12**) |

--- a/extensions/omni_auth/migrate/1_basics.sql
+++ b/extensions/omni_auth/migrate/1_basics.sql
@@ -1,0 +1,19 @@
+select identity_type('authentication_subject_id', type => 'uuid', nextval => 'uuidv7');
+
+create table authentication_subjects
+(
+    id authentication_subject_id not null primary key default authentication_subject_id_nextval()
+);
+
+select pg_catalog.pg_extension_config_dump('authentication_subjects', '');
+
+comment on table authentication_subjects is $$
+Authentication subject is a provisional term for subject of authentication, such as user.
+
+Note, however, that we treat it a bit more broadly. For example, an unrecognized identifier (such as login
+or e-mail) can also be an authentication subject. This way we can track attempts to authenticate against
+a non-existent user.
+
+This can also be useful in the context where we are doing an authentication for a user that does not yet exist,
+especially in the context of third-party OAuth authentications-as-signups.
+$$;

--- a/extensions/omni_auth/migrate/2_password.sql
+++ b/extensions/omni_auth/migrate/2_password.sql
@@ -1,0 +1,67 @@
+create domain password varchar(255);
+
+create type hashing_algorithm as enum ('bcrypt');
+
+create domain hashed_password text check (
+    -- bcrypt
+    value ~ '^\$2[aby]\$[0-9]{2}\$[./A-Za-z0-9]{53}$'
+    );
+
+/*{% include "../src/work_factor.sql" %}*/
+/*{% include "../src/hashing_algorithm.sql" %}*/
+
+/*{% include "../src/hash_password.sql" %}*/
+
+select identity_type('password_credential_id', type => 'uuid', nextval => 'uuidv7');
+
+create table password_credentials
+(
+    id password_credential_id not null default password_credential_id_nextval(),
+    authentication_subject_id authentication_subject_id not null references authentication_subjects (id),
+    hashed_password hashed_password not null,
+    valid_at        tstzrange not null default tstzrange(statement_timestamp(), 'infinity'),
+    constraint password_credentials_valid_at_no_overlap exclude using gist ((authentication_subject_id::uuid) with =, valid_at with &&)
+);
+
+/*{% include "../src/set_password.sql" %}*/
+
+comment on table password_credentials is $$
+Password credentials are temporally-constrained hashed passwords for authentication subjects
+$$;
+
+select pg_catalog.pg_extension_config_dump('password_credentials', '');
+
+select identity_type('password_authentication_attempt_id', type => 'uuid', nextval => 'uuidv7');
+
+--- We store password authentication attempts for detecting suspicious behavior
+--- Example: HIPAA § 164.308(a)(5)(ii)(C)
+
+create table password_authentication_attempts
+(
+    id                        password_authentication_attempt_id not null primary key default password_authentication_attempt_id_nextval(),
+    authentication_subject_id authentication_subject_id references authentication_subjects (id),
+    hashed_password        hashed_password,
+    success     boolean   not null,
+    occurred_at timestamp not null default statement_timestamp()
+);
+
+select pg_catalog.pg_extension_config_dump('password_authentication_attempts', '');
+
+/*{% include "../src/authenticate_password.sql" %}*/
+
+/*{% include "../src/successful_authentification_password_authentication_attempts.sql" %}*/
+
+-- Informational section
+
+--- To determine appropriate work factor, it would be useful to have some information on how long does it take to hash
+--- for any given algorithm and work factor. OWASP suggestion is to target under 1s for hashing to ensure decent user experience
+--- (https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#using-work-factors)
+
+/*{% include "../src/password_work_factor_timings.sql" %}*/
+
+create materialized view password_work_factor_timings as
+select *
+from password_work_factor_timings() with no data;
+
+create unique index password_work_factor_timings_idx on password_work_factor_timings (algorithm, work_factor, iteration);
+

--- a/extensions/omni_auth/mkdocs.yml
+++ b/extensions/omni_auth/mkdocs.yml
@@ -1,0 +1,2 @@
+INHERIT: ../../mkdocs.base.yml
+site_name: omni_auth

--- a/extensions/omni_auth/src/authenticate_password.sql
+++ b/extensions/omni_auth/src/authenticate_password.sql
@@ -1,0 +1,36 @@
+create function authenticate(password password, auth_subject_id authentication_subject_id,
+                             as_of timestamptz default statement_timestamp())
+    returns password_authentication_attempts
+    language plpgsql
+as
+$$
+declare
+    result omni_auth.password_authentication_attempts;
+begin
+    with credentials as (select hashed_password
+                         from omni_auth.password_credentials
+                         where valid_at @> as_of
+                           and authentication_subject_id = auth_subject_id),
+         validation as (select auth_subject_id as subject_id,
+                               hashed_password,
+                               case
+                                   when omni_auth.hashing_algorithm(hashed_password) = 'bcrypt' then
+                                       crypt(password, hashed_password)
+                                   -- unknown algorithm, pretend we're still doing hashing
+                                   else omni_auth.hash_password(password)
+                                   end as hashed_attempted_password
+                        from credentials
+                        -- otherwise, pretend to do work
+                        union
+                        select null as subject_id, '', omni_auth.hash_password(password)
+                        where not exists (select from credentials))
+    insert
+    into omni_auth.password_authentication_attempts (authentication_subject_id, hashed_password, success)
+    select subject_id,
+           hashed_attempted_password,
+           hashed_attempted_password = hashed_password
+    from validation
+    returning * into result;
+    return result;
+end
+$$;

--- a/extensions/omni_auth/src/hash_password.sql
+++ b/extensions/omni_auth/src/hash_password.sql
@@ -1,0 +1,28 @@
+create function hash_password(password password, hashed_password hashed_password default null,
+                              hashing_algorithm hashing_algorithm default 'bcrypt',
+                              work_factor integer default null)
+    returns hashed_password
+    language plpgsql
+    parallel safe
+as
+$$
+declare
+    _hashed_password omni_auth.hashed_password;
+begin
+    if hashed_password is not null then
+        hashing_algorithm := omni_auth.hashing_algorithm(hashed_password);
+        work_factor := omni_auth.work_factor(hashed_password);
+    end if;
+    if hashing_algorithm = 'bcrypt' then
+        work_factor :=
+                coalesce(work_factor, coalesce(current_setting('omni_auth.bcrypt_work_factor', true), 12::text)::int);
+        _hashed_password := crypt(password, coalesce(hashed_password, gen_salt('bf'::text, work_factor)));
+        if hashed_password is not null and _hashed_password != hashed_password then
+            return null;
+        end if;
+        return _hashed_password;
+    else
+        raise exception 'Unknown or missing hashing_algorithm';
+    end if;
+end;
+$$;

--- a/extensions/omni_auth/src/hashing_algorithm.sql
+++ b/extensions/omni_auth/src/hashing_algorithm.sql
@@ -1,0 +1,10 @@
+create function hashing_algorithm(hashed_password hashed_password) returns hashing_algorithm
+    language sql
+    immutable parallel safe as
+$$
+select case
+           when hashed_password ~ '^\$2[aby]\$' then
+               'bcrypt'
+           else null::omni_auth.hashing_algorithm
+           end
+$$;

--- a/extensions/omni_auth/src/password_work_factor_timings.sql
+++ b/extensions/omni_auth/src/password_work_factor_timings.sql
@@ -1,0 +1,42 @@
+create function password_work_factor_timings(iterations int default 3, timeout_ms double precision default 1500)
+    returns table
+            (
+                algorithm       hashing_algorithm,
+                work_factor     int,
+                iteration       int,
+                time_elapsed_ms double precision
+            )
+    language plpgsql
+    parallel safe
+as
+$$
+declare
+    current_work_factor int;
+    current_iteration   int;
+    start_time          timestamp;
+    end_time            timestamp;
+begin
+    -- bcrypt
+    algorithm := 'bcrypt';
+
+    for current_work_factor in 10..31
+        loop
+            for current_iteration in 1..iterations
+                loop
+                    work_factor := current_work_factor;
+                    iteration := current_iteration;
+                    start_time := clock_timestamp();
+                    perform omni_auth.hash_password('password', hashing_algorithm => algorithm,
+                                                    work_factor => current_work_factor);
+                    end_time := clock_timestamp();
+                    time_elapsed_ms := (extract(epoch from end_time) - extract(epoch from start_time)) * 1000;
+                    if time_elapsed_ms >= timeout_ms then
+                        return;
+                    end if;
+                    return next;
+                end loop;
+        end loop;
+    return;
+
+end;
+$$;

--- a/extensions/omni_auth/src/set_password.sql
+++ b/extensions/omni_auth/src/set_password.sql
@@ -1,0 +1,60 @@
+create function set_password(authentication_subject_id authentication_subject_id, password password,
+                             old_password password default null,
+                             valid_from timestamptz default statement_timestamp(),
+                             valid_until timestamptz default null,
+                             hashing_algorithm hashing_algorithm default 'bcrypt',
+                             work_factor integer default null)
+    returns password_credentials
+    language plpgsql
+as
+$$
+declare
+    result           omni_auth.password_credentials;
+    _hashed_password omni_auth.hashed_password;
+begin
+    _hashed_password :=
+            omni_auth.hash_password(password, hashing_algorithm => hashing_algorithm, work_factor => work_factor);
+    with existing_credential as (select *
+                                 from omni_auth.password_credentials
+                                 where password_credentials.authentication_subject_id =
+                                       set_password.authentication_subject_id
+                                   and valid_at @> statement_timestamp()),
+         credential as (select omni_auth.password_credential_id_nextval(),
+                               existing_credential.authentication_subject_id,
+                               case
+                                   when old_password is null then _hashed_password
+                                   when old_password is not null and omni_auth.hash_password(password => old_password,
+                                                                                             hashed_password => hashed_password) is not null
+                                       then
+                                       _hashed_password
+                                   else
+                                       null
+                                   end,
+                               tstzrange(valid_from, coalesce(valid_until, upper(valid_at)))
+                        from existing_credential
+                        union
+                        select omni_auth.password_credential_id_nextval(),
+                               authentication_subject_id,
+                               _hashed_password,
+                               tstzrange(valid_from, coalesce(valid_until, 'infinity'))
+                        where not exists (select from existing_credential)),
+         update_validity
+             as (update omni_auth.password_credentials set valid_at = tstzrange(lower(password_credentials.valid_at),
+                                                                                valid_from) from existing_credential where password_credentials.id = existing_credential.id returning password_credentials.*),
+         update as (select *
+                    from update_validity
+                    union
+                    select (null::omni_auth.password_credentials).*
+                    where not exists (select from update_validity))
+    insert
+    into omni_auth.password_credentials
+    select credential.*
+    from credential,
+         update
+    returning password_credentials.* into result;
+    return result;
+exception
+    when not_null_violation then
+        raise exception 'incorrect old_password';
+end;
+$$;

--- a/extensions/omni_auth/src/successful_authentification_password_authentication_attempts.sql
+++ b/extensions/omni_auth/src/successful_authentification_password_authentication_attempts.sql
@@ -1,0 +1,8 @@
+create function successful_authentication(password_authentication_attempts)
+    returns boolean
+    language sql
+    immutable parallel safe
+as
+$$
+select ($1).success
+$$;

--- a/extensions/omni_auth/src/work_factor.sql
+++ b/extensions/omni_auth/src/work_factor.sql
@@ -1,0 +1,10 @@
+create function work_factor(hashed_password hashed_password) returns int
+    language sql
+    immutable parallel safe as
+$$
+select case
+           when omni_auth.hashing_algorithm(hashed_password) = 'bcrypt' then
+               split_part(hashed_password, '$', 3)::int
+           else null
+           end
+$$;

--- a/extensions/omni_auth/tests/passwords.yaml
+++ b/extensions/omni_auth/tests/passwords.yaml
@@ -1,0 +1,119 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_auth cascade
+  - refresh materialized view omni_auth.password_work_factor_timings
+  - |
+    create table users
+    (
+        id                        serial,
+        authentication_subject_id omni_auth.authentication_subject_id references omni_auth.authentication_subjects (id),
+        identifier                text not null unique
+    )
+  - |
+    create table unrecognized_identifiers
+    (
+        id                        serial,
+        authentication_subject_id omni_auth.authentication_subject_id references omni_auth.authentication_subjects (id),
+        identifier                text not null unique
+    )
+  - |
+    with subject as (insert into omni_auth.authentication_subjects default values returning id)
+    insert
+    into users (authentication_subject_id, identifier)
+    select subject.id, 'alice'
+    from subject
+  - |
+    with subject as (insert into omni_auth.authentication_subjects default values returning id)
+    insert
+    into users (authentication_subject_id, identifier)
+    select subject.id, 'bob'
+    from subject
+  - |
+    select omni_auth.set_password(authentication_subject_id, identifier || '_password')
+    from users
+
+tests:
+
+- name: successful authentication
+  steps:
+  - name: validate successful authentication
+    query: |
+      select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password',
+                                                                        authentication_subject_id)) success
+      from users
+    results:
+    - success: true
+    - success: true
+  - name: check that it took an expected amount of time
+    query: |
+      select timing >= (2 * min(time_elapsed_ms)) / 100 * 85 and timing <= (3 * min(time_elapsed_ms)) / 100 * 115
+                 as result
+      from omni_auth.password_work_factor_timings
+               cross join lateral ( select extract(milliseconds from clock_timestamp() - transaction_timestamp()) as timing ) t
+      where work_factor in (select omni_auth.work_factor(hashed_password) from omni_auth.password_credentials)
+      group by timing
+    results:
+    - result: true
+  - name: check the attempts
+    query: |
+      select success
+      from omni_auth.authentication_subjects
+               inner join omni_auth.password_authentication_attempts paa
+                          on paa.authentication_subject_id = authentication_subjects.id
+    results:
+    - success: true
+    - success: true
+
+- name: unsuccessful authentication
+  steps:
+  - name: validate unsuccessful authentication
+    query: |
+      select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_wrong_password',
+                                                                        authentication_subject_id)) success
+      from users
+    results:
+    - success: false
+    - success: false
+  - name: check that it took an expected amount of time
+    query: |
+      select timing >= (2 * min(time_elapsed_ms)) / 100 * 85 and timing <= (3 * min(time_elapsed_ms)) / 100 * 115
+                 as result
+      from omni_auth.password_work_factor_timings
+               cross join lateral ( select extract(milliseconds from clock_timestamp() - transaction_timestamp()) as timing ) t
+      where work_factor in (select omni_auth.work_factor(hashed_password) from omni_auth.password_credentials)
+      group by timing
+    results:
+    - result: true
+  - name: check the attempts
+    query: |
+      select success
+      from omni_auth.authentication_subjects
+               inner join omni_auth.password_authentication_attempts paa
+                          on paa.authentication_subject_id = authentication_subjects.id
+    results:
+    - success: false
+    - success: false
+
+- name: unsuccessful authentication (null authentication_subject_id)
+  steps:
+  - name: validate unsuccessful authentication
+    query: |
+      select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_whatever_password',
+                                                                        null)) success
+      from users
+    results:
+    - success: false
+    - success: false
+  - name: check that it took an expected amount of time
+    query: |
+      select clock_timestamp() - transaction_timestamp() >=
+             make_interval(secs => 2 * min(time_elapsed_ms) / 1000)
+                 and
+             clock_timestamp() - transaction_timestamp() <
+             make_interval(secs => 3 * ceil(max(time_elapsed_ms) / 1000))
+                 as result
+      from omni_auth.password_work_factor_timings
+      where work_factor in (select omni_auth.work_factor(hashed_password) from omni_auth.password_credentials)
+    results:
+    - result: true

--- a/extensions/omni_auth/tests/set_password.yaml
+++ b/extensions/omni_auth/tests/set_password.yaml
@@ -1,0 +1,220 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_auth cascade
+  - |
+    create table users
+    (
+        id                        serial,
+        authentication_subject_id omni_auth.authentication_subject_id references omni_auth.authentication_subjects (id),
+        identifier                text not null unique
+    )
+  - |
+    create table unrecognized_identifiers
+    (
+        id                        serial,
+        authentication_subject_id omni_auth.authentication_subject_id references omni_auth.authentication_subjects (id),
+        identifier                text not null unique
+    )
+  - |
+    with subject as (insert into omni_auth.authentication_subjects default values returning id)
+    insert
+    into users (authentication_subject_id, identifier)
+    select subject.id, 'alice'
+    from subject
+
+tests:
+
+- name: setting new password
+  steps:
+  - name: empty password credentials
+    query: select count(*)
+           from omni_auth.password_credentials
+    results:
+    - count: 0
+  - |
+    select omni_auth.set_password(authentication_subject_id, identifier || '_password')
+    from users
+  - name: new password credential
+    query: select count(*)
+           from omni_auth.password_credentials
+    results:
+    - count: 1
+  - name: try to authenticate
+    query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password',
+                                                                             authentication_subject_id)) as result
+           from users
+    results:
+    - result: true
+- name: try to authenticate in the past
+  query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password',
+                                                                           authentication_subject_id,
+                                                                           as_of => transaction_timestamp() - interval '1 second')) as result
+         from users
+  results:
+  - result: false
+
+
+- name: setting new password that is not valid yet
+  steps:
+  - name: empty password credentials
+    query: select count(*)
+           from omni_auth.password_credentials
+    results:
+    - count: 0
+  - |
+    select omni_auth.set_password(authentication_subject_id, identifier || '_password',
+                                  valid_from => statement_timestamp() + '2 minutes')
+    from users
+  - name: new password credential
+    query: select count(*)
+           from omni_auth.password_credentials
+    results:
+    - count: 1
+  - name: try to authenticate
+    query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password',
+                                                                             authentication_subject_id)) as result
+           from users
+    results:
+    - result: false
+  - name: try to authenticate
+    query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password',
+                                                                             authentication_subject_id,
+                                                                             as_of => statement_timestamp() + '2 minutes')) as result
+           from users
+    results:
+    - result: true
+
+- name: setting new password with limited validity
+  steps:
+  - name: empty password credentials
+    query: select count(*)
+           from omni_auth.password_credentials
+    results:
+    - count: 0
+  - |
+    select omni_auth.set_password(authentication_subject_id, identifier || '_password',
+                                  valid_until => statement_timestamp() + '2 minutes')
+    from users
+  - name: new password credential
+    query: select count(*)
+           from omni_auth.password_credentials
+    results:
+    - count: 1
+  - name: try to authenticate
+    query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password',
+                                                                             authentication_subject_id)) as result
+           from users
+    results:
+    - result: true
+  - name: try to authenticate
+    query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password',
+                                                                             authentication_subject_id,
+                                                                             as_of => statement_timestamp() + '2 minutes')) as result
+           from users
+    results:
+    - result: false
+
+
+- name: updating a password
+  steps:
+  - |
+    select omni_auth.set_password(authentication_subject_id, identifier || '_password')
+    from users
+  - name: new password credential
+    query: select count(*)
+           from omni_auth.password_credentials
+    results:
+    - count: 1
+  - |
+    select omni_auth.set_password(authentication_subject_id, identifier || '_password1')
+    from users
+  - name: updated password credential
+    query: select count(*)
+           from omni_auth.password_credentials
+    results:
+    - count: 2
+  - name: try to authenticate
+    query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password1',
+                                                                             authentication_subject_id)) as result
+           from users
+    results:
+    - result: true
+  - name: try to authenticate with a previous password
+    query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password',
+                                                                             authentication_subject_id)) as result
+           from users
+    results:
+    - result: false
+
+- name: updating a password (with old_password)
+  steps:
+  - |
+    select omni_auth.set_password(authentication_subject_id, identifier || '_password')
+    from users
+  - |
+    select omni_auth.set_password(authentication_subject_id, identifier || '_password1',
+                                  old_password => identifier || '_password')
+    from users
+  - name: updated password credential
+    query: select count(*)
+           from omni_auth.password_credentials
+    results:
+    - count: 2
+  - name: try to authenticate
+    query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password1',
+                                                                             authentication_subject_id)) as result
+           from users
+    results:
+    - result: true
+  - name: try to authenticate with a previous password
+    query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password',
+                                                                             authentication_subject_id)) as result
+           from users
+    results:
+    - result: false
+  - name: try setting password with the wrong old password
+    query: |
+      select omni_auth.set_password(authentication_subject_id, identifier || '_password1',
+                                    old_password => identifier || '_password')
+      from users
+    error: incorrect old_password
+
+- name: updating a password with limited validity
+  steps:
+  - |
+    select omni_auth.set_password(authentication_subject_id, identifier || '_password',
+                                  valid_until => transaction_timestamp() + '2 minutes')
+    from users
+  - name: new password credential
+    query: select count(*)
+           from omni_auth.password_credentials
+    results:
+    - count: 1
+  - |
+    select omni_auth.set_password(authentication_subject_id, identifier || '_password1')
+    from users
+  - name: updated password credential
+    query: select count(*)
+           from omni_auth.password_credentials
+    results:
+    - count: 2
+  - name: try to authenticate
+    query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password1',
+                                                                             authentication_subject_id)) as result
+           from users
+    results:
+    - result: true
+  - name: try to authenticate with a new (but expired) password
+    query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password1',
+                                                                             authentication_subject_id,
+                                                                             as_of => transaction_timestamp() + '2 minutes')) as result
+           from users
+    results:
+    - result: false
+  - name: try to authenticate with the old password (shouldn't work either)
+    query: select omni_auth.successful_authentication(omni_auth.authenticate(identifier || '_password',
+                                                                             authentication_subject_id)) as result
+           from users
+    results:
+    - result: false

--- a/versions.txt
+++ b/versions.txt
@@ -1,5 +1,6 @@
 omni=0.1.4
 omni_aws=0.1.0
+omni_auth=0.1.0
 omni_containers=0.1.0
 omni_http=0.1.0
 omni_httpc=0.1.1


### PR DESCRIPTION
While not a problem in itself, the fact that every application has to do it, leads to regular reinvention of the wheel.

Solution: design omni_auth to be a common building block

At the first go, it only supports password-based authentication and only supports bcrypt for hashing. More methods and hashing algorithms are to be added later.