### PR TITLE
Problem: uploading files to S3 from the browser (🚀 omni_aws 0.1.1)

### DIFF
--- a/extensions/omni_aws/CHANGELOG.md
+++ b/extensions/omni_aws/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - 2024-10-14
+
+### Added
+
+* Support for pre-signed URLs for uploading [#659](https://github.com/omnigres/omnigres/pull/659)
+
+## [0.1.0] - 2024-03-05
+
+Initial release following a few months of iterative development.
+
+[Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_aws
+
+[0.1.0]: [https://github.com/omnigres/omnigres/pull/511]
+
+[0.1.1]: [https://github.com/omnigres/omnigres/pull/659]

--- a/extensions/omni_aws/src/s3_presigned_url.sql
+++ b/extensions/omni_aws/src/s3_presigned_url.sql
@@ -5,7 +5,8 @@ create function
                      secret_access_key text,
                      expires int default 604800, -- 7 days
                      region text default 'us-east-1',
-                     endpoint s3_endpoint default omni_aws.aws_s3_endpoint()
+                     endpoint s3_endpoint default omni_aws.aws_s3_endpoint(),
+                     method omni_http.http_method default 'GET'
 ) returns text
     language plpgsql
     immutable
@@ -49,7 +50,7 @@ begin
             region,
             's3',
             omni_aws.hash_canonical_request(
-                    'GET',
+                    method::text,
                     path,
                     'X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=' || omni_web.url_encode(credential) ||
                     '&X-Amz-Date=' || amz_date || '&X-Amz-Expires=' || expires || '&X-Amz-SignedHeaders=host',

--- a/extensions/omni_aws/tests/minio.yml
+++ b/extensions/omni_aws/tests/minio.yml
@@ -199,6 +199,25 @@ tests:
                                                                                       from
                                                                                           minio)))
 
+- name: uploading to a pre-signed url
+  query: |
+    select error
+    from
+        omni_httpc.http_execute(omni_httpc.http_request((select omni_aws.s3_presigned_url(bucket => 'omnigres-dev-test',
+                                                                                          path => '/presigned-test',
+                                                                                          access_key_id => 'minioadmin',
+                                                                                          secret_access_key => 'minioadmin',
+                                                                                          method => 'PUT',
+                                                                                          endpoint => omni_aws.s3_endpoint(
+                                                                                                  'http://' ||
+                                                                                                  host_addr() ||
+                                                                                                  ':' ||
+                                                                                                  (select inspect -> 'NetworkSettings' -> 'Ports' -> '9000/tcp' -> 0 ->> 'HostPort'
+                                                                                                   from minio))
+                                                                )), method => 'PUT', body => 'Presigned'))
+  results:
+  - error: null
+
 - name: list objects
   query: |
     select
@@ -219,6 +238,9 @@ tests:
   results:
   - key: bin
     size: 2
+    storage_class: STANDARD
+  - key: presigned-test
+    size: 9
     storage_class: STANDARD
   - key: t est
     size: 4

--- a/versions.txt
+++ b/versions.txt
@@ -1,5 +1,5 @@
 omni=0.2.0
-omni_aws=0.1.0
+omni_aws=0.1.1
 omni_auth=0.1.1
 omni_containers=0.1.0
 omni_http=0.1.0


### PR DESCRIPTION
This requires the file to be uploaded to the backend (Omnigres) and then sent to S3. This introduces an unnecessary step and potential failures (and handling them)

Solution: provide support for pre-signing upload URLs