### PR TITLE
Problem: pg_yregress ignores `notices` key

### DIFF
--- a/pg_yregress/CHANGELOG.md
+++ b/pg_yregress/CHANGELOG.md
@@ -12,6 +12,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Test query parameters (`params`) may have been passed with trailing data from the test suite because scalars were
   processed without their length. This could have led to sending superfluous trailing data to Postgres.
+* When no notices were received, any `notices` key was effectively ignored, leading to
+  potentially wrong tests [#667](https://github.com/omnigres/omnigres/pull/667).
 
 ## [0.3.0]
 

--- a/pg_yregress/test.c
+++ b/pg_yregress/test.c
@@ -506,9 +506,8 @@ proceed:
 
   struct fy_node *notices_key = fy_node_create_scalar(doc, STRLIT("notices"));
 
-  // If there are notices and `notices` key is declared
-  if (!fy_node_sequence_is_empty(notices) &&
-      fy_node_mapping_lookup_key_by_key(test->node, notices_key) != NULL) {
+  // Merge notices
+  if (fy_node_mapping_lookup_key_by_key(test->node, notices_key) != NULL) {
     // Replace `notices` with received notices
     fy_node_mapping_remove_by_key(test->node, fy_node_copy(doc, notices_key));
     fy_node_mapping_append(test->node, notices_key, notices);

--- a/pg_yregress/test.yml
+++ b/pg_yregress/test.yml
@@ -171,15 +171,16 @@ tests:
           raise notice 'test 1';
         end;
       $$ language plpgsql
+    notices:
+    - test 1
   - query: |
       do $$
         begin
           raise notice 'test 2';
         end;
       $$ language plpgsql
-  notices:
-  - test 1
-  - test 2
+    notices:
+    - test 2
 
 - name: multi-step notices (individual)
   steps:


### PR DESCRIPTION
When no notices are received from the server, it looks like as if all notices expected were received, which is clearly incorrect.

Solution: ensure we always compare notices