### PR TITLE
Problem: integration with the rest of the world (🚀 omni_kube 0.1.0, omni_httpc 0.1.3)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -141,6 +141,23 @@ jobs:
           platforms: linux/${{ matrix.platform }}
           target: builder
 
+      - name: Build and push omnikube Docker image
+        id: build-and-push-omnikube
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-kube:${{ github.sha }}-${{ matrix.platform }}
+          provenance: false
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,url=http://127.0.0.1:49160/
+          cache-to: type=gha,url=http://127.0.0.1:49160/
+          build-args: |
+            BUILD_PARALLEL_LEVEL=4
+          platforms: linux/${{ matrix.platform }}
+          target: omnikube
+
         #       # Sign the resulting Docker image digest except on PRs.
         #       # This will only write to the public Rekor transparency log when the Docker
         #       # repository is public to avoid leaking data.  If you would like to publish
@@ -156,7 +173,7 @@ jobs:
   manifest:
     strategy:
       matrix:
-        flavor: [ "", "-slim", "-dev" ]
+        flavor: [ "", "-slim", "-dev","-kube" ]
 
     if: github.event_name != 'pull_request' && github.repository == 'omnigres/omnigres'
     needs: build

--- a/docker/initdb-omnikube/001-settings.sql.templ
+++ b/docker/initdb-omnikube/001-settings.sql.templ
@@ -1,0 +1,2 @@
+alter system set max_worker_processes = 64;
+alter system set shared_preload_libraries = '$OMNI_SO_FILE';

--- a/docker/initdb-omnikube/002-restart.sh.templ
+++ b/docker/initdb-omnikube/002-restart.sh.templ
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+#
+pg_ctl -D "$PGDATA" restart

--- a/docker/initdb-omnikube/003-default-extensions.sql.templ
+++ b/docker/initdb-omnikube/003-default-extensions.sql.templ
@@ -1,0 +1,1 @@
+create extension omni_kube cascade;

--- a/docker/initdb-omnikube/004-default-search_path.sql.templ
+++ b/docker/initdb-omnikube/004-default-search_path.sql.templ
@@ -1,0 +1,1 @@
+alter role omnikube set search_path to 'omni_kube';

--- a/extensions/omni_httpc/CHANGELOG.md
+++ b/extensions/omni_httpc/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Addded
 
 * Support for custom CA certificates [#676](https://github.com/omnigres/omnigres/pull/676)
+* Support for custom client certificates [#676](https://github.com/omnigres/omnigres/pull/676)
 * An option to ignore self-signed certificates [#676](https://github.com/omnigres/omnigres/pull/676)
 
 ## [0.1.2] - 2024-09-27

--- a/extensions/omni_httpc/CHANGELOG.md
+++ b/extensions/omni_httpc/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - TBD
+
+### Addded
+
+* Support for custom CA certificates [#676](https://github.com/omnigres/omnigres/pull/676)
+* An option to ignore self-signed certificates [#676](https://github.com/omnigres/omnigres/pull/676)
+
 ## [0.1.2] - 2024-09-27
 
 ### Added
@@ -21,10 +28,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial release following a few months of iterative development.
 
-[Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_httpd
+[Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_httpc
 
 [0.1.0]: [https://github.com/omnigres/omnigres/pull/511]
 
 [0.1.1]: [https://github.com/omnigres/omnigres/pull/578]
 
 [0.1.2]: [https://github.com/omnigres/omnigres/pull/650]
+
+[0.1.3]: [https://github.com/omnigres/omnigres/pull/676]

--- a/extensions/omni_httpc/docs/reference.md
+++ b/extensions/omni_httpc/docs/reference.md
@@ -195,14 +195,16 @@ headers      | {"(age,500311)","(cache-control,max-age=604800)","(content-type,\
 
 #### Options
 
-|                    Option | Type     | Description                                                            | Default |
-|--------------------------:|----------|------------------------------------------------------------------------|---------|
-|           **http2_ratio** | smallint | Percentage of requests to be attempted with HTTP/2 `(0..100)` [^ratio] | `0`     |
-|           **http3_ratio** | smallint | Percentage of requests to be attempted with HTTP/3 `(0..100)` [^ratio] | `0`     |
-| **force_cleartext_http2** | bool     | Allow HTTP/2 to be used without SSL                                    | `false` |
-|    **first_byte_timeout** | int      | Timeout before first bytes received in milliseconds.                   | 5000    |
-|               **timeout** | int      | General timeout                                                        | 5000    |
-|      **follow_redirects** | bool     | Whether to follow HTTP redirects                                       | `true`  |
+|                    Option | Type               | Description                                                            | Default |
+|--------------------------:|--------------------|------------------------------------------------------------------------|---------|
+|           **http2_ratio** | smallint           | Percentage of requests to be attempted with HTTP/2 `(0..100)` [^ratio] | `0`     |
+|           **http3_ratio** | smallint           | Percentage of requests to be attempted with HTTP/3 `(0..100)` [^ratio] | `0`     |
+| **force_cleartext_http2** | bool               | Allow HTTP/2 to be used without SSL                                    | `false` |
+|    **first_byte_timeout** | int                | Timeout before first bytes received in milliseconds.                   | 5000    |
+|               **timeout** | int                | General timeout                                                        | 5000    |
+|      **follow_redirects** | bool               | Whether to follow HTTP redirects                                       | `true`  |
+|               **cacerts** | text[]             | CA certificates to install (PEM-encoded)                               | `null`  |
+|            **clientcert** | client_certificate | Client certificate (`private_key` and `certificate` encoded as PEM)    | `null`  |
 
 !!! tip "More options will be added in the near future"
 

--- a/extensions/omni_httpc/migrate/3_http_execute.sql
+++ b/extensions/omni_httpc/migrate/3_http_execute.sql
@@ -14,6 +14,6 @@ create domain valid_http_execute_options as http_execute_options
             ((value).http2_ratio + (value).http3_ratio) <= 100
         );
 
-/*{% include "../src/http_execute_options.sql" %}*/
+/*{% include "../src/http_execute_options_prev.sql" %}*/
 /*{% include "../src/http_execute.sql" %}*/
 /*{% include "../src/http_execute_with_options.sql" %}*/

--- a/extensions/omni_httpc/migrate/5_add_http_execute_cert_options.sql
+++ b/extensions/omni_httpc/migrate/5_add_http_execute_cert_options.sql
@@ -1,0 +1,6 @@
+alter type http_execute_options add attribute allow_self_signed_cert boolean;
+
+alter type http_execute_options add attribute cacerts text[];
+
+drop function http_execute_options;
+/*{% include "../src/http_execute_options.sql" %}*/

--- a/extensions/omni_httpc/migrate/5_add_http_execute_cert_options.sql
+++ b/extensions/omni_httpc/migrate/5_add_http_execute_cert_options.sql
@@ -2,5 +2,14 @@ alter type http_execute_options add attribute allow_self_signed_cert boolean;
 
 alter type http_execute_options add attribute cacerts text[];
 
+create type client_certificate
+as
+(
+    certificate text,
+    private_key text
+);
+
+alter type http_execute_options add attribute clientcert client_certificate;
+
 drop function http_execute_options;
 /*{% include "../src/http_execute_options.sql" %}*/

--- a/extensions/omni_httpc/omni_httpc.c
+++ b/extensions/omni_httpc/omni_httpc.c
@@ -458,6 +458,19 @@ static h2o_httpclient_head_cb on_connect(h2o_httpclient_t *client, const char *e
   return on_head;
 }
 
+int allow_self_signed_cert_cb(int preverify_ok, X509_STORE_CTX *ctx) {
+  if (!preverify_ok) {
+    X509 *cert = X509_STORE_CTX_get_current_cert(ctx);
+    int err = X509_STORE_CTX_get_error(ctx);
+
+    // Allow self-signed certificates if this is the specific error
+    if (err == X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN) {
+      return 1;
+    }
+  }
+  return preverify_ok;
+}
+
 PG_FUNCTION_INFO_V1(http_execute);
 
 Datum http_execute(PG_FUNCTION_ARGS) {
@@ -475,6 +488,9 @@ Datum http_execute(PG_FUNCTION_ARGS) {
   h2o_mem_init_pool(pool);
 
   bool follow_redirects = true;
+
+  bool allow_self_signed_cert = false;
+  ArrayType *cacerts = NULL;
 
   // Options
   {
@@ -537,6 +553,19 @@ Datum http_execute(PG_FUNCTION_ARGS) {
       timeout = DatumGetInt32(option_timeout);
     }
     ctx.connect_timeout = ctx.io_timeout = ctx.keepalive_timeout = timeout;
+
+    Datum allow_self_signed_cert_datum =
+        GetAttributeByName(options, "allow_self_signed_cert", &isnull);
+
+    if (!isnull) {
+      allow_self_signed_cert = DatumGetBool(allow_self_signed_cert_datum);
+    }
+
+    Datum cacerts_datum = GetAttributeByName(options, "cacerts", &isnull);
+
+    if (!isnull) {
+      cacerts = DatumGetArrayTypeP(cacerts_datum);
+    }
   }
 
   if (PG_ARGISNULL(1)) {
@@ -683,7 +712,29 @@ Datum http_execute(PG_FUNCTION_ARGS) {
     SSL_CTX *ssl_ctx = SSL_CTX_new(TLS_client_method());
     int bundle_loaded = load_ca_bundle(ssl_ctx, ca_bundle);
     assert(bundle_loaded == 1);
-    SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+
+    if (cacerts != NULL) {
+      ArrayIterator it = array_create_iterator(cacerts, 0, NULL);
+      Datum value;
+      bool isnull;
+      while (array_iterate(it, &value, &isnull)) {
+        text *cert = DatumGetTextPP(value);
+        BIO *cert_bio = BIO_new_mem_buf(VARDATA_ANY(cert), VARSIZE_ANY_EXHDR(cert));
+        X509 *ca_cert = PEM_read_bio_X509(cert_bio, NULL, NULL, NULL);
+        X509_STORE *store = SSL_CTX_get_cert_store(ssl_ctx);
+
+        if (X509_STORE_add_cert(store, ca_cert) != 1) {
+          ereport(ERROR, errmsg("error loading CA certificate"));
+        };
+
+        BIO_free(cert_bio);
+        X509_free(ca_cert);
+      }
+      array_free_iterator(it);
+    }
+
+    SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                       allow_self_signed_cert ? allow_self_signed_cert_cb : NULL);
     h2o_socketpool_set_ssl_ctx(sockpool, ssl_ctx);
     SSL_CTX_free(ssl_ctx);
   }

--- a/extensions/omni_httpc/src/http_execute_options.sql
+++ b/extensions/omni_httpc/src/http_execute_options.sql
@@ -2,10 +2,10 @@ create function http_execute_options(http2_ratio integer default 0, http3_ratio 
                                      force_cleartext_http2 bool default false,
                                      timeout int default null,
                                      first_byte_timeout int default null,
-                                     follow_redirects bool default true) returns http_execute_options
-
+                                     follow_redirects bool default true,
+                                     allow_self_signed_cert bool default false,
+                                     cacerts text[] default null) returns http_execute_options
 as
 $$
-select
-    row (http2_ratio, http3_ratio, force_cleartext_http2, timeout, first_byte_timeout, follow_redirects)::omni_httpc.valid_http_execute_options
+select row (http2_ratio, http3_ratio, force_cleartext_http2, timeout, first_byte_timeout, follow_redirects, allow_self_signed_cert, cacerts)::omni_httpc.valid_http_execute_options
 $$ language sql immutable;

--- a/extensions/omni_httpc/src/http_execute_options.sql
+++ b/extensions/omni_httpc/src/http_execute_options.sql
@@ -4,8 +4,9 @@ create function http_execute_options(http2_ratio integer default 0, http3_ratio 
                                      first_byte_timeout int default null,
                                      follow_redirects bool default true,
                                      allow_self_signed_cert bool default false,
-                                     cacerts text[] default null) returns http_execute_options
+                                     cacerts text[] default null,
+                                     clientcert client_certificate default null) returns http_execute_options
 as
 $$
-select row (http2_ratio, http3_ratio, force_cleartext_http2, timeout, first_byte_timeout, follow_redirects, allow_self_signed_cert, cacerts)::omni_httpc.valid_http_execute_options
+select row (http2_ratio, http3_ratio, force_cleartext_http2, timeout, first_byte_timeout, follow_redirects, allow_self_signed_cert, cacerts, clientcert)::omni_httpc.valid_http_execute_options
 $$ language sql immutable;

--- a/extensions/omni_httpc/src/http_execute_options_prev.sql
+++ b/extensions/omni_httpc/src/http_execute_options_prev.sql
@@ -1,0 +1,10 @@
+create function http_execute_options(http2_ratio integer default 0, http3_ratio integer default 0,
+                                     force_cleartext_http2 bool default false,
+                                     timeout int default null,
+                                     first_byte_timeout int default null,
+                                     follow_redirects bool default true
+) returns http_execute_options
+as
+$$
+select row (http2_ratio, http3_ratio, force_cleartext_http2, timeout, first_byte_timeout, follow_redirects, allow_self_signed_cert, cacerts, clientcert)::omni_httpc.valid_http_execute_options
+$$ language sql immutable;

--- a/extensions/omni_kube/CMakeLists.txt
+++ b/extensions/omni_kube/CMakeLists.txt
@@ -14,4 +14,4 @@ add_postgresql_extension(
         omni_kube
         SCHEMA omni_kube
         RELOCATABLE false
-        REQUIRES omni_httpc omni_web)
+        REQUIRES omni_httpc omni_web omni_var pgcrypto)

--- a/extensions/omni_kube/CMakeLists.txt
+++ b/extensions/omni_kube/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(omni_kube)
+
+include(CTest)
+include(CheckIncludeFile)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
+
+enable_testing()
+
+find_package(PostgreSQL REQUIRED)
+
+add_postgresql_extension(
+        omni_kube
+        SCHEMA omni_kube
+        RELOCATABLE false
+        REQUIRES omni_httpc omni_web)

--- a/extensions/omni_kube/README.md
+++ b/extensions/omni_kube/README.md
@@ -1,0 +1,1 @@
+# omni_kube

--- a/extensions/omni_kube/docs/api.md
+++ b/extensions/omni_kube/docs/api.md
@@ -1,0 +1,24 @@
+# Kubernetes API
+
+## `omni_kube.api()`
+
+This is the central function to invoke Kubernetes API calls
+
+|  **Parameter** | **Type**                      | **Description**                                                 |
+|---------------:|-------------------------------|-----------------------------------------------------------------|
+|       **path** | text                          | Request path                                                    |
+|     **server** | text                          | Kubernetes server, defaults to `https://kubernetes.default.svc` |
+|     **cacert** | text                          | CA certificate                                                  |
+| **clientcert** | omni_httpc.client_certificate | Client certificate                                              |
+|      **token** | text                          | Bearer token                                                    |
+|     **method** | omni_http.http_method         | HTTP method, defaults to `GET`                                  |
+|       **body** | jsonb                         | Request body                                                    |
+
+**token** and **cacert** are automatically inferred from default pod's
+paths (`var/run/secrets/kubernetes.io/serviceaccount/token` and `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
+respectively) to enable
+seamless use of API from within pods (through `omni_kube.pod_credentials()` function). They can be overriden by
+corresponding
+function parameters or `omni_kube.token` and `omni_kube.cacert` settings. In addition
+`omni_kube.clientcert` and `omni_kube.client_private_key` settings can be used to override
+the `clientcert` parameter.

--- a/extensions/omni_kube/docs/views.md
+++ b/extensions/omni_kube/docs/views.md
@@ -1,0 +1,26 @@
+# Cluster views
+
+This extension offers multiple views into the cluster to
+provide most commonly requested information, for example:
+
+* `job_labels`
+* `jobs`
+* `jobs_with_data`
+* `namespaces`
+* `namespaces_with_data`
+* `node_cidrs`
+* `node_images`
+* `node_labels`
+* `nodes`
+* `nodes_with_data`
+* `pod_ip_addresses`
+* `pod_labels`
+* `pods`
+* `pods_with_data`
+* `service_cluster_ips`
+* `service_external_ips`
+* `service_ip_families`
+* `service_labels`
+* `service_ports`
+* `services`
+* `services_with_data`

--- a/extensions/omni_kube/migrate/1_api.sql
+++ b/extensions/omni_kube/migrate/1_api.sql
@@ -1,0 +1,1 @@
+/*{% include "../src/api.sql" %}*/

--- a/extensions/omni_kube/migrate/1_pod_credentials.sql
+++ b/extensions/omni_kube/migrate/1_pod_credentials.sql
@@ -1,0 +1,1 @@
+/*{% include "../src/pod_credentials.sql" %}*/

--- a/extensions/omni_kube/migrate/2_views.sql
+++ b/extensions/omni_kube/migrate/2_views.sql
@@ -144,6 +144,7 @@ from services_with_data,
 create view jobs_with_data as
 select (data -> 'metadata' ->> 'uid')::uuid       as uid,
        data -> 'metadata' ->> 'name'              as name,
+       data -> 'metadata' ->> 'namespace' as namespace,
        (data -> 'metadata' ->> 'creationTimestamp')::timestamptz as creation_timestamp,
        (data -> 'status' ->> 'startTime')::timestamptz           as start_time,
        (data -> 'status' ->> 'completionTime')::timestamptz      as completion_time,
@@ -161,6 +162,7 @@ from (select jsonb_array_elements((api('/apis/batch/v1/jobs'))::jsonb -> 'items'
 create view jobs as
 select uid,
        name,
+       namespace,
        creation_timestamp,
        start_time,
        completion_time,

--- a/extensions/omni_kube/migrate/2_views.sql
+++ b/extensions/omni_kube/migrate/2_views.sql
@@ -2,7 +2,7 @@
 create view namespaces_with_data as
 select (data -> 'metadata' ->> 'uid')::uuid       as uid,
        data -> 'metadata' ->> 'name'              as name,
-       data -> 'metadata' ->> 'creationTimestamp' as creation_timestamp,
+       (data -> 'metadata' ->> 'creationTimestamp')::timestamptz as creation_timestamp,
        data -> 'status' ->> 'phase'               as phase,
        data
 from (select jsonb_array_elements((api('/api/v1/namespaces'))::jsonb -> 'items') as data)
@@ -17,7 +17,7 @@ create view pods_with_data as
 select (data -> 'metadata' ->> 'uid')::uuid                                                                   as uid,
        data -> 'metadata' ->> 'name'                                                                          as name,
        data -> 'metadata' ->> 'namespace'                                                                     as namespace,
-       data -> 'metadata' ->> 'creationTimestamp' as creation_timestamp,
+       (data -> 'metadata' ->> 'creationTimestamp')::timestamptz as creation_timestamp,
        data -> 'status' ->> 'phase'                                                                           as phase,
        data -> 'spec' ->> 'nodeName'                                                                          as node,
        data
@@ -43,7 +43,7 @@ from pods_with_data,
 create view nodes_with_data as
 select (data -> 'metadata' ->> 'uid')::uuid          as uid,
        data -> 'metadata' ->> 'name'                 as name,
-       data -> 'metadata' ->> 'creationTimestamp'    as creation_timestamp,
+       (data -> 'metadata' ->> 'creationTimestamp')::timestamptz as creation_timestamp,
        (data -> 'spec' ->> 'unschedulable')::boolean as unschedulable,
        data
 from (select jsonb_array_elements((api('/api/v1/nodes'))::jsonb -> 'items') as data)
@@ -81,7 +81,7 @@ create view services_with_data as
 select (data -> 'metadata' ->> 'uid')::uuid       as uid,
        data -> 'metadata' ->> 'name'              as name,
        data -> 'metadata' ->> 'namespace'         as namespace,
-       data -> 'metadata' ->> 'creationTimestamp' as creation_timestamp,
+       (data -> 'metadata' ->> 'creationTimestamp')::timestamptz as creation_timestamp,
        data -> 'spec' ->> 'type'                  as type,
        data -> 'spec' ->> 'externalName'          as external_name,
        data -> 'spec' ->> 'internalTrafficPolicy' as internal_traffic_policy,
@@ -144,9 +144,9 @@ from services_with_data,
 create view jobs_with_data as
 select (data -> 'metadata' ->> 'uid')::uuid       as uid,
        data -> 'metadata' ->> 'name'              as name,
-       data -> 'metadata' ->> 'creationTimestamp' as creation_timestamp,
-       data -> 'status' ->> 'startTime'           as start_time,
-       data -> 'status' ->> 'completionTime'      as completion_time,
+       (data -> 'metadata' ->> 'creationTimestamp')::timestamptz as creation_timestamp,
+       (data -> 'status' ->> 'startTime')::timestamptz           as start_time,
+       (data -> 'status' ->> 'completionTime')::timestamptz      as completion_time,
        data -> 'spec' ->> 'completionMode'        as completion_mode,
        (data -> 'spec' ->> 'completions')::int    as completions,
        (data -> 'spec' ->> 'parallelism')::int    as parallelism,

--- a/extensions/omni_kube/migrate/2_views.sql
+++ b/extensions/omni_kube/migrate/2_views.sql
@@ -1,0 +1,140 @@
+-- Namespaces
+create view namespaces_with_data as
+select (data -> 'metadata' ->> 'uid')::uuid       as uid,
+       data -> 'metadata' ->> 'name'              as name,
+       data -> 'metadata' ->> 'creationTimestamp' as creation_timestamp,
+       data -> 'status' ->> 'phase'               as phase,
+       data
+from (select jsonb_array_elements((api('/api/v1/namespaces'))::jsonb -> 'items') as data)
+         as namespaces;
+
+create view namespaces as
+select uid, name, creation_timestamp, phase
+from namespaces_with_data;
+
+-- Pods
+create view pods_with_data as
+select (data -> 'metadata' ->> 'uid')::uuid                                                                   as uid,
+       data -> 'metadata' ->> 'name'                                                                          as name,
+       data -> 'metadata' ->> 'namespace'                                                                     as namespace,
+       data -> 'metadata' ->> 'creationTimestamp' as creation_timestamp,
+       data -> 'status' ->> 'phase'                                                                           as phase,
+       data -> 'spec' ->> 'nodeName'                                                                          as node,
+       data
+from (select jsonb_array_elements((api('/api/v1/pods'))::jsonb -> 'items') as data)
+         as pods;
+
+create view pods as
+select uid, name, namespace, creation_timestamp, phase, node
+from pods_with_data;
+
+create view pod_labels as
+select uid, name, key, value
+from pods_with_data,
+     lateral (select key, value from jsonb_each(data -> 'metadata' -> 'labels') as label(key, value));
+
+create view pod_ip_addresses as
+select uid, name, ip_address
+from pods_with_data,
+     lateral (select jsonb_array_elements_text(jsonb_path_query_array(data, '$.status.podIPs[*].ip'))::inet as ip_address) as ip_addresses(ip_address);
+
+-- Nodes
+
+create view nodes_with_data as
+select (data -> 'metadata' ->> 'uid')::uuid          as uid,
+       data -> 'metadata' ->> 'name'                 as name,
+       data -> 'metadata' ->> 'creationTimestamp'    as creation_timestamp,
+       (data -> 'spec' ->> 'unschedulable')::boolean as unschedulable,
+       data
+from (select jsonb_array_elements((api('/api/v1/nodes'))::jsonb -> 'items') as data)
+         as codes;
+
+create view nodes as
+select uid, name, creation_timestamp, unschedulable
+from nodes_with_data;
+
+create view node_cidrs as
+select uid, name, cidr
+from nodes_with_data,
+     lateral (select jsonb_array_elements_text(jsonb_path_query_array(data, '$.spec.podCIDRs[*]'))::cidr as cidr) as cidrs(cidr);
+
+create view node_images as
+select data -> 'metadata' ->> 'name'                            as node,
+       jsonb_array_elements(case
+                                when jsonb_typeof(image_data -> 'names') = 'null' then '[
+                                  null
+                                ]'::jsonb
+                                else image_data -> 'names' end) as image,
+       image_data ->> 'sizeBytes' as size_bytes
+from (select jsonb_array_elements((api('/api/v1/nodes'))::jsonb -> 'items') as data)
+         as codes,
+     lateral (select jsonb_path_query(data, '$.status.images[*]') as image_data ) images;
+
+create view node_labels as
+select uid, name, key, value
+from nodes_with_data,
+     lateral (select key, value from jsonb_each(data -> 'metadata' -> 'labels') as label(key, value));
+
+-- Services
+
+create view services_with_data as
+select (data -> 'metadata' ->> 'uid')::uuid       as uid,
+       data -> 'metadata' ->> 'name'              as name,
+       data -> 'metadata' ->> 'namespace'         as namespace,
+       data -> 'metadata' ->> 'creationTimestamp' as creation_timestamp,
+       data -> 'spec' ->> 'type'                  as type,
+       data -> 'spec' ->> 'externalName'          as external_name,
+       data -> 'spec' ->> 'internalTrafficPolicy' as internal_traffic_policy,
+       data -> 'spec' ->> 'externalTrafficPolicy' as external_traffic_policy,
+       data -> 'spec' ->> 'ipFamilyPolicy'        as ip_family_policy,
+       data
+from (select jsonb_array_elements((api('/api/v1/services'))::jsonb -> 'items') as data)
+         as services;
+
+create view services as
+select uid,
+       name,
+       namespace,
+       creation_timestamp,
+       type,
+       external_name,
+       internal_traffic_policy,
+       external_traffic_policy,
+       ip_family_policy
+from services_with_data;
+
+create view service_ports as
+select uid,
+       name,
+       port ->> 'name'              as port_name,
+       (port ->> 'port')::int       as port,
+       (port ->> 'targetPort')::int as target_port,
+       port ->> 'protocol'          as protocol
+from services_with_data,
+     lateral (select jsonb_path_query(data, '$.spec.ports[*]') as port) as ports(port);
+
+create view service_cluster_ips as
+select uid,
+       name,
+       ip_address
+from services_with_data,
+     lateral (select (jsonb_path_query(data, '$.spec.clusterIPs[*]') #>> '{}')::inet as ip_address) as ips(ip_address);
+
+create view service_external_ips as
+select uid,
+       name,
+       ip_address
+from services_with_data,
+     lateral (select (jsonb_path_query(data, '$.spec.externalIPs[*]') #>> '{}')::inet as ip_address) as ips(ip_address);
+
+create view service_ip_families as
+select uid,
+       name,
+       ip_family
+from services_with_data,
+     lateral (select (jsonb_path_query(data, '$.spec.ipFamilies[*]') #>> '{}') as ip_family) as ip_families(ip_family);
+
+create view service_labels as
+select uid, name, key, value
+from services_with_data,
+     lateral (select key, value from jsonb_each(data -> 'metadata' -> 'labels') as label(key, value));

--- a/extensions/omni_kube/mkdocs.yml
+++ b/extensions/omni_kube/mkdocs.yml
@@ -1,0 +1,2 @@
+INHERIT: ../../mkdocs.base.yml
+site_name: omni_kube

--- a/extensions/omni_kube/src/api.sql
+++ b/extensions/omni_kube/src/api.sql
@@ -1,0 +1,37 @@
+create function api(path text, server text default 'https://kubernetes.default.svc',
+                    cacert text default null,
+                    token text default null,
+                    method omni_http.http_method default 'GET',
+                    body jsonb default null) returns jsonb
+    language plpgsql
+    stable
+as
+$$
+declare
+    response omni_httpc.http_response;
+begin
+    if substring(path, 1, 1) != '/' then
+        raise exception 'path must start with a leading slash';
+    end if;
+    select *
+    into response
+    from
+        omni_httpc.http_execute_with_options(
+                omni_httpc.http_execute_options(allow_self_signed_cert => cacert is null,
+                                                cacerts => case when cacert is null then null else array [cacert] end),
+                omni_httpc.http_request(
+                        format('%1$s%2$s', server, path),
+                        method,
+                        array [
+                            omni_http.http_header('Content-Type', 'application/json'),
+                            omni_http.http_header('Accept', 'application/json'),
+                            omni_http.http_header('Authorization', 'Bearer ' || token)
+                            ],
+                        convert_to(body::text, 'UTF8')
+                ));
+    if response.error is not null then
+        raise exception 'error: %', response.error;
+    end if;
+    return convert_from(response.body, 'utf-8')::jsonb;
+end;
+$$;

--- a/extensions/omni_kube/src/api.sql
+++ b/extensions/omni_kube/src/api.sql
@@ -12,6 +12,12 @@ $$
 declare
     response omni_httpc.http_response;
 begin
+    if cacert is null then
+        select p.cacert into cacert from omni_kube.pod_credentials() p;
+    end if;
+    if token is null then
+        select p.token into token from omni_kube.pod_credentials() p;
+    end if;
     if substring(path, 1, 1) != '/' then
         raise exception 'path must start with a leading slash';
     end if;

--- a/extensions/omni_kube/src/api.sql
+++ b/extensions/omni_kube/src/api.sql
@@ -2,6 +2,7 @@ create function api(path text,
                     server text default coalesce(current_setting('omni_kube.server', true),
                                                  'https://kubernetes.default.svc'),
                     cacert text default current_setting('omni_kube.cacert', true),
+                    clientcert omni_httpc.client_certificate default row (current_setting('omni_kube.clientcert', true), current_setting('omni_kube.client_private_key', true))::omni_httpc.client_certificate,
                     token text default current_setting('omni_kube.token', true),
                     method omni_http.http_method default 'GET',
                     body jsonb default null) returns jsonb
@@ -36,7 +37,8 @@ begin
     from
         omni_httpc.http_execute_with_options(
                 omni_httpc.http_execute_options(allow_self_signed_cert => cacert is null,
-                                                cacerts => case when cacert is null then null else array [cacert] end),
+                                                cacerts => case when cacert is null then null else array [cacert] end,
+                                                clientcert => case when clientcert is null then null else clientcert end),
                 omni_httpc.http_request(
                         format('%1$s%2$s', server, path),
                         method,

--- a/extensions/omni_kube/src/api.sql
+++ b/extensions/omni_kube/src/api.sql
@@ -1,6 +1,8 @@
-create function api(path text, server text default 'https://kubernetes.default.svc',
-                    cacert text default null,
-                    token text default null,
+create function api(path text,
+                    server text default coalesce(current_setting('omni_kube.server', true),
+                                                 'https://kubernetes.default.svc'),
+                    cacert text default current_setting('omni_kube.cacert', true),
+                    token text default current_setting('omni_kube.token', true),
                     method omni_http.http_method default 'GET',
                     body jsonb default null) returns jsonb
     language plpgsql

--- a/extensions/omni_kube/src/pod_credentials.sql
+++ b/extensions/omni_kube/src/pod_credentials.sql
@@ -9,10 +9,10 @@ create function pod_credentials()
 as
 $$
 begin
-    if pg_stat_file('/var/run/secrets/kubernetes.io/serviceaccount/token', true) is not null then
+    if pg_stat_file('/var/run/secrets/kubernetes.io/serviceaccount/token', true) is distinct from null then
         token := pg_read_file('/var/run/secrets/kubernetes.io/serviceaccount/token');
     end if;
-    if pg_stat_file('/var/run/secrets/kubernetes.io/serviceaccount/ca.crt', true) is not null then
+    if pg_stat_file('/var/run/secrets/kubernetes.io/serviceaccount/ca.crt', true) is distinct from null then
         cacert := pg_read_file('/var/run/secrets/kubernetes.io/serviceaccount/ca.crt');
     end if;
     if not (token is null and cacert is null) then

--- a/extensions/omni_kube/src/pod_credentials.sql
+++ b/extensions/omni_kube/src/pod_credentials.sql
@@ -1,0 +1,23 @@
+create function pod_credentials()
+    returns table
+            (
+                token  text,
+                cacert text
+            )
+    security definer
+    language plpgsql
+as
+$$
+begin
+    if pg_stat_file('/var/run/secrets/kubernetes.io/serviceaccount/token', true) is not null then
+        token := pg_read_file('/var/run/secrets/kubernetes.io/serviceaccount/token');
+    end if;
+    if pg_stat_file('/var/run/secrets/kubernetes.io/serviceaccount/ca.crt', true) is not null then
+        cacert := pg_read_file('/var/run/secrets/kubernetes.io/serviceaccount/ca.crt');
+    end if;
+    if not (token is null and cacert is null) then
+        return next;
+    end if;
+    return;
+end;
+$$;

--- a/versions.txt
+++ b/versions.txt
@@ -1,12 +1,15 @@
-omni=0.2.3
+omni=0.2.1
 omni_aws=0.1.1
 omni_auth=0.1.1
 omni_containers=0.2.0
 omni_http=0.1.0
 omni_httpc=0.1.2
 omni_httpd=0.2.4
+omni_httpc=0.1.3
+omni_httpd=0.2.2
 omni_id=0.3.1
 omni_json=0.1.0
+omni_kube=0.1.0
 omni_ledger=0.1.0
 omni_manifest=0.1.1
 omni_mimetypes=0.1.0

--- a/versions.txt
+++ b/versions.txt
@@ -1,12 +1,10 @@
-omni=0.2.1
+omni=0.2.3
 omni_aws=0.1.1
 omni_auth=0.1.1
 omni_containers=0.2.0
 omni_http=0.1.0
-omni_httpc=0.1.2
-omni_httpd=0.2.4
 omni_httpc=0.1.3
-omni_httpd=0.2.2
+omni_httpd=0.2.4
 omni_id=0.3.1
 omni_json=0.1.0
 omni_kube=0.1.0


### PR DESCRIPTION
Omnigres is often portrayed as an advanced application runtime – the one that embraces data-centric design and control flow.

But if it is an application runtime, how does it fare with today's methods of deployment? Does it integrate well?

Solution: propose a lightweight integration with Kubernetes

omni_kube allows easily making Kubernetes API calls so that one can orchestrate resources and get views into what's happening.

This change also required me to add some CA certificate-related functionality to omni_httpc.

---

## What's missing?

- [ ] Tests (should we try setting up a k3d cluster in CI?)
- [ ] Documentation for both omni_httpc changes and omni_kube