### PR TITLE
Problem: omni may fail to initialize a module (🚀 omni 0.2.1)

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2024-10-26
+
+### Fixed
+
+* Sporadic `unsupported byval length` error message upon module
+  initialization [#677](https://github.com/omnigres/omnigres/pull/677)
+
 ## [0.2.0] - 2024-10-04
 
 ### Added

--- a/extensions/omni/extension.c
+++ b/extensions/omni/extension.c
@@ -198,14 +198,15 @@ MODULE_FUNCTION void extension_upgrade_hook(omni_hook_handle *handle, PlannedStm
               // Ensure to replace only those procedures that had a matching module_pathname
               // from the previous version of the extension (we recorded that in the context)
               bool isnull;
-              Datum probin = heap_getattr(tup, Anum_pg_proc_probin, pg_proc_tuple_desc, &isnull);
+              Datum probin =
+                  heap_getattr(tup, Anum_pg_proc_probin, RelationGetDescr(proc_rel), &isnull);
               if (!isnull && strcmp(old_module_pathname, TextDatumGetCString(probin)) == 0) {
                 // Get the new module_pathname in
                 values[Anum_pg_proc_probin - 1] = CStringGetTextDatum(module_pathname);
                 replaces[Anum_pg_proc_probin - 1] = true;
 
                 HeapTuple newtup =
-                    heap_modify_tuple(tup, pg_proc_tuple_desc, values, nulls, replaces);
+                    heap_modify_tuple(tup, RelationGetDescr(proc_rel), values, nulls, replaces);
 
                 // Update the record
                 CatalogTupleUpdate(proc_rel, &newtup->t_self, newtup);

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
-omni=0.2.0
+omni=0.2.1
 omni_aws=0.1.1
 omni_auth=0.1.1
 omni_containers=0.1.0


### PR DESCRIPTION
Error message: "unsupported byval length"

Solution: don't try to pre-cache `TupleDesc`
(it's readily available in `Relation` anyway)