### PR TITLE
Problem: CI jobs started to fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         pgver: [ 17, 16, 15, 14, 13 ]
-        os: [ warp-ubuntu-latest-x64-4x, warp-macos-14-arm64-6x ]
+        os: [ warp-ubuntu-2204-x64-4x, warp-macos-14-arm64-6x ]
         build_type: [Debug, Release]
         exclude:
         - os: warp-macos-14-arm64-6x
@@ -125,7 +125,7 @@ jobs:
 
   # Ensure it can be built against externally-supplied Postgres
   build-external-pg:
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: warp-ubuntu-2204-x64-4x
 
     steps:
     - uses: actions/checkout@v3
@@ -144,7 +144,7 @@ jobs:
 
   # Ensure every extension can be built independently
   build-extensions-independently:
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: warp-ubuntu-2204-x64-4x
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
         platform: [ amd64, arm64 ]
 
     if: github.repository == 'omnigres/omnigres'
-    runs-on: ${{ fromJSON('["warp-ubuntu-latest-x64-4x", "warp-ubuntu-latest-arm64-16x"]')[matrix.platform == 'arm64'] }}
+    runs-on: ${{ fromJSON('["warp-ubuntu-2204-x64-4x", "warp-ubuntu-2204-arm64-16x"]')[matrix.platform == 'arm64'] }}
 
     permissions:
       contents: read


### PR DESCRIPTION
Solution: pin runner image to Ubuntu 22.04

Eventually, we need to upgrade, but for now, we need them to work.