### PR TITLE
Add timeout parameter to omni_txn.retry procedure 

### DIFF
--- a/extensions/omni_txn/migrate/2_retry.sql
+++ b/extensions/omni_txn/migrate/2_retry.sql
@@ -4,7 +4,7 @@ create procedure retry(stmts text, max_attempts int default 10, repeatable_read 
 'MODULE_PATHNAME';
 
 comment on procedure retry is $$
-Retry serializable transaction on statements `stmts`, `max_attempt` number of times (10 by default). `collect_backoff_values` controls if the backoff values used for sleeping will be recorded for debugging/testing purposes (false in orded to increase performance)
+Retry serializable transaction on statements `stmts`, `max_attempt` number of times (10 by default). `collect_backoff_values` controls if the backoff values used for sleeping will be recorded for debugging/testing purposes (false in orded to increase performance). `timeout` specifies the maximum duration in seconds for which to attempt the retries (60 seconds by default).
 $$;
 
 create function current_retry_attempt()

--- a/extensions/omni_txn/migrate/3_retry_params.sql
+++ b/extensions/omni_txn/migrate/3_retry_params.sql
@@ -8,5 +8,5 @@ create procedure retry(stmts text, max_attempts int default 10, repeatable_read 
 'MODULE_PATHNAME';
 
 comment on procedure retry is $$
-Retry serializable transaction on statements `stmts`, `max_attempt` number of times (10 by default). `collect_backoff_values` controls if the backoff values used for sleeping will be recorded for debugging/testing purposes (false in orded to increase performance)
+Retry serializable transaction on statements `stmts`, `max_attempt` number of times (10 by default). `collect_backoff_values` controls if the backoff values used for sleeping will be recorded for debugging/testing purposes (false in orded to increase performance). `timeout` specifies the maximum duration in seconds for which to attempt the retries (60 seconds by default).
 $$;

--- a/extensions/omni_txn/migrate/7_update_retry.sql
+++ b/extensions/omni_txn/migrate/7_update_retry.sql
@@ -1,0 +1,28 @@
+drop procedure if exists retry(stmts text, max_attempts int, repeatable_read boolean,
+                               collect_backoff_values boolean, params record);
+
+
+create procedure retry(
+    stmts text, 
+    max_attempts int default 10, 
+    repeatable_read boolean default false, 
+    collect_backoff_values boolean default false, 
+    params record default null::record,    
+    timeout interval default null           
+)
+    language c as
+'MODULE_PATHNAME';
+
+
+comment on procedure retry is $$
+Retry serializable transaction on statements `stmts`, retrying up to `max_attempts` times or until `timeout` is reached,
+whichever occurs first. If both parameters are omitted, the procedure defaults to retrying 10 times with no time limit.
+
+Scenarios:
+1. If both `timeout` and `max_attempts` are provided, retries continue until the earlier of the two conditions.
+2. If only `timeout` is specified, retries continue until the timeout is reached.
+3. If only `max_attempts` is specified, retries continue up to that number of attempts.
+4. If neither is specified, the default behavior is to retry 10 times without a time limit.
+
+If a timeout is exceeded during a single attempt, retries are immediately aborted.
+$$;

--- a/extensions/omni_txn/migrate/7_update_retry.sql
+++ b/extensions/omni_txn/migrate/7_update_retry.sql
@@ -1,4 +1,4 @@
-drop procedure if exists retry(stmts text, max_attempts int, repeatable_read boolean,
+drop procedure retry(stmts text, max_attempts int, repeatable_read boolean,
                                collect_backoff_values boolean, params record);
 
 

--- a/extensions/omni_txn/retry.c
+++ b/extensions/omni_txn/retry.c
@@ -377,6 +377,6 @@ Datum reset_retry_prepared_statements(PG_FUNCTION_ARGS) {
   PG_RETURN_VOID();
 }
 
-static bool TimestampDifferenceExceeds(TimestampTz end_time, TimestampTz start_time, int64 timeout_microsecs) {
+bool TimestampDifferenceExceeds(TimestampTz end_time, TimestampTz start_time, int64 timeout_microsecs) {
     return (end_time - start_time) > timeout_microsecs;
 }

--- a/extensions/omni_txn/retry.c
+++ b/extensions/omni_txn/retry.c
@@ -377,6 +377,7 @@ Datum reset_retry_prepared_statements(PG_FUNCTION_ARGS) {
   PG_RETURN_VOID();
 }
 
-bool TimestampDifferenceExceeds(TimestampTz end_time, TimestampTz start_time, int64 timeout_microsecs) {
-    return (end_time - start_time) > timeout_microsecs;
+bool TimestampDifferenceExceeds(TimestampTz end_time, TimestampTz start_time, int timeout_microsecs) {
+    int64 difference = (end_time - start_time) / 1000;
+    return difference > timeout_microsecs;
 }

--- a/extensions/omni_txn/tests/retry.yml
+++ b/extensions/omni_txn/tests/retry.yml
@@ -165,6 +165,32 @@ tests:
         min:  true
         avg: true
 
+- name: timeout exceeds allowed duration
+  transaction: false
+  tests:
+  - query: |
+      call omni_txn.retry($$select quantity from inventory where product_name = 'Widget';
+      select call_other_session() where omni_txn.current_retry_attempt() < 10;
+      update inventory set quantity = quantity + 20 where product_name = 'Widget';
+      $$, timeout => 1);  # Set a short timeout of 1 second
+    transaction: false
+    error: transaction timed out after 1 seconds
+
+- name: timeout not exceeded
+  transaction: false
+  tests:
+  - query: |
+      call omni_txn.retry($$select quantity from inventory where product_name = 'Widget';
+      select call_other_session() where omni_txn.current_retry_attempt() < 10;
+      update inventory set quantity = quantity + 20 where product_name = 'Widget';
+      $$, timeout => 10);  # Set a longer timeout of 10 seconds
+    transaction: false
+  - query: select quantity
+           from inventory
+           where product_name = 'Widget'
+    results:
+    - quantity: 110
+
 - name: params
   transaction: false
   tests:


### PR DESCRIPTION
Problem:
The current implementation of the omni_txn.retry function uses a max_attempts parameter to control how many times a transaction should be retried. However, this approach does not allow specifying how long the system should continue retrying, which makes it difficult to control the overall retry duration. As a result, transactions may attempt retries beyond a practical time limit, potentially leading to longer-than-desired delays or system timeouts.

Solution:
The omni_txn.retry function has been updated to introduce a timeout parameter, which specifies the maximum duration (in milliseconds) for which retry attempts should be made. This allows for more fine-grained control over retry behavior by setting a time limit for retry attempts, rather than relying solely on the number of attempts.

Additionally, the following updates have been made:

-Test cases in retry.yml have been updated to include scenarios that validate the timeout functionality.
-The function implementation has been refactored to ensure the new parameter integrates smoothly with the existing logic while maintaining readability.

This solution provides a more flexible way to handle transaction retries by focusing on time-based limits instead of only retry counts, thus improving the practical applicability of the retry mechanism.