### PR TITLE
Problem: omni_sql.execute doesn't work well with custom types

### DIFF
--- a/extensions/omni_sql/CHANGELOG.md
+++ b/extensions/omni_sql/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - TBA
+## [0.3.4] - TBA
+
+### Fixed
+
+* SQL execution with text parameters mapped to non-text types [#689](https://github.com/omnigres/omnigres/pull/689)
 
 ## [0.3.3] - 2024-09-27
 
@@ -83,4 +87,6 @@ Initial release following a few months of iterative development.
 [0.3.2]: [https://github.com/omnigres/omnigres/pull/615]
 
 [0.3.3]: [https://github.com/omnigres/omnigres/pull/650]
+
+[0.3.4]: [https://github.com/omnigres/omnigres/pull/688]
 

--- a/extensions/omni_sql/omni_sql.c
+++ b/extensions/omni_sql/omni_sql.c
@@ -672,6 +672,14 @@ static inline void extract_information_json_types(ExecCtx *call_ctx, ArrayType *
       continue;
     }
     Oid id = DatumGetObjectId(type_val);
+    if (call_ctx->types[i] == TEXTOID && id != TEXTOID) {
+      Oid typioparam;
+      Oid input_func;
+
+      getTypeInputInfo(id, &input_func, &typioparam);
+      call_ctx->values[i] = OidInputFunctionCall(
+          input_func, text_to_cstring(DatumGetTextPP(call_ctx->values[i])), typioparam, -1);
+    }
     // Handle numeric type specialization
     if (call_ctx->types[i] == NUMERICOID) {
       switch (id) {

--- a/extensions/omni_sql/tests/omni_sql/execute.yml
+++ b/extensions/omni_sql/tests/omni_sql/execute.yml
@@ -24,6 +24,21 @@ tests:
       first: 1
       second: hello
 
+- name: string parameter to type conversion (using "char")
+  steps:
+  - create domain code as "char"
+  - query: select * from omni_sql.execute('select $1 as value', parameters => jsonb_build_array('T'), types => '{code}')
+    results:
+    - stmt_row:
+        value: T
+
+- name: string parameter to type conversion (using uuid)
+  steps:
+  - query: select * from omni_sql.execute('select $1 as value', parameters => jsonb_build_array('8a0f43cd-a640-4426-94ca-f33955195a1f'), types => '{uuid}')
+    results:
+    - stmt_row:
+        value: 8a0f43cd-a640-4426-94ca-f33955195a1f
+
 - name: non-array parameters
   query: select *
          from omni_sql.execute('select $1', parameters => jsonb_build_object('a', 1))


### PR DESCRIPTION
When we pass parameters in a JSON array that are typed as text but specify the type as something other than text (or physical equivalent of it), the resulting data is effectively garbage.

Solution: ensure we call input function on the given string