### PR TITLE
Problem: using older versions of Postgres

### DIFF
--- a/.github/workflows/ext-scripts.yml
+++ b/.github/workflows/ext-scripts.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         pgver: [ 17, 16, 15, 14, 13 ]
-        os: [ { name: ubuntu, image: warp-ubuntu-latest-x64-4x, arch: x86-64 }, { name: macos, image: warp-macos-14-arm64-6x, arch: arm } ]
+        os: [ { name: ubuntu, image: warp-ubuntu-2204-x64-4x, arch: x86-64 }, { name: macos, image: warp-macos-14-arm64-6x, arch: arm } ]
         build_type: [ Release ]
         exclude:
         - os: { name: macos, image: warp-macos-14-arm64-6x, arch: arm }

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -61,11 +61,11 @@ if(NOT DEFINED PG_CONFIG)
     endif()
 
     # If the version is not known, try resolving the alias
-    set(PGVER_ALIAS_17 17.0)
-    set(PGVER_ALIAS_16 16.4)
-    set(PGVER_ALIAS_15 15.8)
-    set(PGVER_ALIAS_14 14.13)
-    set(PGVER_ALIAS_13 13.16)
+    set(PGVER_ALIAS_17 17.1)
+    set(PGVER_ALIAS_16 16.5)
+    set(PGVER_ALIAS_15 15.9)
+    set(PGVER_ALIAS_14 14.14)
+    set(PGVER_ALIAS_13 13.17)
 
     if("${PGVER}" MATCHES "[0-9]+.[0-9]+")
         set(PGVER_ALIAS "${PGVER}")


### PR DESCRIPTION
We have new versions of Postgres that fix non-impossible-to-reproduce bugs (one such bug is a [race condition in serializable transactions](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=234f6d09e))

Solution: use newer releases by default