### PR TITLE
Problem: Dockerfile still uses 17.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.5
 
 # Version of PostgreSQL
-ARG PG=17.1
+ARG PG=17.2
 # Build type
 ARG BUILD_TYPE=RelWithDebInfo
 # User name to be used for builder


### PR DESCRIPTION
17.1 was quickly superseded by 17.2 because of regressions.

Solution: use 17.2 now that it is available