### PR TITLE
Problem: omni_httpd doesn't work on multiple databases (🚀 omni_httpd 0.2.3, omni 0.2.2)

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2024-11-29
+
+### Changed
+
+* All shmem allocations are to be zero-initialized [#698](https://github.com/omnigres/omnigres/pull/698)
+
 ## [0.2.1] - 2024-10-26
 
 ### Fixed
@@ -86,3 +92,7 @@ Initial release following a few months of iterative development.
 [0.1.5]: [https://github.com/omnigres/omnigres/pull/650]
 
 [0.2.0]: [https://github.com/omnigres/omnigres/pull/572]
+
+[0.2.1]: [https://github.com/omnigres/omnigres/pull/677]
+
+[0.2.2]: [https://github.com/omnigres/omnigres/pull/698]

--- a/extensions/omni/omni.c
+++ b/extensions/omni/omni.c
@@ -701,7 +701,7 @@ static struct dsa_ref {
       dsa_area *dsa = dsa_handle_to_area(shared_info->dsa);
       uint32 interrupt_holdoff = InterruptHoldoffCount;
       PG_TRY();
-      { alloc->dsa_pointer = dsa_allocate(dsa, size); }
+      { alloc->dsa_pointer = dsa_allocate0(dsa, size); }
       PG_CATCH();
       {
         // errfinish sets `InterruptHoldoffCount` to zero as part of its cleanup

--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2024-11-29
+
+### Fixed
+
+* Running omni_httpd in multiple databases [#698](https://github.com/omnigres/omnigres/pull/698)
+
 ## [0.2.2] - 2024-11-21
 
 ### Fixed
@@ -68,3 +74,5 @@ Initial release following a few months of iterative development.
 [0.2.1]: [https://github.com/omnigres/omnigres/pull/657]
 
 [0.2.2]: [https://github.com/omnigres/omnigres/pull/692]
+
+[0.2.3]: [https://github.com/omnigres/omnigres/pull/698]

--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -28,7 +28,7 @@ add_postgresql_extension(
         SOURCES omni_httpd.c master_worker.c http_worker.c event_loop.c fd.c cascading_query.c
         DEPENDS_ON omni_sql omni libomni libpgaug libgluepg_stc
         REQUIRES omni_types omni_http
-        TESTS_REQUIRE omni_httpc omni_vfs omni_mimetypes)
+        TESTS_REQUIRE omni_httpc omni_vfs omni_mimetypes dblink)
 
 set_property(TARGET omni_httpd PROPERTY C_STANDARD 11)
 

--- a/extensions/omni_httpd/master_worker.c
+++ b/extensions/omni_httpd/master_worker.c
@@ -234,10 +234,12 @@ void master_worker(Datum db_oid) {
       // We do this by inspecting all processes
       worker_present = false; // tentatively
       for (int i = 0; i < ProcGlobal->allProcCount; i++) {
-        pid_t pid = ProcGlobal->allProcs[i].pid;
+        PGPROC proc = ProcGlobal->allProcs[i];
+        pid_t pid = proc.pid;
         const char *worker_type = GetBackgroundWorkerTypeByPid(pid);
         if (worker_type &&
-            strncmp(worker_type, "omni_httpd worker", sizeof("omni_httpd worker")) == 0) {
+            strncmp(worker_type, "omni_httpd worker", sizeof("omni_httpd worker")) == 0 &&
+            proc.databaseId == MyDatabaseId) {
           worker_present = true;
           if (!reported[i]) {
             ereport(DEBUG2,

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -35,9 +35,12 @@ extern char **temp_dir;
 static const char *OMNI_HTTPD_CONFIGURATION_NOTIFY_CHANNEL = "omni_httpd_configuration";
 
 static const char *OMNI_HTTPD_CONFIGURATION_RELOAD_SEMAPHORE =
-    "omni_httpd:" EXT_VERSION ":_configuration_reload_semaphore";
+    "omni_httpd(%s):" EXT_VERSION ":_configuration_reload_semaphore";
 
-static const char *OMNI_HTTPD_MASTER_WORKER = "omni_httpd:" EXT_VERSION ":_master_worker";
+static const char *OMNI_HTTPD_MASTER_WORKER = "omni_httpd(%s):" EXT_VERSION ":_master_worker";
+
+static const char *OMNI_HTTPD_MASTER_WORKER_LEADER =
+    "omni_httpd(%s):" EXT_VERSION ":_master_worker_leader";
 
 static const char *OMNI_HTTPD_GUC_NUM_HTTP_WORKERS =
     "omni_httpd:" EXT_VERSION ":_guc_num_http_workers";
@@ -56,6 +59,7 @@ extern bool IsOmniHttpdWorker;
 
 extern pg_atomic_uint32 *semaphore;
 extern omni_bgworker_handle *master_worker_bgw;
+extern pg_atomic_uint64 *master_worker_leader;
 
 extern bool BackendInitialized;
 

--- a/extensions/omni_httpd/tests/multi_db.yml
+++ b/extensions/omni_httpd/tests/multi_db.yml
@@ -1,0 +1,53 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 64
+  init:
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - call omni_httpd.wait_for_configuration_reloads(1)
+  - create extension dblink
+  - create database anotherdb
+  - select dblink_connect('anotherdb', 'hostaddr=127.0.0.1 dbname=anotherdb user=yregress port=' || (select setting
+                                                                                                     from pg_settings
+                                                                                                     where name = 'port'))
+  - select dblink_exec('anotherdb', 'create extension omni_httpd cascade')
+  - select dblink_exec('anotherdb', 'call omni_httpd.wait_for_configuration_reloads(1)')
+
+tests:
+
+- query: select count(*)
+         from omni_httpd.listeners
+  results:
+  - count: 1
+
+- query: select *
+         from dblink('anotherdb', $$select count(*)
+         from omni_httpd.listeners$$) as t(count int)
+  results:
+  - count: 1
+
+- name: non-zero effective port
+  query: select count(*)
+         from omni_httpd.listeners
+         where effective_port = 0
+  results:
+  - count: 0
+
+- name: non-zero effective port in another database
+  query: select *
+         from dblink('anotherdb', $$select count(*)
+         from omni_httpd.listeners
+         where effective_port = 0$$) as t(count int)
+  results:
+  - count: 0
+
+- name: ports should not match up
+  query: select count(*)
+         from omni_httpd.listeners
+                  inner join dblink('anotherdb',
+                                    $$select effective_port from omni_httpd.listeners$$) t(effective_port int)
+                             on t.effective_port = listeners.effective_port
+  results:
+  - count: 0

--- a/omni/omni/omni_v0.h
+++ b/omni/omni/omni_v0.h
@@ -116,6 +116,8 @@ typedef void (*omni_allocate_shmem_callback_function)(const omni_handle *handle,
 /**
  * @brief Shared memory allocation function
  *
+ * Allocated memory is zero-initialized.
+ *
  * @param handle Handle passed by the loader
  * @param name Name to register this allocation under. It is advised to include
  *             version information into the name to facilitate easier upgrades

--- a/versions.txt
+++ b/versions.txt
@@ -1,10 +1,10 @@
-omni=0.2.1
+omni=0.2.2
 omni_aws=0.1.1
 omni_auth=0.1.1
 omni_containers=0.2.0
 omni_http=0.1.0
 omni_httpc=0.1.2
-omni_httpd=0.2.2
+omni_httpd=0.2.3
 omni_id=0.3.1
 omni_json=0.1.0
 omni_ledger=0.1.0


### PR DESCRIPTION
If the extension is installed in more than one database, only one database will have it running.

Solution: ensure omni_httpd tracking is database-scoped

This also transfered the atomic switchboard to omni_httpd itself (posing a good question: should we remove this functionality from the `omni` interface?)

Another concern here is that using multiple databases leads to a much higher number of workers used. We use the same number of workers per database. How should we handle this in the future, split the number between databases? Introduce a total cap and a parameter for per-database workers?

omni now zero-initializes shmem allocations. This is a safe change but may potentially be a performance issue, though unlikely. If that will ever be needed, we can introduce a flagged version of the call.
