### PR TITLE
Problem: lack of HTTP server controls

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2024-11-30
+
+### Changed
+
+* Backend initialization transaction ends with a commit [#699](https://github.com/omnigres/omnigres/pull/699)
+
 ## [0.2.2] - 2024-11-29
 
 ### Changed
@@ -96,3 +102,5 @@ Initial release following a few months of iterative development.
 [0.2.1]: [https://github.com/omnigres/omnigres/pull/677]
 
 [0.2.2]: [https://github.com/omnigres/omnigres/pull/698]
+
+[0.2.3]: [https://github.com/omnigres/omnigres/pull/699]

--- a/extensions/omni/init.c
+++ b/extensions/omni/init.c
@@ -272,9 +272,9 @@ MODULE_FUNCTION void init_backend(void *arg) {
     PopActiveSnapshot();
 
     if (MyBackendType == B_BACKEND) {
-      // We only abort a transaction if it is a backend. Background worker is already
+      // We only commit transaction if it is a backend. Background worker is already
       // in a transaction (pre-commit).
-      AbortCurrentTransaction();
+      CommitTransactionCommand();
     }
   }
   // Ensure we can clean up when the backend is exiting

--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2024-11-30
+
+### Added
+
+* Explicit omni_httpd server controls [#699](https://github.com/omnigres/omnigres/pull/699)
+
 ## [0.2.3] - 2024-11-29
 
 ### Fixed
@@ -76,3 +82,5 @@ Initial release following a few months of iterative development.
 [0.2.2]: [https://github.com/omnigres/omnigres/pull/692]
 
 [0.2.3]: [https://github.com/omnigres/omnigres/pull/698]
+
+[0.2.4]: [https://github.com/omnigres/omnigres/pull/699]

--- a/extensions/omni_httpd/docs/intro.md
+++ b/extensions/omni_httpd/docs/intro.md
@@ -157,3 +157,19 @@ from
 * `omni_httpd.http_workers` to configure the number of http workers. It defaults to the number of cpus and adjusts if this is higher than what [max_worker_processes](https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-MAX-WORKER-PROCESSES) allows.
 * `omni_httpd.temp_dir` to set the temporary directory for `omni_httpd` files like unix domain sockets, defaults
   to `/tmp`
+
+## Controls
+
+To stop or start omni_httpd server, one can use `omni_httpd.stop()` and `omni_httpd.start()` procedures. They both
+accept a boolean `immediate` parameter (defaults to `false`), which
+will perform the operation immediately without waiting for the transaction to successfully commit.
+
+!!! tip "When is it useful?"
+
+    Beyond the most obvious scenario, in which you just need the server to be stopped,
+    there's a case when the database it is running in requires to be free of users.
+    For example, if you want to create another database with the primary database
+    as its template (for example, for isolated testing).
+
+    Bear in mind that currently, in order for the templated database to get its HTTP
+    server running, you need to connect to it. This may change in the future.

--- a/extensions/omni_httpd/migrate/9_control.sql
+++ b/extensions/omni_httpd/migrate/9_control.sql
@@ -1,0 +1,7 @@
+create procedure stop(immediate boolean default false)
+as
+'MODULE_PATHNAME'language c;
+
+create procedure start(immediate boolean default false)
+as
+'MODULE_PATHNAME'language c;

--- a/extensions/omni_httpd/tests/control.yml
+++ b/extensions/omni_httpd/tests/control.yml
@@ -1,0 +1,74 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 64
+  init:
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - call omni_httpd.wait_for_configuration_reloads(1)
+
+tests:
+
+- name: works
+  query: |
+    select error from omni_httpc.http_execute(
+            omni_httpc.http_request('http://127.0.0.1:' ||
+                                    (select effective_port from omni_httpd.listeners) || '/'))
+  results:
+  - error: null
+
+- name: immediate stop / start
+  steps:
+  - call omni_httpd.stop(immediate => true)
+  - select pg_sleep(0.5)
+  - query: |
+      select error from omni_httpc.http_execute(
+              omni_httpc.http_request('http://127.0.0.1:' ||
+                                      (select effective_port from omni_httpd.listeners) || '/'))
+    results:
+    - error: connection refused
+  - call omni_httpd.start(immediate => true)
+  - select pg_sleep(0.5)
+  - query: |
+      select error from omni_httpc.http_execute(
+      omni_httpc.http_request('http://127.0.0.1:' ||
+      (select effective_port from omni_httpd.listeners) || '/'))
+    results:
+      - error: null
+
+- name: transactional stop / start
+  transaction: false
+  tests:
+  - call omni_httpd.stop()
+  - select pg_sleep(0.5)
+  - query: |
+      select error from omni_httpc.http_execute(
+              omni_httpc.http_request('http://127.0.0.1:' ||
+                                      (select effective_port from omni_httpd.listeners) || '/'))
+    results:
+    - error: connection refused
+  - call omni_httpd.start()
+  - select pg_sleep(0.5)
+  - query: |
+      select error from omni_httpc.http_execute(
+              omni_httpc.http_request('http://127.0.0.1:' ||
+                                      (select effective_port from omni_httpd.listeners) || '/'))
+    results:
+    - error: null
+
+- name: templated setup
+  transaction: false
+  tests:
+  - call omni_httpd.stop()
+  - create database t1 template yregress
+
+- name: new database works
+  database: t1
+  query: |
+    select error
+    from omni_httpc.http_execute(
+            omni_httpc.http_request('http://127.0.0.1:' ||
+                                    (select effective_port from omni_httpd.listeners) || '/'))
+  results:
+  - error: null

--- a/versions.txt
+++ b/versions.txt
@@ -1,10 +1,10 @@
-omni=0.2.2
+omni=0.2.3
 omni_aws=0.1.1
 omni_auth=0.1.1
 omni_containers=0.2.0
 omni_http=0.1.0
 omni_httpc=0.1.2
-omni_httpd=0.2.3
+omni_httpd=0.2.4
 omni_id=0.3.1
 omni_json=0.1.0
 omni_ledger=0.1.0


### PR DESCRIPTION
Sometimes we need to shut HTTP server down (maintenance, security issues, database administration tasks), but short of dropping the extension and/or removing the listeners, this is not possible.

Removing the listeners is also insufficient for database administrative tasks as the master worker will still be runing and preventing some of the tasks from being accomplished.

Solution: introduce explicit stop/start procedures

This also necessitated a fix to `omni` that ensures that backend initialization is folllowed by a commit and not a rollback to ensure that the initialization sequence that latches onto "after commit" timing will actually fire.