### PR TITLE
Problem: omnigres container image only has Omnigres extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,9 @@ RUN curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg | t
 RUN apt-get update && apt-get -y install tailscale
 RUN apt-get install -y lldb-16 libc6-dbg vim valgrind # Ultimate debug toolkit
 COPY docker/entrypoint.sh /usr/local/bin/omnigres-entrypoint.sh
+RUN curl -fsSL https://repo.pigsty.io/key | gpg --dearmor -o /etc/apt/keyrings/pigsty.gpg
+COPY docker/pigsty-io.list /etc/apt/sources.list.d/pigsty-io.list
+RUN apt-get update
 ENTRYPOINT ["omnigres-entrypoint.sh"]
 CMD ["postgres"]
 EXPOSE 22

--- a/docker/pigsty-io.list
+++ b/docker/pigsty-io.list
@@ -1,0 +1,2 @@
+deb [signed-by=/etc/apt/keyrings/pigsty.gpg] https://repo.pigsty.io/apt/infra generic main
+deb [signed-by=/etc/apt/keyrings/pigsty.gpg] https://repo.pigsty.io/apt/pgsql/bookworm bookworm main


### PR DESCRIPTION
However, users may need more than that.

Solution: include pigsty.io distribution for the time being

We are working on [postgres.pm](https://postgres.pm), but before it's ready, we need something to fill in the gap. Pigsty is a fantastic effort by @vonng