### PR TITLE
Problem: omni_sql.execute with nulls for typeless parameters

### DIFF
--- a/extensions/omni_sql/CHANGELOG.md
+++ b/extensions/omni_sql/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.5] - TBD
 
+### Fixed
+
+* SQL execution with typeless `null`-valued parameters [#709](https://github.com/omnigres/omnigres/pull/709)
+
 ## [0.3.4] - 2024-11-09
 
 ### Fixed

--- a/extensions/omni_sql/omni_sql.c
+++ b/extensions/omni_sql/omni_sql.c
@@ -643,12 +643,16 @@ static inline void extract_information_json_parameters(ExecCtx *call_ctx, FuncCa
         call_ctx->types[i] = NUMERICOID;
         call_ctx->values[i] = NumericGetDatum(val.val.numeric);
         break;
+      case jbvNull:
+        // Handle null as if it was text, because we'd just need to
+        // cast it (explicitly or implicitly)
+        call_ctx->types[i] = TEXTOID;
+        call_ctx->values[i] = PointerGetDatum(NULL);
+        break;
       case jbvString:
         call_ctx->types[i] = TEXTOID;
         call_ctx->values[i] =
             PointerGetDatum(cstring_to_text_with_len(val.val.string.val, val.val.string.len));
-        break;
-      case jbvNull:
         break;
       default:
         ereport(ERROR, errmsg("unsupported parameter type at index %i", i));

--- a/extensions/omni_sql/tests/omni_sql/execute.yml
+++ b/extensions/omni_sql/tests/omni_sql/execute.yml
@@ -39,6 +39,15 @@ tests:
     - stmt_row:
         value: 8a0f43cd-a640-4426-94ca-f33955195a1f
 
+- name: typed null parameters
+  steps:
+  - create type kind as enum ('this', 'that')
+  - query: select *
+           from omni_sql.execute('select $1::kind', parameters => jsonb_build_array(null))
+    results:
+    - stmt_row:
+        kind: null
+
 - name: non-array parameters
   query: select *
          from omni_sql.execute('select $1', parameters => jsonb_build_object('a', 1))


### PR DESCRIPTION
Fails with `cache lookup failed for type`

Solution: assume `null`s to be strings at first

This gives us an opportunity to cast it.