### PR TITLE
Problem: omni_polyfill installation instruction

### DIFF
--- a/extensions/omni_polyfill/docs/polyfills.md
+++ b/extensions/omni_polyfill/docs/polyfills.md
@@ -6,7 +6,7 @@
     in order to ensure polyfills are attempted in the right order.
 
     ```postgresql
-    set search_path to omni_polyfill, pg_catalog, '$user', public
+    set search_path to '$user', public, omni_polyfill, pg_catalog
     ```
 
 ## Polyfilled functions


### PR DESCRIPTION
It puts `omni_polyfill` and `pg_catalog` in the begining which affects the selection of the schema to create objects in. We don't want that to be affected.

Solution: put them in the end