### PR TITLE
Problem: extensions can't be installed by non-superuser (🚀 omni_aws 0.1.2, omni_json 0.1.1)

### DIFF
--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -165,6 +165,10 @@ function(add_postgresql_extension NAME)
         add_library(${_ext_TARGET} MODULE ${_ext_SOURCES})
     endif()
 
+    if(NOT DEFINED _ext_SUPERUSER)
+        set(_ext_SUPERUSER true)
+    endif ()
+
     # inja ia a default target dependency for all extensions
     if(NOT TARGET inja)
         add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../misc/inja" "${CMAKE_CURRENT_BINARY_DIR}/inja")
@@ -281,7 +285,7 @@ $<$<NOT:$<BOOL:${_ext_ENCODING}>>:#>encoding = '${_ext_ENCODING}'
 $<$<NOT:$<BOOL:${_ext_REQUIRES}>>:#>requires = '$<JOIN:${_ext_REQUIRES},$<COMMA>>'
 $<$<NOT:$<BOOL:${_ext_SCHEMA}>>:#>schema = ${_ext_SCHEMA}
 $<$<NOT:$<BOOL:${_ext_RELOCATABLE}>>:#>relocatable = ${_ext_RELOCATABLE}
-$<$<NOT:$<BOOL:${_ext_SUPERUSER}>>:#>superuser = ${_ext_SUPERUSER}
+$<$<BOOL:${_ext_SUPERUSER}>:#>superuser = ${_ext_SUPERUSER}
             ")
     # Packaged control file
     if(NOT ${_ext_PRIVATE})
@@ -296,7 +300,7 @@ $<$<NOT:$<BOOL:${_ext_ENCODING}>>:#>encoding = '${_ext_ENCODING}'
 $<$<NOT:$<BOOL:${_ext_REQUIRES}>>:#>requires = '$<JOIN:${_ext_REQUIRES},$<COMMA>>'
 $<$<NOT:$<BOOL:${_ext_SCHEMA}>>:#>schema = ${_ext_SCHEMA}
 $<$<NOT:$<BOOL:${_ext_RELOCATABLE}>>:#>relocatable = ${_ext_RELOCATABLE}
-$<$<NOT:$<BOOL:${_ext_SUPERUSER}>>:#>superuser = ${_ext_SUPERUSER}
+$<$<BOOL:${_ext_SUPERUSER}>:#>superuser = ${_ext_SUPERUSER}
               ")
     endif()
 

--- a/extensions/omni_aws/CMakeLists.txt
+++ b/extensions/omni_aws/CMakeLists.txt
@@ -17,4 +17,5 @@ add_postgresql_extension(
         RELOCATABLE false
         REQUIRES omni_httpc pgcrypto omni_xml omni_web
         TESTS_REQUIRE omni_containers omni_os
+        SUPERUSER false
         SHARED_PRELOAD ON)

--- a/extensions/omni_json/CHANGELOG.md
+++ b/extensions/omni_json/CHANGELOG.md
@@ -5,26 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.2] - 2024-12-25
+## [0.1.1] - 2024-12-25
 
 ### Fixed
 
 * Allow this extension to be installed by non-superuser [#726](https://github.com/omnigres/omnigres/pull/726)
 
-## [0.1.1] - 2024-10-14
-
-### Added
-
-* Support for pre-signed URLs for uploading [#659](https://github.com/omnigres/omnigres/pull/659)
-
 ## [0.1.0] - 2024-03-05
 
 Initial release following a few months of iterative development.
 
-[Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_aws
+[Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_json
 
 [0.1.0]: [https://github.com/omnigres/omnigres/pull/511]
 
-[0.1.1]: [https://github.com/omnigres/omnigres/pull/659]
-
-[0.1.2]: [https://github.com/omnigres/omnigres/pull/726]
+[0.1.1]: [https://github.com/omnigres/omnigres/pull/726]

--- a/extensions/omni_json/CMakeLists.txt
+++ b/extensions/omni_json/CMakeLists.txt
@@ -12,4 +12,5 @@ find_package(PostgreSQL REQUIRED)
 add_postgresql_extension(
         omni_json
         SCHEMA omni_json
+        SUPERUSER false
         RELOCATABLE false)

--- a/versions.txt
+++ b/versions.txt
@@ -1,12 +1,12 @@
 omni=0.2.4
-omni_aws=0.1.1
+omni_aws=0.1.2
 omni_auth=0.1.2
 omni_containers=0.2.0
 omni_http=0.1.0
 omni_httpc=0.1.4
 omni_httpd=0.2.5
 omni_id=0.4.0
-omni_json=0.1.0
+omni_json=0.1.1
 omni_kube=0.1.0
 omni_ledger=0.1.1
 omni_manifest=0.1.1


### PR DESCRIPTION
This is because all of our extensions are built as `superuser=true` (default) by default, requiring superuser, even when this is not necessary.

Solution: allow regulating this parameter through CMake