### PR TITLE
Problem: managing API keys and other secrets (🚀 omni_credentials 0.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Below is the current list of components being worked on, experimented with and d
 |------------------------------------------------------------------------------------------|----------------------------------------------|-------------------------------------------------------|
 | [omni](extensions/omni/README.md) and [Omni interface](omni/README.md)                   | :white_check_mark: First release candidate   | Advanced adapter for Postgres extensions              |
 | [omni_schema](extensions/omni_schema/README.md)                                          | :white_check_mark: First release candidate   | Application schema management                         |
+| [omni_credentials](extensions/omni_schema/README.md)                                     | :white_check_mark: First release candidate   | Application credential management                     |
 | [omni_id](extensions/omni_id/README.md)                                                  | :white_check_mark: First release candidate   | Identity types                                        |
 | [omni_aws](extensions/omni_aws/README.md)                                                | :white_check_mark: First release candidate   | AWS APIs                                              |
 | [omni_json](extensions/omni_json/README.md)                                              | :white_check_mark: First release candidate   | JSON toolkit                                          |

--- a/extensions/omni_credentials/CHANGELOG.md
+++ b/extensions/omni_credentials/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-12-26
+
+Initial release
+
+[Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_credentials
+
+[0.1.0]: [https://github.com/omnigres/omnigres/pull/728]

--- a/extensions/omni_credentials/CMakeLists.txt
+++ b/extensions/omni_credentials/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(omni_json)
+
+include(CTest)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
+
+enable_testing()
+
+find_package(PostgreSQL REQUIRED)
+
+add_postgresql_extension(
+        omni_credentials
+        SCHEMA omni_credentials
+        REQUIRES pgcrypto omni_os
+        RELOCATABLE false)

--- a/extensions/omni_credentials/README.md
+++ b/extensions/omni_credentials/README.md
@@ -1,0 +1,3 @@
+# omni_credentials
+
+Basic application credential management.

--- a/extensions/omni_credentials/docs/credentials.md
+++ b/extensions/omni_credentials/docs/credentials.md
@@ -1,0 +1,52 @@
+# Credential Management
+
+??? tip "`omni_credentials` is a templated extension"
+
+    `omni_credentials` is a templated extension. This means that by installing it, a default copy of it is instantiated into extension's schema. However, you can replicate it into any other schema, tune some of the parameters and make the database own the objects (as opposed to the extension itself):
+
+     ```postgresql 
+     select omni_credentials.instantiate(
+        [schema => 'omni_credentials'],    
+        [env_var => 'OMNI_CREDENTIALS_MASTER_PASSWORD'])
+     ```
+
+    This allows you to have multiple independent credential systems, even if
+    using different versions of `omni_credentials`. 
+
+## Core Architecture
+
+The central object of interest is the `credentials` view (instantiated into `omni_credentials` schema by default), it
+only contains `name` and `value` columns that represent credential name
+and value.
+
+You can simply query and update it as you see fit. Behind the scene, it will propage changes as necessary.
+
+## Credential Encryption
+
+By default, all credentials are stored into the _encryped credentials store_. The encryption key is derived from the
+`OMNI_CREDENTIALS_MASTER_PASSWORD` environment variable[^env].
+
+The store keeps the data in `encrypted_credentials` table.
+
+## File Store
+
+In development mode, it is practical to store encrypted files in the repository
+(conceptually similar to what Ruby on Rails [does](https://guides.rubyonrails.org/security.html#custom-credentials)).
+
+In order to use one, a file store must be instantiated:
+
+```postgresql
+select omni_credentials.instantiate_file_store(filename, [schema])
+```
+
+It will import any available records in this file into the encrypted store,
+and export what's missing in it from the table. After that, every time the credentials are
+updated and commited, the file will be updated.
+
+To reload the credentials from the file (for example, if a new version of the code was pulled),
+invoke `credential_file_store_reload(filename)`. All registered file stores are listed in the
+`credential_file_stores` table.
+
+[^env]:
+
+     This is fine for development environment but may be limited beyond it. In staging and production, direct use of encrypted credentials or future integrated stores is recommended.

--- a/extensions/omni_credentials/migrate/1_instantiate.sql
+++ b/extensions/omni_credentials/migrate/1_instantiate.sql
@@ -1,0 +1,3 @@
+/*{% include "../src/instantiate.sql" %}*/
+/*{% include "../src/instantiate_file_store.sql" %}*/
+select instantiate(schema => 'omni_credentials');

--- a/extensions/omni_credentials/mkdocs.yml
+++ b/extensions/omni_credentials/mkdocs.yml
@@ -1,0 +1,2 @@
+INHERIT: ../../mkdocs.base.yml
+site_name: omni_credentials

--- a/extensions/omni_credentials/src/instantiate.sql
+++ b/extensions/omni_credentials/src/instantiate.sql
@@ -1,0 +1,67 @@
+create function instantiate(schema regnamespace default 'omni_credentials',
+                            env_var text default 'OMNI_CREDENTIALS_MASTER_PASSWORD') returns void
+    language plpgsql
+as
+$$
+begin
+    perform set_config('search_path', schema::text || ',public', true);
+
+    create table credentials_config
+    (
+        environment_variable text not null,
+        unique (environment_variable)
+    );
+
+    insert into credentials_config (environment_variable) values (env_var);
+
+    create table encrypted_credentials
+    (
+        name  text  not null unique,
+        value bytea not null
+    );
+
+    create function credentials_master_password() returns text
+        language sql
+    as
+    $sql$
+    select value
+    from omni_os.env
+             inner join credentials_config on true
+    where variable = environment_variable
+    $sql$;
+    execute format('alter function credentials_master_password set search_path to %I', schema);
+
+
+    create view credentials as
+    select name,
+           pgp_sym_decrypt(value, credentials_master_password()) as value
+    from encrypted_credentials;
+
+    create function credentials_update() returns trigger
+        security definer
+        language plpgsql as
+    $code$
+    begin
+        if old is distinct from null then
+            update encrypted_credentials
+            set value = pgp_sym_encrypt(new.value, credentials_master_password()),
+                name  = new.name
+            where name = old.name;
+        else
+            insert
+            into encrypted_credentials (name, value)
+            values (new.name, pgp_sym_encrypt(new.value, credentials_master_password()));
+        end if;
+        return new;
+    end;
+    $code$;
+    execute format('alter function credentials_update set search_path to %I,public', schema);
+
+    create trigger credentials_update
+        instead of update or insert
+        on credentials
+        for each row
+    execute function credentials_update();
+
+end;
+$$;

--- a/extensions/omni_credentials/src/instantiate_file_store.sql
+++ b/extensions/omni_credentials/src/instantiate_file_store.sql
@@ -1,0 +1,80 @@
+create function instantiate_file_store(filename text, schema regnamespace default 'omni_credentials') returns void
+    language plpgsql
+as
+$$
+begin
+    perform set_config('search_path', schema::text || ',public', true);
+
+    if filename not like '/%' then
+        filename := current_setting('data_directory') || '/' || filename;
+    end if;
+
+    create table if not exists credential_file_stores
+    (
+        filename text unique
+    );
+
+    create or replace function credential_file_store_reload(filename text) returns boolean
+        language plpgsql
+    as
+    $code$
+    begin
+        if filename not like '/%' then
+            filename := current_setting('data_directory') || '/' || filename;
+        end if;
+        perform pg_stat_file(filename);
+        create temp table __new_encrypted_credentials__
+        (
+            like encrypted_credentials
+        ) on commit drop;
+        execute format('copy __new_encrypted_credentials__ from %L', filename);
+
+        insert into encrypted_credentials (name, value)
+        select name, value
+        from __new_encrypted_credentials__
+        on conflict (name) do update set value = excluded.value;
+        return true;
+    exception
+        when others then return false;
+    end;
+    $code$;
+    execute format('alter function credential_file_store_reload set search_path to %I,public', schema);
+
+    insert into credential_file_stores (filename) values (instantiate_file_store.filename);
+
+    perform credential_file_store_reload(filename);
+    execute format('copy encrypted_credentials to %L', filename);
+
+    create or replace function file_store_credentials_update() returns trigger
+        security definer
+        language plpgsql as
+    $code$
+    declare
+        rec record;
+    begin
+        for rec in select * from credential_file_stores
+            loop
+                execute format('copy encrypted_credentials to %L', rec.filename);
+            end loop;
+        return new;
+    end;
+    $code$;
+    execute format('alter function file_store_credentials_update set search_path to %I,public', schema);
+
+    perform
+    from pg_trigger
+    where tgname = 'file_store_credentials_update'
+      and tgrelid = 'encrypted_credentials'::regclass;
+
+    if not found then
+        create constraint trigger file_store_credentials_update
+            -- TODO: truncate can't be supported at this level
+            after update or insert or delete
+            on encrypted_credentials
+            deferrable initially deferred
+            for each row
+        execute function file_store_credentials_update();
+    end if;
+
+end;
+$$;

--- a/extensions/omni_credentials/tests/credentials.yaml
+++ b/extensions/omni_credentials/tests/credentials.yaml
@@ -1,0 +1,42 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_credentials cascade
+  - create schema creds
+  # FIXME: we use PATH because we can't set env variables yet
+  - select omni_credentials.instantiate('creds', env_var => 'PATH')
+
+tests:
+
+- name: encrypts credentials on insert
+  steps:
+  - insert into creds.credentials (name, value) values ('a', 'b')
+  - query: select count(*) from creds.encrypted_credentials where name = 'a'
+    results:
+    - count: 1
+  - query: select value from creds.credentials
+    results:
+    - value: b
+
+- name: encrypts credentials on update
+  steps:
+  - insert into creds.credentials (name, value) values ('a', 'b')
+  - update creds.credentials set value = value || '123'
+  - query: select count(*) from creds.encrypted_credentials where name = 'a'
+    results:
+    - count: 1
+  - query: select value from creds.credentials
+    results:
+    - value: b123
+
+- name: credentials are unique
+  query: insert into creds.credentials (name, value) values ('a', 'b'), ('a','c')
+  error: duplicate key value violates unique constraint "encrypted_credentials_name_key"
+
+- name: credential removal cleans up encrypted credentials
+  steps:
+  - delete from creds.credentials
+  - query: select count(*) from creds.encrypted_credentials
+    results:
+    - count: 0
+

--- a/extensions/omni_credentials/tests/credentials_file_store.yaml
+++ b/extensions/omni_credentials/tests/credentials_file_store.yaml
@@ -1,0 +1,62 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_credentials cascade
+  - create schema creds
+  # FIXME: we use PATH because we can't set env variables yet
+  - select omni_credentials.instantiate('creds', env_var => 'PATH')
+  - create schema creds1
+  # FIXME: we use PATH because we can't set env variables yet
+  - select omni_credentials.instantiate('creds1', env_var => 'PATH')
+
+tests:
+
+- name: exports credentials to a file store upon instantiation
+  commit: true
+  steps:
+  - insert into creds.credentials (name, value) values ('a', 'b')
+  - select omni_credentials.instantiate_file_store(filename => 'creds.txt', schema => 'creds')
+  - select pg_stat_file('creds.txt')
+  - query: select octet_length(pg_read_file('creds.txt'))
+    results:
+    - octet_length: 140
+
+- name: does not update credentials in a file store during transaction
+  commit: true
+  steps:
+  - insert into creds.credentials (name, value) values ('b', 'c')
+  - query: select octet_length(pg_read_file('creds.txt'))
+    results:
+    - octet_length: 140
+
+- name: but it does update credentials in a file store after the transaction
+  query: select octet_length(pg_read_file('creds.txt'))
+  results:
+  - octet_length: 280
+
+- name: imports credentials from a file store
+  commit: true
+  steps:
+  - select omni_credentials.instantiate_file_store(filename => 'creds.txt', schema => 'creds1')
+  - query: select * from creds1.credentials
+    results:
+    - name: a
+      value: b
+    - name: b
+      value: c
+
+- name: updating credentials file
+  commit: true
+  query: insert into creds1.credentials (name, value) values ('c', 'd')
+
+- name: it does not propagate back right away
+  query: select * from creds.credentials where name = 'c'
+  results: [ ]
+
+- name: but it does if explicitly reloaded
+  steps:
+  - select creds.credential_file_store_reload(filename) from creds.credential_file_stores
+  - query: select * from creds.credentials where name = 'c'
+    results:
+    - name: c
+      value: d

--- a/versions.txt
+++ b/versions.txt
@@ -2,6 +2,7 @@ omni=0.2.4
 omni_aws=0.1.2
 omni_auth=0.1.2
 omni_containers=0.2.0
+omni_credentials=0.1.0
 omni_http=0.1.0
 omni_httpc=0.1.4
 omni_httpd=0.2.5


### PR DESCRIPTION
There's no standard facility provided by Omnigres, and this is very common functionality.

Solution: add omni_credentials

It's a template extension that can be instantiated independently of the extension itself (though by default, it instantiates itself)

It employs a neat trick useful in dev mode: you can instantiate a file store that will be kept in sync with a file on the filesystem. In the future, this can also potentially use omni_vfs (once https://github.com/omnigres/omnigres/pull/710 is in).

This means that while developing, you can keep encrypted credentials file up to date.