### PR TITLE
Problem: docker image is only built for latest Postgres

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,7 @@ jobs:
     strategy:
       matrix:
         platform: [ amd64, arm64 ]
+        pg: [ 17, 16, 15, 14, 13 ]
 
     if: github.repository == 'omnigres/omnigres'
     runs-on: ${{ fromJSON('["warp-ubuntu-2204-x64-4x", "warp-ubuntu-2204-arm64-16x"]')[matrix.platform == 'arm64'] }}
@@ -96,7 +97,7 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.platform }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.pg }}:${{ github.sha }}-${{ matrix.platform }}-${{ matrix.pg }}
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
           # Currently using S3 in EU as BuildJet is in the EU and going to the U.S. may be slow
@@ -104,6 +105,7 @@ jobs:
           cache-to: type=gha,url=http://127.0.0.1:49160/
           build-args: |
             BUILD_PARALLEL_LEVEL=4
+            PG=${{ matrix.pg }}
           platforms: linux/${{ matrix.platform }}
           target: pg
 
@@ -114,13 +116,14 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-slim:${{ github.sha }}-${{ matrix.platform }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-slim-${{ matrix.pg }}:${{ github.sha }}-${{ matrix.platform }}-${{ matrix.pg }}
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,url=http://127.0.0.1:49160/
           cache-to: type=gha,url=http://127.0.0.1:49160/
           build-args: |
             BUILD_PARALLEL_LEVEL=4
+            PG=${{ matrix.pg }}
           platforms: linux/${{ matrix.platform }}
           target: pg-slim
 
@@ -131,13 +134,14 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dev:${{ github.sha }}-${{ matrix.platform }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dev-${{ matrix.pg }}:${{ github.sha }}-${{ matrix.platform }}-${{ matrix.pg }}
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,url=http://127.0.0.1:49160/
           cache-to: type=gha,url=http://127.0.0.1:49160/
           build-args: |
             BUILD_PARALLEL_LEVEL=4
+            PG=${{ matrix.pg }}
           platforms: linux/${{ matrix.platform }}
           target: builder
 
@@ -148,13 +152,14 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-kube:${{ github.sha }}-${{ matrix.platform }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-kube-${{ matrix.pg }}:${{ github.sha }}-${{ matrix.platform }}-${{ matrix.pg }}
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,url=http://127.0.0.1:49160/
           cache-to: type=gha,url=http://127.0.0.1:49160/
           build-args: |
             BUILD_PARALLEL_LEVEL=4
+            PG=${{ matrix.pg }}
           platforms: linux/${{ matrix.platform }}
           target: omnikube
 
@@ -173,6 +178,7 @@ jobs:
   manifest:
     strategy:
       matrix:
+        pg: [ 17, 16, 15, 14, 13 ]
         flavor: [ "", "-slim", "-dev","-kube" ]
 
     if: github.event_name != 'pull_request' && github.repository == 'omnigres/omnigres'
@@ -197,19 +203,19 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}-${{ matrix.pg }}
 
       - name: Create and push manifest images (rev)
         uses: Noelware/docker-manifest-action@master # or use a pinned version in the Releases tab
         with:
           inputs:
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}:${{ github.sha }}
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}:${{ github.sha }}-amd64,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}:${{ github.sha }}-arm64
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}-${{ matrix.pg }}:${{ github.sha }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}-${{ matrix.pg }}:${{ github.sha }}-amd64-${{ matrix.pg }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}-${{ matrix.pg }}:${{ github.sha }}-arm64-${{ matrix.pg }}
           push: true
 
       - name: Create and push manifest images (latest)
         uses: Noelware/docker-manifest-action@master # or use a pinned version in the Releases tab
         with:
-          inputs: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}:latest
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}:${{ github.sha }}-amd64,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}:${{ github.sha }}-arm64
+          inputs: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}-${{ matrix.pg }}:latest
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}-${{ matrix.pg }}:${{ github.sha }}-amd64-${{ matrix.pg }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.flavor }}-${{ matrix.pg }}:${{ github.sha }}-arm64-${{ matrix.pg }}
           push: true

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The fastest way to try Omnigres out is by using its [container image](https://gi
 ```shell
 docker volume create omnigres
 docker run --name omnigres --mount source=omnigres,target=/var/lib/postgresql/data \
-           -p 127.0.0.1:5432:5432 -p 127.0.0.1:8080:8080 --rm ghcr.io/omnigres/omnigres:latest
+           -p 127.0.0.1:5432:5432 -p 127.0.0.1:8080:8080 --rm ghcr.io/omnigres/omnigres-17:latest
 # Now you can connect to it:
 psql -h localhost -p 5432 -U omnigres omnigres # password is `omnigres`
 ```

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -9,7 +9,7 @@ docker run --name omnigres \
            -e POSTGRES_USER=omnigres \
            -e POSTGRES_DB=omnigres \
            --mount source=omnigres,target=/var/lib/postgresql/data \
-           -p 127.0.0.1:5432:5432 -p 127.0.0.1:8080:8080 --rm ghcr.io/omnigres/omnigres:latest
+           -p 127.0.0.1:5432:5432 -p 127.0.0.1:8080:8080 --rm ghcr.io/omnigres/omnigres-17:latest
 # Now you can connect to it:
 psql -h localhost -p 5432 -U omnigres omnigres # password is `omnigres`
 ```
@@ -108,7 +108,7 @@ You can access the HTTP server at [localhost:8080](http://localhost:8080)
     However, if you want a smaller image and don't need Rust, use __slim__ flavor:
 
     ```
-    ghcr.io/omnigres/omnigres-slim:latest
+    ghcr.io/omnigres/omnigres-slim-17:latest
     ```
 
 ### Building your own image

--- a/extensions/omni_python/docs/intro.md
+++ b/extensions/omni_python/docs/intro.md
@@ -87,7 +87,7 @@ docker run --name omnigres \
            -e POSTGRES_USER=omnigres \
            -e POSTGRES_DB=omnigres \
            --mount source=omnigres,target=/var/lib/postgresql/data -v $(pwd)/python-files:/python-files \
-           -p 127.0.0.1:5433:5432 --rm ghcr.io/omnigres/omnigres-slim:latest
+           -p 127.0.0.1:5433:5432 --rm ghcr.io/omnigres/omnigres-slim-17:latest
 ```
 
 Let's try it out!
@@ -207,7 +207,7 @@ docker run --name omnigres \
            -e POSTGRES_DB=omnigres \
            --mount source=omnigres,target=/var/lib/postgresql/data -v $(pwd)/python-files:/python-files \
            -p 127.0.0.1:5450:5432 -p 127.0.0.1:8000:8000 \
-           --rm ghcr.io/omnigres/omnigres-slim:latest
+           --rm ghcr.io/omnigres/omnigres-slim-17:latest
 ```
 
 Setup HTTP handler for out Flask application:


### PR DESCRIPTION
(Which is currently 17.2)

However, this can be problematic when one needs a specific major version for one reason or another (for example, some extensions do not always support the latest version)

Solution: build image per major version