### PR TITLE
Problem: container image build started failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,8 @@ EXPOSE 5432
 # Official PostgreSQL build
 FROM pg-slim AS pg
 ENV PG=${PG}
-RUN apt-get -y install $(apt-cache search  "^postgresql-${PG}-*" | cut -d' ' -f1 | grep -v 'hunspell' | grep -v 'citus')
+COPY docker/apt-pin /etc/apt/preferences.d/99-pin
+RUN apt-get -y install $(apt-cache search  "^postgresql-${PG}-*" | cut -d' ' -f1 | grep -v 'hunspell' | grep -v 'citus' | grep -v 'pgdg' | grep -v 'dbgsym')
 #COPY --from=plrust /var/lib/postgresql/plrust/target/release /plrust-release
 ## clear it in case it already exists
 #RUN rm -rf /docker-entrypoint-initdb.d

--- a/docker/apt-pin
+++ b/docker/apt-pin
@@ -1,0 +1,3 @@
+Package: postgresql-*
+Pin: release o=Pigsty
+Pin-Priority: 700


### PR DESCRIPTION
Example:

```
The following packages have unmet dependencies:
 postgresql-16-pgdg-pgroonga : Conflicts: postgresql-16-pgroonga but 3.2.5-1PIGSTY~bookworm is to be installed
```

Solution: make Pigsty higher priority and exclude pgpg-denominated packages and dbgsym in a search to avoid conflicts