### PR TITLE
Problem: where should Python wheels come from?

### DIFF
--- a/extensions/omni_python/CHANGELOG.md
+++ b/extensions/omni_python/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.1.1] - TBD
 
+### Changed
+
+* Bundle Python wheels into the pkglibdir [#736](https://github.com/omnigres/omnigres/pull/736)
+
 ## [0.1.0] - 2024-03-05
 
 Initial release following a few months of iterative development.

--- a/extensions/omni_python/CMakeLists.txt
+++ b/extensions/omni_python/CMakeLists.txt
@@ -15,5 +15,6 @@ add_postgresql_extension(
         SCHEMA omni_python
         RELOCATABLE false
         REQUIRES plpython3u
+        SOURCES omni_python.c
         TESTS_REQUIRE omni_httpd
 )

--- a/extensions/omni_python/migrate/5_install_requirements.sql
+++ b/extensions/omni_python/migrate/5_install_requirements.sql
@@ -3,4 +3,4 @@ create function install_requirements(requirements text) returns void
 as
 $$
 /*{% include "../src/install_requirements.py" %}*/
-$$
+$$;

--- a/extensions/omni_python/migrate/6_wheel_path.sql
+++ b/extensions/omni_python/migrate/6_wheel_path.sql
@@ -1,0 +1,4 @@
+create function wheel_paths() returns setof text
+    language c
+as
+'MODULE_PATHNAME';

--- a/extensions/omni_python/omni_python.c
+++ b/extensions/omni_python/omni_python.c
@@ -1,0 +1,49 @@
+/**
+ * \file omni_python.c
+ *
+ */
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+#include <nodes/execnodes.h>
+#include <miscadmin.h>
+#include <utils/builtins.h>
+#include <sys/stat.h>
+// clang-format on
+
+PG_MODULE_MAGIC;
+
+PG_FUNCTION_INFO_V1(wheel_paths);
+
+Datum wheel_paths(PG_FUNCTION_ARGS) {
+
+  ReturnSetInfo *rsinfo = (ReturnSetInfo *)fcinfo->resultinfo;
+  rsinfo->returnMode = SFRM_Materialize;
+
+  MemoryContext per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
+  MemoryContext oldcontext = MemoryContextSwitchTo(per_query_ctx);
+
+  Tuplestorestate *tupstore = tuplestore_begin_heap(false, false, work_mem);
+  rsinfo->setResult = tupstore;
+
+  char _pkglib_path[MAXPGPATH];
+  get_pkglib_path(my_exec_path, _pkglib_path);
+
+  char *wheel_path = psprintf("%s/omni_python--" EXT_VERSION, _pkglib_path);
+
+  struct stat st;
+  if (stat(wheel_path, &st) == 0) {
+
+    tuplestore_putvalues(tupstore, rsinfo->expectedDesc,
+                         (Datum[1]){PointerGetDatum(cstring_to_text(wheel_path))},
+                         (bool[1]){false});
+  }
+
+#if PG_MAJORVERSION_NUM < 17
+  tuplestore_donestoring(tupstore);
+#endif
+
+  MemoryContextSwitchTo(oldcontext);
+
+  PG_RETURN_NULL();
+}

--- a/extensions/omni_python/src/install_requirements.py
+++ b/extensions/omni_python/src/install_requirements.py
@@ -21,7 +21,8 @@ index = plpy.execute(
 
 find_links = plpy.execute(
     plpy.prepare(
-        "select array_agg(value) as value from omni_python.config where name = 'pip_find_links'"))[0][
+        "select array_agg(value) as value from (select value from omni_python.config where name = 'pip_find_links' union all select * from omni_python.wheel_paths()) t"))[
+                 0][
                  'value'] or []
 
 requirements_txt = tempfile.mktemp()


### PR DESCRIPTION
It's very inconvenient that for every deployment, we need to provision `find_links` configuration.

Solution: make omni_python expect packaging to put them into pkglibdir

More specifically, `pkglibdir/omni_python--VERSION` directory.