### PR TITLE
Problem: importing a Python module after a failed attempt

### DIFF
--- a/extensions/omni_python/CHANGELOG.md
+++ b/extensions/omni_python/CHANGELOG.md
@@ -11,6 +11,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Bundle Python wheels into the pkglibdir [#736](https://github.com/omnigres/omnigres/pull/736)
 
+### Fixed
+
+* Ensure newly installed modules can be successfully imported after a failed
+  attempt [#737](https://github.com/omnigres/omnigres/pull/737)
+
 ## [0.1.0] - 2024-03-05
 
 Initial release following a few months of iterative development.

--- a/extensions/omni_python/src/execute.sql
+++ b/extensions/omni_python/src/execute.sql
@@ -3,6 +3,7 @@ create function execute(code text) returns void
 as
 $$
     import os
+    import importlib
     site_packages = os.path.expanduser(
         plpy.execute(plpy.prepare("""
                      select coalesce(
@@ -11,8 +12,12 @@ $$
                         as value
        """))[0]['value'])
     import sys
-    sys.path.insert(0, site_packages)
+
+    if sys.path[0] != site_packages:
+        sys.path.insert(0, site_packages)
+    importlib.invalidate_caches()
     del sys
     del os
+    del importlib
     exec(compile(code, 'unnamed.py', 'exec'), globals(), locals())
 $$;

--- a/extensions/omni_python/src/functions.py
+++ b/extensions/omni_python/src/functions.py
@@ -5,6 +5,7 @@ import typing
 import types
 import sys
 import hashlib
+import importlib
 
 # types.UnionType has only been available since Python 3.10
 if sys.version_info >= (3, 10):
@@ -20,7 +21,11 @@ site_packages = os.path.expanduser(
                         as value
        """))[0]['value'])
 
-sys.path.insert(0, site_packages)
+if sys.path[0] != site_packages:
+    sys.path.insert(0, site_packages)
+
+importlib.invalidate_caches()
+
 import omni_python
 
 have_omni_vfs = False


### PR DESCRIPTION
If we try to load a module and it wasn't available, and then install it and try again, omni_python might not see it.

Solution: invalidate loader caches

It is not very efficient to put this into every function call, but this is currently handling the fact that installation may occur in a different backend and therefore invalidating there wouldn't do anything.

While at it, let's make sure we don't add new `sys.path` if it is already there.