### PR TITLE
Problem: container images build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,7 +138,7 @@ EXPOSE 5432
 FROM pg-slim AS pg
 ENV PG=${PG}
 COPY docker/apt-pin /etc/apt/preferences.d/99-pin
-RUN apt-get -y install $(apt-cache search  "^postgresql-${PG}-*" | cut -d' ' -f1 | grep -v 'hunspell' | grep -v 'citus' | grep -v 'pgdg' | grep -v 'dbgsym')
+RUN apt-get -y install $(apt-cache search  "^postgresql-${PG}-*" | cut -d' ' -f1 | grep -v 'hunspell' | grep -v 'citus' | grep -v 'pgdg' | grep -v 'timescaledb-tsl' | grep -v 'anonymizer' | grep -v 'dbgsym')
 #COPY --from=plrust /var/lib/postgresql/plrust/target/release /plrust-release
 ## clear it in case it already exists
 #RUN rm -rf /docker-entrypoint-initdb.d


### PR DESCRIPTION
Conflicts between `timescaledb` and `timescaledb-tsl` as well as `pg-anon` and `anonymizer`

Solution: hard-code resolution of this conflict

Once we switch over to pgpm, this should not be a problem because because we'll (hopefully) rely on a single source.