### PR TITLE
Problem: Omnigres extensions discovery

### DIFF
--- a/cmake/PostgreSQLExtension.cmake
+++ b/cmake/PostgreSQLExtension.cmake
@@ -143,7 +143,7 @@ endfunction()
 
 function(add_postgresql_extension NAME)
     set(_optional SHARED_PRELOAD PRIVATE UNVERSIONED_SO NO_DEFAULT_CONTROL)
-    set(_single VERSION ENCODING SCHEMA RELOCATABLE TESTS SUPERUSER TARGET)
+    set(_single VERSION ENCODING SCHEMA RELOCATABLE TESTS SUPERUSER TARGET COMMENT)
     set(_multi SOURCES REQUIRES TESTS_REQUIRE REGRESS DEPENDS_ON UPGRADE_SCRIPTS)
     cmake_parse_arguments(_ext "${_optional}" "${_single}" "${_multi}" ${ARGN})
 
@@ -313,6 +313,7 @@ $<$<BOOL:${_ext_SUPERUSER}>:#>superuser = ${_ext_SUPERUSER}
         OUTPUT ${_default_control_file}
         CONTENT
         "default_version = '${_ext_VERSION}'
+$<$<NOT:$<BOOL:${_ext_COMMENT}>>:#>comment = '${_ext_COMMENT}'
 ")
     # Packaged default control file
     if(NOT ${_ext_PRIVATE})

--- a/extensions/omni/CMakeLists.txt
+++ b/extensions/omni/CMakeLists.txt
@@ -15,6 +15,7 @@ check_symbol_exists(dladdr "dlfcn.h" HAVE_DLADDR)
 
 add_postgresql_extension(
         omni
+        COMMENT "Advanced adapter for Postgres extensions"
         SCHEMA omni
         RELOCATABLE false
         SOURCES init.c omni.c hook_harness.c module.c extension.c workers.c utils.c dshash.c

--- a/extensions/omni_auth/CMakeLists.txt
+++ b/extensions/omni_auth/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_auth
+        COMMENT "Basic session management"
         SCHEMA omni_auth
         REQUIRES omni_types omni_id pgcrypto btree_gist omni_polyfill
         RELOCATABLE false)

--- a/extensions/omni_aws/CMakeLists.txt
+++ b/extensions/omni_aws/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_aws
+        COMMENT "Amazon Web Services APIs (S3)"
         SCHEMA omni_aws
         RELOCATABLE false
         REQUIRES omni_httpc pgcrypto omni_xml omni_web

--- a/extensions/omni_containers/CMakeLists.txt
+++ b/extensions/omni_containers/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_containers
+        COMMENT "Docker container management"
         SCHEMA omni_containers
         RELOCATABLE false
         SOURCES omni_containers.c

--- a/extensions/omni_credentials/CMakeLists.txt
+++ b/extensions/omni_credentials/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_credentials
+        COMMENT "Application credential management"
         SCHEMA omni_credentials
         REQUIRES pgcrypto omni_os
         RELOCATABLE false)

--- a/extensions/omni_http/CMakeLists.txt
+++ b/extensions/omni_http/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_http
+        COMMENT "Basic HTTP types"
         SCHEMA omni_http
         RELOCATABLE false)
 

--- a/extensions/omni_httpc/CMakeLists.txt
+++ b/extensions/omni_httpc/CMakeLists.txt
@@ -17,6 +17,7 @@ pkg_check_modules(BROTLI_ENC libbrotlienc)
 
 add_postgresql_extension(
         omni_httpc
+        COMMENT "HTTP client"
         SCHEMA omni_httpc
         RELOCATABLE false
         SOURCES omni_httpc.c ca-bundle.cc ssl.c

--- a/extensions/omni_httpd/CMakeLists.txt
+++ b/extensions/omni_httpd/CMakeLists.txt
@@ -23,6 +23,7 @@ pkg_check_modules(BROTLI_ENC libbrotlienc)
 
 add_postgresql_extension(
         omni_httpd
+        COMMENT "HTTP server"
         SCHEMA omni_httpd
         RELOCATABLE false
         SOURCES omni_httpd.c master_worker.c http_worker.c event_loop.c fd.c cascading_query.c

--- a/extensions/omni_id/CMakeLists.txt
+++ b/extensions/omni_id/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_id
+        COMMENT "Identity types"
         SOURCES uuidv7_stub.c
         RELOCATABLE true
 )

--- a/extensions/omni_json/CMakeLists.txt
+++ b/extensions/omni_json/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_json
+        COMMENT "JSON toolkit"
         SCHEMA omni_json
         SUPERUSER false
         RELOCATABLE false)

--- a/extensions/omni_kube/CMakeLists.txt
+++ b/extensions/omni_kube/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_kube
+        COMMENT "Kubernetes (k8s) integration"
         SCHEMA omni_kube
         RELOCATABLE false
         REQUIRES omni_httpc omni_web omni_var pgcrypto)

--- a/extensions/omni_ledger/CMakeLists.txt
+++ b/extensions/omni_ledger/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_ledger
+        COMMENT "Financial ledger"
         SCHEMA omni_ledger
         SOURCES omni_ledger.c
         REQUIRES omni_id omni_polyfill

--- a/extensions/omni_manifest/CMakeLists.txt
+++ b/extensions/omni_manifest/CMakeLists.txt
@@ -45,6 +45,7 @@ add_postgresql_extension(
 
 add_postgresql_extension(
         omni_manifest
+        COMMENT "Package installation manifests"
         SCHEMA omni_manifest
         TESTS_REQUIRE omni_manifest_test_1 omni_manifest_test_2 omni_manifest_test_1_2 omni_manifest_test_2_2
         RELOCATABLE false)

--- a/extensions/omni_mimetypes/CMakeLists.txt
+++ b/extensions/omni_mimetypes/CMakeLists.txt
@@ -13,5 +13,6 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_mimetypes
+        COMMENT "MIME types"
         SCHEMA omni_mimetypes
         RELOCATABLE false)

--- a/extensions/omni_os/CMakeLists.txt
+++ b/extensions/omni_os/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_os
+        COMMENT "Operating system integration"
         SCHEMA omni_os
         RELOCATABLE false
         SUPERUSER true

--- a/extensions/omni_polyfill/CMakeLists.txt
+++ b/extensions/omni_polyfill/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_polyfill
+        COMMENT "Postgres API polyfills"
         SCHEMA omni_polyfill
         RELOCATABLE NO
         SOURCES omni_polyfill.c arrays.c uuidv7.c

--- a/extensions/omni_python/CMakeLists.txt
+++ b/extensions/omni_python/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_python
+        COMMENT "First-class Python support"
         SCHEMA omni_python
         RELOCATABLE false
         REQUIRES plpython3u

--- a/extensions/omni_regex/CMakeLists.txt
+++ b/extensions/omni_regex/CMakeLists.txt
@@ -17,6 +17,7 @@ CPMAddPackage(NAME pcre2 SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../deps/pcre2 V
 
 add_postgresql_extension(
         omni_regex
+        COMMENT "PCRE-compatible regular expressions"
         SOURCES omni_regex.c pcre2.c
         RELOCATABLE true
 )

--- a/extensions/omni_rest/CMakeLists.txt
+++ b/extensions/omni_rest/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_rest
+        COMMENT "REST API toolkit (with PostgREST support)"
         SCHEMA omni_rest
         REQUIRES omni_httpd omni_sql omni_web omni_var pgcrypto
 )

--- a/extensions/omni_schema/CMakeLists.txt
+++ b/extensions/omni_schema/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_schema
+        COMMENT "Advanced schema management tooling"
         SCHEMA omni_schema
         RELOCATABLE false
         REQUIRES omni_sql omni_vfs dblink

--- a/extensions/omni_seq/CMakeLists.txt
+++ b/extensions/omni_seq/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_seq
+        COMMENT "Distributed integer sequences"
         SCHEMA omni_seq
         RELOCATABLE false
         SOURCES omni_seq.c

--- a/extensions/omni_service/CMakeLists.txt
+++ b/extensions/omni_service/CMakeLists.txt
@@ -13,5 +13,6 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_service
+        COMMENT "Service management"
         SCHEMA omni_service
         RELOCATABLE false)

--- a/extensions/omni_session/CMakeLists.txt
+++ b/extensions/omni_session/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_session
+        COMMENT "Session management"
         SCHEMA omni_session
         REQUIRES omni_var omni_id omni_web omni_httpd omni_polyfill
         RELOCATABLE false)

--- a/extensions/omni_sql/CMakeLists.txt
+++ b/extensions/omni_sql/CMakeLists.txt
@@ -23,6 +23,7 @@ if(NOT DEFINED ENV{OMNI_SQL_ALREADY_INCLUDED})
 
     add_postgresql_extension(
             omni_sql
+            COMMENT "Programmatic SQL manipulation"
             SCHEMA omni_sql
             RELOCATABLE false
             SOURCES omni_sql.c

--- a/extensions/omni_txn/CMakeLists.txt
+++ b/extensions/omni_txn/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_txn
+        COMMENT "Transaction management"
         SCHEMA omni_txn
         RELOCATABLE false
         SOURCES omni_txn.c retry.c linearization.c

--- a/extensions/omni_types/CMakeLists.txt
+++ b/extensions/omni_types/CMakeLists.txt
@@ -16,6 +16,7 @@ endif ()
 
 add_postgresql_extension(
         omni_types
+        COMMENT "Advanced types"
         SCHEMA omni_types
         RELOCATABLE false
         SOURCES omni_types.c unit.c sum_type.c funsig_type.c

--- a/extensions/omni_var/CMakeLists.txt
+++ b/extensions/omni_var/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_var
+        COMMENT "Scoped variables"
         SCHEMA omni_var
         RELOCATABLE false
         SOURCES omni_var.c txn.c session.c statement.c

--- a/extensions/omni_vfs/CMakeLists.txt
+++ b/extensions/omni_vfs/CMakeLists.txt
@@ -13,12 +13,14 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_vfs_types_v1
+        COMMENT "Virtual File System types (v1)"
         SCHEMA omni_vfs_types_v1
         RELOCATABLE false
         TESTS OFF)
 
 add_postgresql_extension(
         omni_vfs
+        COMMENT "Virtual File System"
         SCHEMA omni_vfs
         RELOCATABLE false
         DEPENDS_ON libpgaug

--- a/extensions/omni_web/CMakeLists.txt
+++ b/extensions/omni_web/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(Uriparser REQUIRED)
 
 add_postgresql_extension(
         omni_web
+        COMMENT "Common web stack primitives"
         SCHEMA omni_web
         RELOCATABLE false
         SOURCES omni_web.c urlencode.c

--- a/extensions/omni_xml/CMakeLists.txt
+++ b/extensions/omni_xml/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(PostgreSQL REQUIRED)
 
 add_postgresql_extension(
         omni_xml
+        COMMENT "XML toolkit"
         SCHEMA omni_xml
         RELOCATABLE false
         SOURCES omni_xml.cc)

--- a/extensions/omni_yaml/CMakeLists.txt
+++ b/extensions/omni_yaml/CMakeLists.txt
@@ -14,6 +14,7 @@ CPMAddPackage(NAME libfyaml SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../deps/libf
 
 add_postgresql_extension(
         omni_yaml
+        COMMENT "YAML toolkit"
         SCHEMA omni_yaml
         SOURCES omni_yaml.c
         RELOCATABLE false)


### PR DESCRIPTION
Once installed, it may be difficult to tell what each extension does. Browsing `pg_available_extensions` does not reveal any additional information.

Solution: supply extension descriptions