### PR TITLE
Problem: ensuring applications work as intended (🚀 omni_test 0.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Below is the current list of components being worked on, experimented with and d
 |------------------------------------------------------------------------------------------|----------------------------------------------|-------------------------------------------------------|
 | [omni](extensions/omni/README.md) and [Omni interface](omni/README.md)                   | :white_check_mark: First release candidate   | Advanced adapter for Postgres extensions              |
 | [omni_service](extensions/omni_service/README.md)                                        | :white_check_mark: First release candidate   | Uniform service management bus                        |
+| [omni_test](extensions/omni_test/README.md)                                              | :white_check_mark: First release candidate   | Testing framework                                     |
 | [omni_schema](extensions/omni_schema/README.md)                                          | :white_check_mark: First release candidate   | Application schema management                         |
 | [omni_credentials](extensions/omni_schema/README.md)                                     | :white_check_mark: First release candidate   | Application credential management                     |
 | [omni_id](extensions/omni_id/README.md)                                                  | :white_check_mark: First release candidate   | Identity types                                        |

--- a/docker/initdb-slim/004-default-extensions.sql.templ
+++ b/docker/initdb-slim/004-default-extensions.sql.templ
@@ -6,3 +6,4 @@ create extension omni_kube cascade;
 create extension omni_manifest cascade;
 create extension omni_os cascade;
 create extension omni_yaml cascade;
+create extension omni_test cascade;

--- a/extensions/omni/test/CMakeLists.txt
+++ b/extensions/omni/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.25.1)
-project(omni_test)
+project(omni__test)
 
 include(CPM)
 include(CTest)
@@ -10,11 +10,11 @@ enable_testing()
 
 find_package(PostgreSQL REQUIRED)
 
-set(SOURCES omni_test.c hooks.c)
+set(SOURCES omni__test.c hooks.c)
 
 add_postgresql_extension(
-        omni_test
-        SCHEMA omni_test
+        omni__test
+        SCHEMA omni__test
         PRIVATE ON
         RELOCATABLE false
         SOURCES ${SOURCES}
@@ -22,13 +22,13 @@ add_postgresql_extension(
         VERSION 1)
 
 add_postgresql_extension(
-        omni_test
-        TARGET omni_test_v2
-        SCHEMA omni_test
+        omni__test
+        TARGET omni__test_v2
+        SCHEMA omni__test
         PRIVATE ON
         RELOCATABLE false
         SOURCES ${SOURCES}
-        UPGRADE_SCRIPTS tests/omni_test--1--2.sql
+        UPGRADE_SCRIPTS tests/omni__test--1--2.sql
         NO_DEFAULT_CONTROL ON
         TESTS_REQUIRE omni omni_types
         VERSION 2
@@ -37,7 +37,7 @@ add_postgresql_extension(
 
 add_postgresql_extension(
         no_fun
-        SCHEMA omni_test
+        SCHEMA omni__test
         PRIVATE ON
         RELOCATABLE false
         SOURCES no_fun.c
@@ -45,8 +45,8 @@ add_postgresql_extension(
         VERSION 1)
 
 
-target_link_libraries(omni_test libomni)
-target_link_libraries(omni_test_v2 libomni)
+target_link_libraries(omni__test libomni)
+target_link_libraries(omni__test_v2 libomni)
 target_link_libraries(no_fun libomni)
 
-#add_dependencies(omni_test omni)
+#add_dependencies(omni__test omni)

--- a/extensions/omni/test/omni__test.c
+++ b/extensions/omni/test/omni__test.c
@@ -24,7 +24,7 @@
 PG_MODULE_MAGIC;
 OMNI_MAGIC;
 
-OMNI_MODULE_INFO(.name = "omni_test", .version = EXT_VERSION,
+OMNI_MODULE_INFO(.name = "omni__test", .version = EXT_VERSION,
                  .identity = "ed0aaa35-54c6-426e-a69d-2c74a836053b");
 
 static bool omni_loaded = false;
@@ -173,7 +173,7 @@ void _Omni_init(const omni_handle *handle) {
         &found);
   }
 
-  omni_guc_variable guc_bool = {.name = "omni_test.bool",
+  omni_guc_variable guc_bool = {.name = "omni__test.bool",
                                 .type = PGC_BOOL,
                                 .typed = {.bool_val = {.boot_value = false}},
                                 .context = PGC_USERSET};
@@ -181,7 +181,7 @@ void _Omni_init(const omni_handle *handle) {
   GUC_bool = guc_bool.typed.bool_val.value;
 
   omni_guc_variable guc_int = {
-      .name = "omni_test.int",
+      .name = "omni__test.int",
       .type = PGC_INT,
       .typed = {.int_val = {.boot_value = 1, .min_value = 1, .max_value = INT_MAX}},
       .context = PGC_USERSET};
@@ -189,14 +189,14 @@ void _Omni_init(const omni_handle *handle) {
   GUC_int = guc_int.typed.int_val.value;
 
   omni_guc_variable guc_real = {
-      .name = "omni_test.real",
+      .name = "omni__test.real",
       .type = PGC_REAL,
       .typed = {.real_val = {.boot_value = 1.23, .min_value = 1, .max_value = 100}},
       .context = PGC_USERSET};
   handle->declare_guc_variable(handle, &guc_real);
   GUC_real = guc_real.typed.real_val.value;
 
-  omni_guc_variable guc_string = {.name = "omni_test.string",
+  omni_guc_variable guc_string = {.name = "omni__test.string",
                                   .type = PGC_STRING,
                                   .typed = {.string_val = {.boot_value = ""}},
                                   .context = PGC_USERSET};
@@ -204,7 +204,7 @@ void _Omni_init(const omni_handle *handle) {
   GUC_string = guc_string.typed.string_val.value;
 
   omni_guc_variable guc_enum = {
-      .name = "omni_test.enum",
+      .name = "omni__test.enum",
       .type = PGC_ENUM,
       .typed = {.enum_val = {.boot_value = 1, .options = GUC_enum_options}},
       .context = PGC_USERSET};

--- a/extensions/omni/test/tests/bgworker.yml
+++ b/extensions/omni/test/tests/bgworker.yml
@@ -4,7 +4,7 @@ instance:
     shared_preload_libraries: */env/OMNI_SO
   init:
   # We create the extension here
-  - create extension omni_test
+  - create extension omni__test
 
 tests:
 
@@ -47,7 +47,7 @@ tests:
 - name: with a new database, there's going to be more local workers
   database: db1
   tests:
-  - create extension omni_test
+  - create extension omni__test
   - query: select
                count(*)
            from
@@ -58,7 +58,7 @@ tests:
     - count: 2
 
 - name: omni's own background worker handle
-  query: select omni_test.local_worker_pid() is not null as result
+  query: select omni__test.local_worker_pid() is not null as result
   results:
   - result: true
 

--- a/extensions/omni/test/tests/dsa.yml
+++ b/extensions/omni/test/tests/dsa.yml
@@ -5,7 +5,7 @@ instance:
     max_worker_processes: 4
   init:
   # We create the extension here
-  - create extension omni_test
+  - create extension omni__test
   - create extension omni
 # This is silly, but pg_yregress is not programmable (yet)
 # so we just repeat the same thing a lot of times...name:

--- a/extensions/omni/test/tests/guc.yml
+++ b/extensions/omni/test/tests/guc.yml
@@ -2,34 +2,34 @@ $schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress
 instance:
   config:
     shared_preload_libraries: */env/OMNI_SO
-    omni_test.int: 10
-    omni_test.bool: true
-    omni_test.real: 3.14
-    omni_test.string: hello
-    omni_test.enum: test1
+    omni__test.int: 10
+    omni__test.bool: true
+    omni__test.real: 3.14
+    omni__test.string: hello
+    omni__test.enum: test1
   init:
   # We create the extension here
-  - create extension omni_test
+  - create extension omni__test
 
 tests:
 
 - name: int
   tests:
   - name: int value after boot
-    query: select omni_test.guc_int()
+    query: select omni__test.guc_int()
     results:
     - guc_int: 10
 
   - name: int value after change
     steps:
-    - select set_config('omni_test.int', '100', true)
-    - query: select omni_test.guc_int()
+    - select set_config('omni__test.int', '100', true)
+    - query: select omni__test.guc_int()
       results:
       - guc_int: 100
 
   - name: int value after reset
     reset: true
-    query: select omni_test.guc_int()
+    query: select omni__test.guc_int()
     results:
     # because it is user-set
     - guc_int: 10
@@ -37,20 +37,20 @@ tests:
 - name: bool
   tests:
   - name: bool value after boot
-    query: select omni_test.guc_bool()
+    query: select omni__test.guc_bool()
     results:
     - guc_bool: true
 
   - name: bool value after change
     steps:
-    - select set_config('omni_test.bool', 'false', true)
-    - query: select omni_test.guc_bool()
+    - select set_config('omni__test.bool', 'false', true)
+    - query: select omni__test.guc_bool()
       results:
       - guc_bool: false
 
   - name: bool value after reset
     reset: true
-    query: select omni_test.guc_bool()
+    query: select omni__test.guc_bool()
     results:
     # because it is user-set
     - guc_bool: true
@@ -59,20 +59,20 @@ tests:
   tests:
 
   - name: real value after boot
-    query: select omni_test.guc_real()
+    query: select omni__test.guc_real()
     results:
     - guc_real: 3.14
 
   - name: real value after change
     steps:
-    - select set_config('omni_test.real', '21.22', true)
-    - query: select omni_test.guc_real()
+    - select set_config('omni__test.real', '21.22', true)
+    - query: select omni__test.guc_real()
       results:
       - guc_real: 21.22
 
   - name: real value after reset
     reset: true
-    query: select omni_test.guc_real()
+    query: select omni__test.guc_real()
     results:
     # because it is user-set
     - guc_real: 3.14
@@ -81,20 +81,20 @@ tests:
   tests:
 
   - name: string value after boot
-    query: select omni_test.guc_string()
+    query: select omni__test.guc_string()
     results:
     - guc_string: hello
 
   - name: string value after change
     steps:
-    - select set_config('omni_test.string', 'bye', true)
-    - query: select omni_test.guc_string()
+    - select set_config('omni__test.string', 'bye', true)
+    - query: select omni__test.guc_string()
       results:
       - guc_string: bye
 
   - name: string value after reset
     reset: true
-    query: select omni_test.guc_string()
+    query: select omni__test.guc_string()
     results:
     # because it is user-set
     - guc_string: hello
@@ -103,20 +103,20 @@ tests:
   tests:
 
   - name: enum value after boot
-    query: select omni_test.guc_enum()
+    query: select omni__test.guc_enum()
     results:
     - guc_enum: 2
 
   - name: enum value after change
     steps:
-    - select set_config('omni_test.enum', 'test', true)
-    - query: select omni_test.guc_enum()
+    - select set_config('omni__test.enum', 'test', true)
+    - query: select omni__test.guc_enum()
       results:
       - guc_enum: 1
 
   - name: enum value after reset
     reset: true
-    query: select omni_test.guc_enum()
+    query: select omni__test.guc_enum()
     results:
     # because it is user-set
     - guc_enum: 2

--- a/extensions/omni/test/tests/hooks.yml
+++ b/extensions/omni/test/tests/hooks.yml
@@ -8,7 +8,7 @@ tests:
 - name: load hooks in a transaction
   tests:
   - steps:
-    - create extension omni_test
+    - create extension omni__test
     - query: select 1
       notices:
       - run_hook
@@ -18,7 +18,7 @@ tests:
       notices: [ ]
 
 - name: commit creating the extension
-  query: create extension omni_test
+  query: create extension omni__test
   commit: true
 
 - name: the hook should stay
@@ -28,7 +28,7 @@ tests:
 
 - name: drop extension in an uncommitted transaction
   steps:
-  - drop extension omni_test
+  - drop extension omni__test
   - query: select 1
     # Hook is not running
     notices: [ ]

--- a/extensions/omni/test/tests/hooks_coverage.yml
+++ b/extensions/omni/test/tests/hooks_coverage.yml
@@ -3,16 +3,16 @@ instance:
   config:
     shared_preload_libraries: */env/OMNI_SO
   init:
-  - create extension omni_test
+  - create extension omni__test
 
 tests:
 
 - name: xact_callback
-  query: select omni_test.was_hook_called('xact_callback') as result
+  query: select omni__test.was_hook_called('xact_callback') as result
   results:
   - result: true
 
 - name: planner_hook
-  query: select omni_test.was_hook_called('planner') as result
+  query: select omni__test.was_hook_called('planner') as result
   results:
   - result: true

--- a/extensions/omni/test/tests/lwlock.yml
+++ b/extensions/omni/test/tests/lwlock.yml
@@ -4,18 +4,18 @@ instance:
     shared_preload_libraries: */env/OMNI_SO
   init:
   # We create the extension here
-  - create extension omni_test
+  - create extension omni__test
 
 tests:
 
 - name: mylock's identifier is correct
-  query: select omni_test.lwlock_identifier(omni_test.mylock_tranche_id()) as ident
+  query: select omni__test.lwlock_identifier(omni__test.mylock_tranche_id()) as ident
   results:
   - ident: mylock
 
 - name: record mylock tranche id
   commit: true
-  query: create table tranche as (select omni_test.mylock_tranche_id())
+  query: create table tranche as (select omni__test.mylock_tranche_id())
 
 - name: other backend gets the same tranche id and name for the lock
   reset: true
@@ -23,11 +23,11 @@ tests:
   # tranche id gets us the right id
   query: select
              count(*),
-             omni_test.lwlock_identifier(omni_test.mylock_tranche_id()) as ident
+             omni__test.lwlock_identifier(omni__test.mylock_tranche_id()) as ident
          from
              tranche
          where
-             mylock_tranche_id = omni_test.mylock_tranche_id()
+             mylock_tranche_id = omni__test.mylock_tranche_id()
   results:
   - count: 1
     ident: mylock

--- a/extensions/omni/test/tests/multidb.yml
+++ b/extensions/omni/test/tests/multidb.yml
@@ -4,7 +4,7 @@ instance:
     shared_preload_libraries: */env/OMNI_SO
   init:
   # We create the extension here
-  - create extension omni_test
+  - create extension omni__test
   - create extension omni
 
 tests:
@@ -15,7 +15,7 @@ tests:
          from
              omni.modules
          where
-             path like '%/omni_test--1.so'
+             path like '%/omni__test--1.so'
   results:
   - count: 1
 
@@ -32,7 +32,7 @@ tests:
            from
                omni.modules
            where
-               path like '%/omni_test--1.so'
+               path like '%/omni__test--1.so'
     results:
     - count: 1
 
@@ -42,6 +42,6 @@ tests:
          from
              omni.modules
          where
-             path like '%/omni_test--1.so'
+             path like '%/omni__test--1.so'
   results:
   - count: 1

--- a/extensions/omni/test/tests/shmem.yml
+++ b/extensions/omni/test/tests/shmem.yml
@@ -4,32 +4,32 @@ instance:
     shared_preload_libraries: */env/OMNI_SO
   init:
   # We create the extension here
-  - create extension omni_test
+  - create extension omni__test
   - create extension omni
 
 tests:
 
 - name: initial value
-  query: select omni_test.get_shmem()
+  query: select omni__test.get_shmem()
   results:
   - get_shmem: hello
 
 - name: set value
   steps:
-  - select omni_test.set_shmem('test')
-  - query: select omni_test.get_shmem()
+  - select omni__test.set_shmem('test')
+  - query: select omni__test.get_shmem()
     results:
     - get_shmem: test
 
 - name: value is set after a reconnect (new backend)
   reset: true
   steps:
-  - query: select omni_test.get_shmem()
+  - query: select omni__test.get_shmem()
     results:
     - get_shmem: test
   # This one below is testing a particular scenario of having to re-attach
   # to a DSA that is already attached (or, the after-effects of _Omni_init, rather)
-  - query: select omni_test.get_shmem1()
+  - query: select omni__test.get_shmem1()
     results:
     - get_shmem1: hello
 
@@ -41,18 +41,18 @@ tests:
   database: db1
   commit: true
   steps:
-  - create extension omni_test
-  - query: select omni_test.get_shmem()
+  - create extension omni__test
+  - query: select omni__test.get_shmem()
     results:
     - get_shmem: hello
 
 - name: lookup shmem that was not allocated
-  query: select omni_test.lookup_shmem('not-allocated')
+  query: select omni__test.lookup_shmem('not-allocated')
   results:
   - lookup_shmem: null
 
 - name: lookup shmem that was allocated
-  query: select omni_test.lookup_shmem('test:db1')
+  query: select omni__test.lookup_shmem('test:db1')
   results:
   - lookup_shmem: hello
 
@@ -79,7 +79,7 @@ tests:
 
 - name: bad shared memory allocation doesn't get recorded
   steps:
-  - query: select omni_test.bad_shmalloc()
+  - query: select omni__test.bad_shmalloc()
     error: invalid DSA memory alloc request size 18446744073709551615
   - query: select
                count(*)
@@ -92,10 +92,10 @@ tests:
 
 - name: shmem refcounting
   steps:
-  - query: select omni_test.alloc_shmem('refc', 100);
+  - query: select omni__test.alloc_shmem('refc', 100);
     results:
     - alloc_shmem: false
-  - query: select omni_test.alloc_shmem('refc', 100);
+  - query: select omni__test.alloc_shmem('refc', 100);
     results:
     - alloc_shmem: true
   - query: select
@@ -106,7 +106,7 @@ tests:
                name = 'refc'
     results:
     - refcounter: 2
-  - query: select omni_test.dealloc_shmem('refc');
+  - query: select omni__test.dealloc_shmem('refc');
     results:
     - dealloc_shmem: true
   - query: select
@@ -117,7 +117,7 @@ tests:
                name = 'refc'
     results:
     - refcounter: 1
-  - query: select omni_test.dealloc_shmem('refc');
+  - query: select omni__test.dealloc_shmem('refc');
     results:
     - dealloc_shmem: true
   - query: select
@@ -127,6 +127,6 @@ tests:
            where
                name = 'refc'
     results: [ ]
-  - query: select omni_test.dealloc_shmem('refc');
+  - query: select omni__test.dealloc_shmem('refc');
     results:
     - dealloc_shmem: false

--- a/extensions/omni/test/tests/shmem_rollback.yml
+++ b/extensions/omni/test/tests/shmem_rollback.yml
@@ -10,7 +10,7 @@ tests:
 - name: uncommited allocations don't leak
   tests:
   - steps:
-    - create extension omni_test
+    - create extension omni__test
     - query: select
                  count(*)
              from

--- a/extensions/omni/test/tests/switch.yml
+++ b/extensions/omni/test/tests/switch.yml
@@ -4,28 +4,28 @@ instance:
     shared_preload_libraries: */env/OMNI_SO
   init:
   # We create the extension here
-  - create extension omni_test
+  - create extension omni__test
 
 tests:
 
 # NB: we don't use two first switches because they already used in init/deinit
 
 - name: turn some on
-  query: select omni_test.atomic_on(B'110100'::int8)::bit(6)
+  query: select omni__test.atomic_on(B'110100'::int8)::bit(6)
   results:
   - atomic_on: 110100
 
 - name: turn more on
-  query: select omni_test.atomic_on(B'111100'::int8)::bit(6)
+  query: select omni__test.atomic_on(B'111100'::int8)::bit(6)
   results:
   - atomic_on: 001000
 
 - name: turn some off
-  query: select omni_test.atomic_off(B'101000'::int8)::bit(6)
+  query: select omni__test.atomic_off(B'101000'::int8)::bit(6)
   results:
   - atomic_off: 101000
 
 - name: turn more off
-  query: select omni_test.atomic_off(B'111000'::int8)::bit(6)
+  query: select omni__test.atomic_off(B'111000'::int8)::bit(6)
   results:
   - atomic_off: 010000

--- a/extensions/omni/test/tests/tests.yml
+++ b/extensions/omni/test/tests/tests.yml
@@ -4,13 +4,13 @@ instance:
     shared_preload_libraries: */env/OMNI_SO
   init:
   # We create the extension here
-  - create extension omni_test
+  - create extension omni__test
   - create extension omni
 
 tests:
 
 - name: _Omni_init() gets called
-  query: select omni_test.is_backend_initialized()
+  query: select omni__test.is_backend_initialized()
   results:
   - is_backend_initialized: true
 
@@ -27,7 +27,7 @@ tests:
          from
              omni.modules
          where
-             path like '%/omni_test--1.so'
+             path like '%/omni__test--1.so'
   results:
   - count: 1
 
@@ -36,9 +36,9 @@ tests:
                 identity,
                 version
          from omni.modules
-         where path like '%/omni_test--1.so'
+         where path like '%/omni__test--1.so'
   results:
-  - name: omni_test
+  - name: omni__test
     identity: ed0aaa35-54c6-426e-a69d-2c74a836053b
     version: 1
 
@@ -50,6 +50,6 @@ tests:
   - select 1
 
 - name: omni_is_present
-  query: select omni_test.omni_present_test() as loaded
+  query: select omni__test.omni_present_test() as loaded
   results:
   - loaded: true

--- a/extensions/omni/test/tests/upgrade.yml
+++ b/extensions/omni/test/tests/upgrade.yml
@@ -4,7 +4,7 @@ instance:
     shared_preload_libraries: */env/OMNI_SO
   init:
   # We create the extension here
-  - create extension omni_test version '1' cascade
+  - create extension omni__test version '1' cascade
   - create extension omni
 
 tests:
@@ -18,7 +18,7 @@ tests:
                                               on modules.path = probin and modules.path not like '%' || $1 || '%')
     params:
       - */env/OMNI_SO
-  - alter extension omni_test update to '2'
+  - alter extension omni__test update to '2'
   - query: select
                count(*)
            from

--- a/extensions/omni/test/tests/upgrade_extra_deps.yml
+++ b/extensions/omni/test/tests/upgrade_extra_deps.yml
@@ -7,7 +7,7 @@ instance:
     shared_preload_libraries: */env/OMNI_SO
   init:
   # We create the extension here
-  - create extension omni_test version '1' cascade
+  - create extension omni__test version '1' cascade
   - create extension omni
   # We use omni_types to test how dependencies are upgraded
   - create extension omni_types cascade
@@ -23,7 +23,7 @@ tests:
         ((select oid from pg_class where relname = 'pg_proc'),
          (select oid from pg_proc where prosrc = 'sum_in' limit 1), 0,
          (select oid from pg_class where relname = 'pg_extension'),
-         (select oid from pg_catalog.pg_extension where extname = 'omni_test'), 0, 'e')
+         (select oid from pg_catalog.pg_extension where extname = 'omni__test'), 0, 'e')
   - query: select
                probin like '%omni_types%' as result
            from
@@ -36,7 +36,7 @@ tests:
 
 - name: updates pg_proc's probin
   steps:
-  - alter extension omni_test update to '2'
+  - alter extension omni__test update to '2'
   - query: select
                probin like '%omni_types%' as result
            from

--- a/extensions/omni/test/tests/upgrade_init_sequence.yml
+++ b/extensions/omni/test/tests/upgrade_init_sequence.yml
@@ -4,7 +4,7 @@ instance:
     shared_preload_libraries: */env/OMNI_SO
   init:
   # We create the extension here
-  - create extension omni_test version '1' cascade
+  - create extension omni__test version '1' cascade
 
 tests:
 
@@ -25,7 +25,7 @@ tests:
   - delete
     from
         events
-  - alter extension omni_test update to '2'
+  - alter extension omni__test update to '2'
   - query: select
                event
            from

--- a/extensions/omni_manifest/tests/artifact.yml
+++ b/extensions/omni_manifest/tests/artifact.yml
@@ -10,20 +10,20 @@ tests:
   - name: text to artifact
     query: |
       with
-          artifact as (select ('omni_test=1.2#req=2'::text::omni_manifest.artifact).*)
+          artifact as (select ('omni__test=1.2#req=2'::text::omni_manifest.artifact).*)
       select
           (self).*,
           requirements::text
       from
           artifact
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
       requirements: req=2
   - name: text to artifacts
     query: |
       with
-          artifact as (select * from unnest(e'omni_test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]))
+          artifact as (select * from unnest(e'omni__test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]))
       select
           (self).*,
           requirements::text
@@ -32,7 +32,7 @@ tests:
       order by
           name
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
       requirements: req=2
     - name: req
@@ -41,7 +41,7 @@ tests:
   - name: text to artifacts
     query: |
       with
-          artifact as (select * from unnest(e'omni_test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]))
+          artifact as (select * from unnest(e'omni__test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]))
       select
           (self).*,
           requirements::text
@@ -50,7 +50,7 @@ tests:
       order by
           name
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
       requirements: req=2
     - name: req
@@ -60,7 +60,7 @@ tests:
   - name: text to artifacts (semicolon instead of newline)
     query: |
       with
-          artifact as (select * from unnest('omni_test=1.2#req=2;req=2#base=0'::text::omni_manifest.artifact[]))
+          artifact as (select * from unnest('omni__test=1.2#req=2;req=2#base=0'::text::omni_manifest.artifact[]))
       select
           (self).*,
           requirements::text
@@ -69,7 +69,7 @@ tests:
       order by
           name
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
       requirements: req=2
     - name: req
@@ -79,7 +79,7 @@ tests:
   - name: text to artifacts (superfluous newline tolerance)
     query: |
       with
-          artifact as (select * from unnest(e'omni_test=1.2#req=2\nreq=2#base=0\n'::text::omni_manifest.artifact[]))
+          artifact as (select * from unnest(e'omni__test=1.2#req=2\nreq=2#base=0\n'::text::omni_manifest.artifact[]))
       select
           (self).*,
           requirements::text
@@ -88,7 +88,7 @@ tests:
       order by
           name
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
       requirements: req=2
     - name: req
@@ -96,17 +96,17 @@ tests:
       requirements: base=0
 
   - name: artifact to text
-    query: select 'omni_test=1.2#req=2'::text::omni_manifest.artifact::text as artifact
+    query: select 'omni__test=1.2#req=2'::text::omni_manifest.artifact::text as artifact
     results:
-    - artifact: omni_test=1.2#req=2
+    - artifact: omni__test=1.2#req=2
   - name: artifacts to text
-    query: select e'omni_test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]::text as artifact
+    query: select e'omni__test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]::text as artifact
     results:
-    - artifact: omni_test=1.2#req=2;req=2#base=0
+    - artifact: omni__test=1.2#req=2;req=2#base=0
   - name: artifacts to text
-    query: select e'omni_test=1.2#req=2\nreq=2'::text::omni_manifest.artifact[]::text as artifact
+    query: select e'omni__test=1.2#req=2\nreq=2'::text::omni_manifest.artifact[]::text as artifact
     results:
-    - artifact: omni_test=1.2#req=2;req=2
+    - artifact: omni__test=1.2#req=2;req=2
 
 - name: JSON conversion
   tests:
@@ -114,14 +114,14 @@ tests:
     query: |
       with
           artifact as (select
-                           ('{"target": {"omni_test": "1.2"}, "requirements": {"req": "2"}}'::json::omni_manifest.artifact).*)
+                           ('{"target": {"omni__test": "1.2"}, "requirements": {"req": "2"}}'::json::omni_manifest.artifact).*)
       select
           (self).*,
           requirements::text
       from
           artifact
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
       requirements: req=2
   - name: JSON to artifacts
@@ -129,7 +129,7 @@ tests:
       with
           artifact as (select *
                        from
-                           unnest('[{"target": {"omni_test": "1.2"}, "requirements": {"req": "2"}}, {"target": {"req": "2"}, "requirements": {"base": "0"}}]'::json::omni_manifest.artifact[]))
+                           unnest('[{"target": {"omni__test": "1.2"}, "requirements": {"req": "2"}}, {"target": {"req": "2"}, "requirements": {"base": "0"}}]'::json::omni_manifest.artifact[]))
       select
           (self).*,
           requirements::text
@@ -138,27 +138,27 @@ tests:
       order by
           name
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
       requirements: req=2
     - name: req
       version: 2
       requirements: base=0
   - name: artifact to JSON
-    query: select 'omni_test=1.2#req=2'::text::omni_manifest.artifact::json as artifact
+    query: select 'omni__test=1.2#req=2'::text::omni_manifest.artifact::json as artifact
     results:
     - artifact:
         target:
-          omni_test: 1.2
+          omni__test: 1.2
         requirements:
           req: 2
   - name: artifacts to JSON
     query: select
-               json_array_elements(e'omni_test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]::json) as artifact
+               json_array_elements(e'omni__test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]::json) as artifact
     results:
     - artifact:
         target:
-          omni_test: 1.2
+          omni__test: 1.2
         requirements:
           req: 2
     - artifact:
@@ -173,14 +173,14 @@ tests:
     query: |
       with
           artifact as (select
-                           ('{"target": {"omni_test": "1.2"}, "requirements": {"req": "2"}}'::jsonb::omni_manifest.artifact).*)
+                           ('{"target": {"omni__test": "1.2"}, "requirements": {"req": "2"}}'::jsonb::omni_manifest.artifact).*)
       select
           (self).*,
           requirements::text
       from
           artifact
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
       requirements: req=2
   - name: JSONB to artifacts
@@ -188,7 +188,7 @@ tests:
       with
           artifact as (select *
                        from
-                           unnest('[{"target": {"omni_test": "1.2"}, "requirements": {"req": "2"}}, {"target": {"req": "2"}, "requirements": {"base": "0"}}]'::jsonb::omni_manifest.artifact[]))
+                           unnest('[{"target": {"omni__test": "1.2"}, "requirements": {"req": "2"}}, {"target": {"req": "2"}, "requirements": {"base": "0"}}]'::jsonb::omni_manifest.artifact[]))
       select
           (self).*,
           requirements::text
@@ -197,27 +197,27 @@ tests:
       order by
           name
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
       requirements: req=2
     - name: req
       version: 2
       requirements: base=0
   - name: artifact to JSONB
-    query: select 'omni_test=1.2#req=2'::text::omni_manifest.artifact::jsonb as artifact
+    query: select 'omni__test=1.2#req=2'::text::omni_manifest.artifact::jsonb as artifact
     results:
     - artifact:
         target:
-          omni_test: 1.2
+          omni__test: 1.2
         requirements:
           req: 2
   - name: artifacts to JSONB
     query: select
-               jsonb_array_elements(e'omni_test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]::jsonb) as artifact
+               jsonb_array_elements(e'omni__test=1.2#req=2\nreq=2#base=0'::text::omni_manifest.artifact[]::jsonb) as artifact
     results:
     - artifact:
         target:
-          omni_test: 1.2
+          omni__test: 1.2
         requirements:
           req: 2
     - artifact:

--- a/extensions/omni_manifest/tests/requirement.yml
+++ b/extensions/omni_manifest/tests/requirement.yml
@@ -16,25 +16,25 @@ tests:
 - name: text conversion
   tests:
   - name: text to requirement
-    query: select ('omni_test=1.2'::text::omni_manifest.requirement).*
+    query: select ('omni__test=1.2'::text::omni_manifest.requirement).*
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
 
   - name: text to requirements (single)
     query: select *
            from
-               unnest('omni_test=1.2'::text::omni_manifest.requirement[])
+               unnest('omni__test=1.2'::text::omni_manifest.requirement[])
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
 
   - name: text to requirements
     query: select *
            from
-               unnest('omni_test=1.2,omni_experiment=0.1'::text::omni_manifest.requirement[])
+               unnest('omni__test=1.2,omni_experiment=0.1'::text::omni_manifest.requirement[])
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
     - name: omni_experiment
       version: 0.1
@@ -42,9 +42,9 @@ tests:
   - name: text to requirements (with spaces)
     query: select *
            from
-               unnest('omni_test=1.2 , omni_experiment=0.1'::text::omni_manifest.requirement[])
+               unnest('omni__test=1.2 , omni_experiment=0.1'::text::omni_manifest.requirement[])
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
     - name: omni_experiment
       version: 0.1
@@ -64,27 +64,27 @@ tests:
   tests:
   - name: json to requirement
     query: |
-      select ('{"omni_test": "1.2"}'::json::omni_manifest.requirement).*
+      select ('{"omni__test": "1.2"}'::json::omni_manifest.requirement).*
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
 
   - name: json to requirements (single)
     query: |
       select *
       from
-          unnest('{"omni_test": "1.2"}'::json::omni_manifest.requirement[])
+          unnest('{"omni__test": "1.2"}'::json::omni_manifest.requirement[])
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
 
   - name: json to requirements
     query: |
       select *
       from
-          unnest('{"omni_test": "1.2", "omni_experimental": "0.1"}'::json::omni_manifest.requirement[])
+          unnest('{"omni__test": "1.2", "omni_experimental": "0.1"}'::json::omni_manifest.requirement[])
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
     - name: omni_experimental
       version: 0.1
@@ -107,27 +107,27 @@ tests:
   tests:
   - name: jsonb to requirement
     query: |
-      select ('{"omni_test": "1.2"}'::jsonb::omni_manifest.requirement).*
+      select ('{"omni__test": "1.2"}'::jsonb::omni_manifest.requirement).*
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
 
   - name: jsonb to requirements (single)
     query: |
       select *
       from
-          unnest('{"omni_test": "1.2"}'::jsonb::omni_manifest.requirement[])
+          unnest('{"omni__test": "1.2"}'::jsonb::omni_manifest.requirement[])
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
 
   - name: jsonb to requirements
     query: |
       select *
       from
-          unnest('{"omni_test": "1.2", "omni_experimental": "0.1"}'::jsonb::omni_manifest.requirement[])
+          unnest('{"omni__test": "1.2", "omni_experimental": "0.1"}'::jsonb::omni_manifest.requirement[])
     results:
-    - name: omni_test
+    - name: omni__test
       version: 1.2
     - name: omni_experimental
       version: 0.1

--- a/extensions/omni_test/CHANGELOG.md
+++ b/extensions/omni_test/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-01-17
+
+Initial release
+
+[Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_test
+
+[0.1.0]: [https://github.com/omnigres/omnigres/pull/745]

--- a/extensions/omni_test/CMakeLists.txt
+++ b/extensions/omni_test/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(omni_test)
+
+include(CTest)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
+
+enable_testing()
+
+find_package(PostgreSQL REQUIRED)
+
+add_postgresql_extension(
+        omni_test
+        SCHEMA omni_test
+        REQUIRES dblink
+        TESTS_REQUIRE omni_schema omni_httpd
+        RELOCATABLE false)

--- a/extensions/omni_test/README.md
+++ b/extensions/omni_test/README.md
@@ -1,0 +1,3 @@
+# omni_test
+
+Testing framework.

--- a/extensions/omni_test/docs/guide.md
+++ b/extensions/omni_test/docs/guide.md
@@ -1,0 +1,47 @@
+# Testing Guide
+
+`omni_test` allows you to run tests from within the database.
+
+!!! tip "`omni_test` is a templated extension"
+
+    `omni_test` is a templated extension. This means that by installing it, its default-instantiated
+     into `omni_test` but can be instantiated into any other schema:
+
+     ```postgresql 
+     select omni_test.instantiate([schema => 'omni_test'])
+     ```
+
+In order to use it, you need to provision a template database with your test functions and everything they need:
+
+```postgresql
+create database myapp_test;
+update pg_database set datistemplate = true where datname = 'myapp_test';
+-- provision the content
+```
+
+!!! tip "Use `omni_schema.assemble_schema`"
+
+    One of the easiest way to provision files into this new schema is to use
+    `omni_schema.assemble_schema`:
+
+    ```postgresql
+    select * from 
+      omni_schema.assemble_schema('dbname=myapp_test ..',
+                                   omni_vfs.local_fs('/path/to/tests'))
+    ```
+
+To run tests, simply pass the name of the database to the `run_tests` function:
+
+```postgresql
+select * from omni_test.run_tests('myapp_test')
+```
+
+The results will conform to this structure:
+
+|          **Name** | Type        | Description                           |
+|------------------:|:------------|:--------------------------------------|
+|          **name** | `text`      | The name of the test.                 |
+|   **description** | `text`      | A detailed description of the test    |
+|    **start_time** | `timestamp` | The start time of the test.           |
+|      **end_time** | `timestamp` | The end time of the test.             |
+| **error_message** | `text`      | An error message, if the test failed. |

--- a/extensions/omni_test/migrate/1_instantiate.sql
+++ b/extensions/omni_test/migrate/1_instantiate.sql
@@ -1,0 +1,2 @@
+/*{% include "../src/instantiate.sql" %}*/
+select instantiate(schema => 'omni_test');

--- a/extensions/omni_test/mkdocs.yml
+++ b/extensions/omni_test/mkdocs.yml
@@ -1,0 +1,2 @@
+INHERIT: ../../mkdocs.base.yml
+site_name: omni_test

--- a/extensions/omni_test/src/instantiate.sql
+++ b/extensions/omni_test/src/instantiate.sql
@@ -1,0 +1,185 @@
+create function instantiate(schema regnamespace default 'omni_test') returns void
+    language plpgsql
+as
+$$
+begin
+    -- Set the search path to target schema and public
+    perform
+        set_config('search_path', schema::text || ',public', true);
+
+
+    -- Ensure we have omni_test role (these are cluster-wide)
+    perform from pg_roles where rolname = 'omni_test';
+    if not found then
+        -- We set password to omni_test; this is not expected to be used in production
+        -- but used to ensure we have stable connection parameters.
+        -- We also grant it superuser privileges as tests might require that.
+        create role omni_test superuser password 'omni_test';
+    end if;
+
+    create type test as
+    (
+
+    );
+    execute format('alter type test set schema %s', schema);
+
+    -- Test report
+    create type test_report as
+    (
+        name          text,
+        description   text,
+        start_time    timestamp,
+        end_time      timestamp,
+        error_message text
+    );
+
+    -- Utility functions
+    create function _omni_test_dropdb_helper(self_conn text, db name) returns void
+        language plpgsql
+    as
+    $_omni_test_dropdb_helper$
+    declare
+        conn text := 'omni_test_drop_' || db;
+    begin
+        if current_setting('server_version') ~ '^(15|16).*' then
+            perform dblink_connect(conn, self_conn);
+            perform dblink_send_query(conn, format('drop database if exists %I', db));
+            while dblink_is_busy(conn)
+                loop
+                    null;
+                end loop;
+            perform dblink_disconnect(conn);
+        else
+            perform dblink(self_conn, format('drop database if exists %I', db));
+        end if;
+    end;
+    $_omni_test_dropdb_helper$;
+
+    -- Create test runner
+    create function run_tests(db name, out test_report test_report) returns setof test_report
+        language plpgsql as
+    $run_tests$
+    declare
+        run            int  := 1;
+        test_run       text := 'omni_test_' || run;
+        conn           text := 'omni_test_' || run;
+        host           text := ' host=' ||
+                               current_setting('unix_socket_directories') || ' port=' || current_setting('port') ||
+                               ' user=' || current_user;
+        self_conn      text := 'dbname=' || current_database() || host;
+        template_conn  text := 'dbname=' || db || host;
+        rec            record;
+        -- TODO: temporary workaround until we have omni_service fully integrated
+        has_omni_httpd bool;
+    begin
+        -- We must only run this off a template database so we can easily clone it.
+        -- Technically, it doesn't have to be a template one – but this further enforces
+        -- the notion that this is not a working database (for example, `omni_httpd`
+        -- does not start the server in a template database)
+        perform from pg_database where datname = db and datistemplate;
+        if not found then
+            raise exception 'Selected database (%) must be a template database', db;
+        end if;
+
+
+        select
+            present
+        into has_omni_httpd
+        from
+            dblink(template_conn, $sql$
+            select true from pg_extension where extname = 'omni_httpd'
+            $sql$) as t(present bool);
+
+        -- Clean up the test run database if one is left over
+        -- TODO: stop services uniformly when this will become possible
+        perform from pg_database where datname = test_run;
+        if found and has_omni_httpd then
+            perform dblink_exec('dbname=' || test_run || host, 'call omni_httpd.stop()');
+            perform _omni_test_dropdb_helper(self_conn, test_run);
+        end if;
+
+        begin
+
+            -- Find qualifying tests
+            for rec in
+                select *
+                from
+                    dblink(template_conn,
+                           $sql$
+                           select
+                               pg_proc.prokind,
+                               pg_proc.proname,
+                               ns.nspname,
+                               d.description
+                           from
+                               pg_proc
+                                   inner join pg_namespace ns on ns.oid = pg_proc.pronamespace
+                                   left join pg_description d on d.objoid = pg_proc.oid
+                           where
+                               (cardinality(proargtypes) = 1 and proargtypes[0] = 'omni_test.test'::regtype
+                                   and prokind = 'p') or
+                               (cardinality(proargtypes) = 0 and
+                                   prorettype = 'omni_test.test'::regtype)
+                           $sql$) t(prokind "char", proname name, nspname name, description text)
+                loop
+                    -- Clone the database
+                    perform dblink(self_conn, format('create database %I template %I', test_run, db));
+                    -- Connect to it
+                    perform dblink_connect(conn, 'dbname=' || test_run || host);
+
+                    test_report.name = rec.nspname || '.' || rec.proname;
+                    test_report.description = rec.description;
+
+                    -- Run the test
+                    test_report.start_time := clock_timestamp();
+                    begin
+                        if rec.prokind = 'p' then
+                            perform *
+                            from
+                                dblink(conn, format('call %I.%I(null)', rec.nspname, rec.proname)) r(result test);
+                        else
+                            perform *
+                            from
+                                dblink(conn, format('select %I.%I()', rec.nspname, rec.proname)) r(result test);
+                        end if;
+                        raise notice 'ok – %', test_report.name;
+                    exception
+                        when others then
+                            raise notice 'failure – % – %', test_report.name, sqlerrm;
+                            test_report.error_message = sqlerrm;
+                            null;
+                    end;
+                    test_report.end_time := clock_timestamp();
+                    return next;
+                    test_report.error_message = null;
+
+                    -- TODO: stop services uniformly when this will become possible
+                    if has_omni_httpd then
+                        perform dblink_exec(conn, 'call omni_httpd.stop()');
+                    end if;
+                    perform dblink_disconnect(conn);
+                    perform _omni_test_dropdb_helper(self_conn, test_run);
+                end loop;
+        exception
+            when others then
+                perform from unnest(dblink_get_connections()) t(name) where name = conn;
+                if found then
+                    perform dblink_disconnect(conn);
+                end if;
+                -- TODO: stop services uniformly when this will become possible
+                if has_omni_httpd then
+                    perform dblink_exec('dbname=' || test_run || host, 'call omni_httpd.stop()');
+                end if;
+                perform _omni_test_dropdb_helper(self_conn, test_run);
+                raise;
+        end;
+        return;
+
+    end;
+    $run_tests$;
+
+    execute format('alter function run_tests set search_path to %I,public', schema);
+
+
+end;
+$$;

--- a/extensions/omni_test/tests/fixture/db1/extensions.sql
+++ b/extensions/omni_test/tests/fixture/db1/extensions.sql
@@ -1,0 +1,1 @@
+create extension omni_test cascade;

--- a/extensions/omni_test/tests/fixture/db1/tests.sql
+++ b/extensions/omni_test/tests/fixture/db1/tests.sql
@@ -1,0 +1,48 @@
+create procedure test1(inout test omni_test.test)
+    language plpgsql
+as
+$$
+begin
+    create table test
+    (
+    );
+end;
+$$;
+
+comment on procedure test1 is $$Test 1$$;
+
+create procedure test2(inout test omni_test.test)
+    language plpgsql
+as
+$$
+begin
+    -- Intentionally conflicting with test1
+    create table test
+    (
+    );
+end;
+$$;
+
+comment on procedure test2 is $$Test 2$$;
+
+
+create procedure err(inout test omni_test.test)
+    language plpgsql
+as
+$$
+begin
+    raise exception 'failed test';
+end;
+$$;
+
+comment on procedure err is $$Error test$$;
+
+create function test_fun() returns omni_test.test
+    language plpgsql as
+$$
+begin
+    return null;
+end;
+$$;
+
+comment on function test_fun is $$Test function$$;

--- a/extensions/omni_test/tests/fixture/db_http/extensions.sql
+++ b/extensions/omni_test/tests/fixture/db_http/extensions.sql
@@ -1,0 +1,2 @@
+create extension omni_test cascade;
+create extension omni_httpd cascade;

--- a/extensions/omni_test/tests/fixture/db_http/tests.sql
+++ b/extensions/omni_test/tests/fixture/db_http/tests.sql
@@ -1,0 +1,47 @@
+create procedure test1(inout test omni_test.test)
+    language plpgsql
+as
+$$
+begin
+    create table test
+    (
+    );
+end;
+$$;
+
+comment on procedure test1 is $$Test 1$$;
+
+create procedure test2(inout test omni_test.test)
+    language plpgsql
+as
+$$
+begin
+    -- Intentionally conflicting with test1
+    create table test
+    (
+    );
+end;
+$$;
+
+comment on procedure test2 is $$Test 2$$;
+
+create procedure err(inout test omni_test.test)
+    language plpgsql
+as
+$$
+begin
+    raise exception 'failed test';
+end;
+$$;
+
+comment on procedure err is $$Error test$$;
+
+create function test_fun() returns omni_test.test
+    language plpgsql as
+$$
+begin
+    return null;
+end;
+$$;
+
+comment on function test_fun is $$Test function$$;

--- a/extensions/omni_test/tests/httpd.yaml
+++ b/extensions/omni_test/tests/httpd.yaml
@@ -1,0 +1,42 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 64
+  init:
+    - create extension omni_test cascade
+    - create extension omni_schema cascade
+    - create extension omni_httpd cascade
+    - create database db_http
+    - update pg_database set datistemplate = true where datname = 'db_http'
+
+tests:
+
+- name: prepare db_http
+  commit: true
+  steps:
+  - query: |
+      select migration_filename,
+      execution_error
+      from omni_schema.assemble_schema('dbname=db_http user=yregress host=localhost port=' ||
+      (select setting from pg_settings where name = 'port'),
+      omni_vfs.local_fs('../../../../extensions/omni_test/tests/fixture/db_http')
+      )
+      order by execution_position
+
+- name: run db_http tests
+  steps:
+  - query: select name, description, error_message from omni_test.run_tests('db_http') order by name
+    results:
+      - name: public.err
+        description: Error test
+        error_message: failed test
+      - name: public.test1
+        description: Test 1
+        error_message: null
+      - name: public.test2
+        description: Test 2
+        error_message: null
+      - name: public.test_fun
+        description: Test function
+        error_message: null

--- a/extensions/omni_test/tests/test.yaml
+++ b/extensions/omni_test/tests/test.yaml
@@ -1,0 +1,38 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+    - create extension omni_test cascade
+    - create extension omni_schema cascade
+    - create database db1
+
+tests:
+
+- name: prepare db1
+  commit: true
+  steps:
+  - query: |
+      select migration_filename,
+      execution_error
+      from omni_schema.assemble_schema('dbname=db1 user=yregress host=localhost port=' ||
+      (select setting from pg_settings where name = 'port'),
+      omni_vfs.local_fs('../../../../extensions/omni_test/tests/fixture/db1')
+      )
+      order by execution_position
+  - update pg_database set datistemplate = true where datname = 'db1'
+
+- name: run db1 tests
+  steps:
+  - query: select name, description, error_message from omni_test.run_tests('db1') order by name
+    results:
+    - name: public.err
+      description: Error test
+      error_message: failed test
+    - name: public.test1
+      description: Test 1
+      error_message: null
+    - name: public.test2
+      description: Test 2
+      error_message: null
+    - name: public.test_fun
+      description: Test function
+      error_message: null

--- a/versions.txt
+++ b/versions.txt
@@ -22,6 +22,7 @@ omni_seq=0.1.1
 omni_service=0.1.0
 omni_session=0.1.1
 omni_sql=0.4.0
+omni_test=0.1.0
 omni_txn=0.5.0
 omni_types=0.2.1
 omni_var=0.3.0


### PR DESCRIPTION
Right now, we can use external test suite systems, but they would have to deal with database state, etc.

Solution: devise our own omni_test extension

It will take care of running tests, cloning environment from a template database.

This renames private testing package for `omni` to `omni__test` (it's never published)

As a note, I've initially tried to be smarter and tried to employ `pg_stat_all_tables` to track changes, but it wasn't working out too well and the overhead for copying a small database (which is presumably what you have when you run development-time tests) was not worth it. In particular, I needed to ensure I take dead tuples into account in the case of rolled back transactions, and the code was much, much lengthier.