### PR TITLE
Problem: event messaging between different systems (🚀 omni_cloudevents 0.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Below is the current list of components being worked on, experimented with and d
 | [omni_credentials](extensions/omni_schema/README.md)                                     | :white_check_mark: First release candidate   | Application credential management                     |
 | [omni_id](extensions/omni_id/README.md)                                                  | :white_check_mark: First release candidate   | Identity types                                        |
 | [omni_aws](extensions/omni_aws/README.md)                                                | :white_check_mark: First release candidate   | AWS APIs                                              |
+| [omni_cloudevents](extensions/omni_cloudevents/README.md)                                | :white_check_mark: First release candidate   | [CloudEvents](https://cloudevents.io/) support        |
 | [omni_json](extensions/omni_json/README.md)                                              | :white_check_mark: First release candidate   | JSON toolkit                                          |
 | [omni_yaml](extensions/omni_yaml/README.md)                                              | :white_check_mark: First release candidate   | YAML toolkit                                          |
 | [omni_xml](extensions/omni_xml/README.md)                                                | :white_check_mark: First release candidate   | XML toolkit                                           |

--- a/extensions/omni_cloudevents/CHANGELOG.md
+++ b/extensions/omni_cloudevents/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - TBD
+
+Initial release
+
+[Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_cloudevents
+
+[0.1.0]: [https://github.com/omnigres/omnigres/pull/746]

--- a/extensions/omni_cloudevents/CHANGELOG.md
+++ b/extensions/omni_cloudevents/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - TBD
+## [0.1.0] - 2025-01-31
 
 Initial release
 

--- a/extensions/omni_cloudevents/CMakeLists.txt
+++ b/extensions/omni_cloudevents/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(omni_cloudevents)
+
+include(CTest)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
+
+enable_testing()
+
+find_package(PostgreSQL REQUIRED)
+
+add_postgresql_extension(
+        omni_cloudevents
+        SCHEMA omni_cloudevents
+        REQUIRES omni_web
+        RELOCATABLE false)

--- a/extensions/omni_cloudevents/CMakeLists.txt
+++ b/extensions/omni_cloudevents/CMakeLists.txt
@@ -12,5 +12,6 @@ find_package(PostgreSQL REQUIRED)
 add_postgresql_extension(
         omni_cloudevents
         SCHEMA omni_cloudevents
+        COMMENT "CloudEvents support"
         REQUIRES omni_web
         RELOCATABLE false)

--- a/extensions/omni_cloudevents/README.md
+++ b/extensions/omni_cloudevents/README.md
@@ -1,0 +1,3 @@
+# omni_cloudevents
+
+[CloudEvents](https://cloudevents.io/) support.

--- a/extensions/omni_cloudevents/docs/cloud_events.md
+++ b/extensions/omni_cloudevents/docs/cloud_events.md
@@ -1,0 +1,146 @@
+# Using CloudEvents
+
+This extension lets you create, validate, and publish standardized [CloudEvents](https://cloudevents.io/) events directly from your SQL workflows.
+
+!!! tip "`omni_cloudevents` is a templated extension"
+
+    `omni_cloudevents` is a templated extension. This means that by installing it, a default copy of it is instantiated into extension's schema. However, you can replicate it into any other schema, tune some of the parameters and make the database own the objects (as opposed to the extension itself):
+
+     ```postgresql 
+     select omni_cloudevents.instantiate([schema => 'omni_cloudevents'])
+     ```
+
+    This allows you to have multiple independent credential systems, even if
+    using different versions of `omni_cloudevents`. 
+
+## Getting Started 
+
+!!! tip "Add cloudevents schema to `search_path`"
+
+    In order to make your queries that work with omni_cloudevents easier to read,
+    consider adding `omni_cloudevents` (or the schema of your choosing if you instantiated the
+    template) to `search_path`:
+
+    ```postgresql
+    set search_path to omni_cloudevents, public;
+    ```
+
+    Examples in this documentation follow this suggestion.
+
+
+## Preparing events
+
+In order to prepare events, use the `cloudevent` function. It features a number of mandatory and
+optional arguments to let you form the event that you need.
+
+```postgresql
+select cloudevent(
+  id => gen_random_uuid(),
+  source => 'https://service.com/endpoint',
+  type => 'user.login'
+);
+```
+
+|        **Argument** | **Type**               | **Description**                                                                                                        |
+|--------------------:|------------------------|------------------------------------------------------------------------------------------------------------------------|
+|              **id** | `text` _or_ `uuid`     | Unique event identifier (text string or UUID value)                                                                    |
+|          **source** | `cloudevent_uri_ref`   | Event origin URI with URI reference validation ([RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-4.1)) |
+|            **type** | `text`                 | Event type descriptor (e.g., "app.order.processed")                                                                    |
+| **datacontenttype** | `text`                 | _(Optional)_ Content type of data payload (e.g., "application/json")                                                   |
+|       **datschema** | `cloudevent_uri`       | _(Optional)_ Schema URL for data payload validation                                                                    |
+|         **subject** | `text`                 | _(Optional)_ Event subject/context identifier                                                                          |
+|              **ts** | `timestamptz`          | _(Optional)_ Event timestamp (default: current statement time)                                                         |
+|            **data** | `anyelement`           | _(Optional)_ Payload content (supports any PostgreSQL data type)                                                       |
+|     **specversion** | `text`                 | _(Optional)_ CloudEvents specification version (default: '1.0')                                                        |
+
+## Publishing events
+
+In order to publish an event we can this helper:
+
+```postgresql
+select publish(
+  cloudevent(id => gen_random_uuid(), 
+            source => 'https://api.yourservice.com/sys', 
+            type => 'file.uploaded', 
+             data => 'data-lake-bucket-123'::text));
+```
+
+It will return the `id` of the event for further convenience:
+
+```
+               publish                
+--------------------------------------
+ 8d253e18-c49a-464d-abcd-c2f7f84e3c46
+(1 row)
+```
+
+Under the hood, it'll write it into the `cloudevent_egress` table. This helps us enforce outgoing
+message uniqueness and manage the audit trail.
+
+```postgresql
+select * from cloudevents_egress;
+```
+
+```
+-[ RECORD 1 ]---+-------------------------------------------
+id              | 8d253e18-c49a-464d-abcd-c2f7f84e3c46
+source          | https://api.yourservice.com/sys
+specversion     | 1.0
+type            | file.uploaded
+datacontenttype | 
+datschema       | 
+subject         | 
+time            | 2025-01-31 11:54:06.249177-08
+data            | \x646174612d6c616b652d6275636b65742d313233
+datatype        | text
+```
+
+## Published event consumption
+
+Event systems hugely benefits from reactivity – the sooner the event reaches the
+intended recipients, the sooner they can take necessary action. In order to facilitate this,
+`omni_cloudevents` has a system of "publishers" that are triggered on event insertion 
+
+!!! warning "Work in progress"
+
+    Currently, there is a very limited set of publishers (namely, `NOTICE` publisher) but this
+    is planned to be extended in the near future.
+
+### NOTICE publisher
+
+To create a NOTICE publisher to be used by a `psql` session or tooling that makes use
+of such notifications, you can call this idempotent function below. It will return the
+singleton name of this publisher.
+
+```postgresql
+select omni_cloudevents.create_notice_publisher();
+```
+
+Now, if you will publish an event, you will see a notification:
+
+```postgresql
+select publish(
+  cloudevent(id => gen_random_uuid(), 
+            source => 'https://api.yourservice.com/sys', 
+            type => 'file.uploaded', 
+             data => 'data-lake-bucket-123'::text));
+```
+
+```
+NOTICE:  {"id":"1c9e6c07-ddcc-4de1-987b-e26ec9e8d253","source":"https://api.yourservice.com/sys","specversion":"1.0","type":"file.uploaded","time":"2025-01-31T12:00:34.147227-08:00","data":"data-lake-bucket-123"}
+```
+
+To delete the publisher, simply call `delete_publisher` with the name you received from `create_notice_publisher`:
+
+```postgresql
+select omni_cloudevents.delete_publisher(name);
+```
+
+!!! tip "Observing events in flight"
+
+    If your tooling needs to see events that weren't committed yet (for example, to provide a more responsive
+    experience within a transaction), notice publisher can be made to observe uncommitted events as well:
+    
+    ```postgresql
+    select omni_cloud_events.create_notice_publisher(publish_uncommitted => true);
+    ```

--- a/extensions/omni_cloudevents/migrate/1_instantiate.sql
+++ b/extensions/omni_cloudevents/migrate/1_instantiate.sql
@@ -1,0 +1,2 @@
+/*{% include "../src/instantiate.sql" %}*/
+select instantiate(schema => 'omni_cloudevents');

--- a/extensions/omni_cloudevents/mkdocs.yml
+++ b/extensions/omni_cloudevents/mkdocs.yml
@@ -1,0 +1,2 @@
+INHERIT: ../../mkdocs.base.yml
+site_name: omni_cloudevents

--- a/extensions/omni_cloudevents/src/instantiate.sql
+++ b/extensions/omni_cloudevents/src/instantiate.sql
@@ -1,0 +1,212 @@
+create function instantiate(schema regnamespace default 'omni_cloudevents') returns void
+    language plpgsql
+as
+$$
+begin
+    -- Set the search path to target schema and public
+    perform
+        set_config('search_path', schema::text || ',public', true);
+
+    -- Domain types for verifying correctness of some event fields
+    create domain cloudevent_uri as text check (value is null or omni_web.text_to_uri(value) is distinct from null);
+    execute format('alter domain cloudevent_uri set schema %s', schema);
+
+    create domain cloudevent_uri_ref as cloudevent_uri check (value is null or
+                                                              (omni_web.text_to_uri(value)).path is not null or
+                                                              (omni_web.text_to_uri(value)).query is not null);
+    execute format('alter domain cloudevent_uri_ref set schema %s', schema);
+
+
+    -- The crux of it, the event
+    create type cloudevent as
+    (
+        id              text,
+        source          cloudevent_uri_ref,
+        specversion     text,
+        type            text,
+        datacontenttype text,
+        datschema       cloudevent_uri,
+        subject         text,
+        "time"          timestamptz,
+        data            bytea,
+        datatype        regtype
+    );
+    execute format('alter type cloudevent set schema %s', schema);
+
+    -- Make events convertible to JSON
+    create or replace function to_json(event cloudevent)
+        returns json
+        immutable
+        language plpgsql as
+    $cloudevent_to_json$
+    begin
+        return json_strip_nulls(json_build_object(
+                'id', event.id,
+                'source', event.source,
+                'specversion', event.specversion,
+                'type', event.type,
+                'datacontenttype', event.datacontenttype,
+                'datschema', event.datschema,
+                'subject', event.subject,
+                'time', event."time",
+                'data', case
+                            when event.datatype = 'json'::regtype or event.datatype = 'jsonb'::regtype
+                                then convert_from(event.data, 'utf8')::json
+                            when event.datatype = 'text'::regtype
+                                then to_json(convert_from(event.data, 'utf8'))
+                            else
+                                to_json(encode(event.data, 'base64'))
+                    end
+                                ));
+    end;
+    $cloudevent_to_json$;
+
+    create or replace function to_jsonb(event cloudevent)
+        returns jsonb
+        immutable
+        language plpgsql as
+    $cloudevent_to_jsonb$
+    begin
+        return to_json(event)::jsonb;
+    end;
+    $cloudevent_to_jsonb$;
+    execute format(
+            'alter function to_jsonb(cloudevent) set search_path to %I,public',
+            schema);
+
+    -- Creation of event values (does not publish them)
+    create function cloudevent(id text, source cloudevent_uri_ref,
+                               type text, datacontenttype text default null, datschema cloudevent_uri default null,
+                               subject text default null,
+                               ts timestamptz default statement_timestamp(),
+                               data anyelement default null::bytea,
+                               specversion text default '1.0') returns cloudevent
+        language sql as
+    $sql$
+    select
+        row (id, source, specversion, type, datacontenttype, datschema, subject, ts,
+            convert_to(data::text, 'utf8'),
+            pg_typeof(data))::cloudevent
+    $sql$;
+    execute format(
+            'alter function cloudevent(text, cloudevent_uri_ref, text, text, cloudevent_uri, text, timestamptz, anyelement, text) set search_path to %I,public',
+            schema);
+
+    create function cloudevent(id uuid, source cloudevent_uri_ref,
+                               type text, datacontenttype text default null, datschema cloudevent_uri default null,
+                               subject text default null,
+                               ts timestamptz default statement_timestamp(),
+                               data anyelement default null::bytea,
+                               specversion text default '1.0') returns cloudevent
+        language sql as
+    $sql$
+    select
+        cloudevent(id => id::text, source => source, type => type, datacontenttype => datacontenttype,
+                   datschema => datschema,
+                   subject => subject, ts => ts, data => data, specversion => specversion)
+    $sql$;
+    execute format(
+            'alter function cloudevent(uuid, cloudevent_uri_ref, text, text, cloudevent_uri, text, timestamptz, anyelement, text) set search_path to %I,public',
+            schema);
+
+    -- We record all outgoing (published) events
+    -- One of the reasons for doing this is to ensure uniqueness of (id, source)
+    create table cloudevents_egress
+    (
+        like cloudevent,
+        primary key (id, source),
+        constraint source_required check (source is not null),
+        constraint specversion_required check (specversion is not null),
+        constraint type_required check (type is not null)
+    );
+    execute format('alter table cloudevents_egress set schema %s', schema);
+
+    create or replace function cloudevents_egress_to_cloudevent(event cloudevents_egress)
+        returns cloudevent as
+    $cloudevents_egress_to_cloudevent$
+    begin
+        return row (
+            event.id,
+            event.source,
+            event.specversion,
+            event.type,
+            event.datacontenttype,
+            event.datschema,
+            event.subject,
+            event."time",
+            event.data,
+            event.datatype
+            )::cloudevent;
+    end;
+    $cloudevents_egress_to_cloudevent$ language plpgsql immutable;
+    execute format('alter function cloudevents_egress_to_cloudevent set schema %s', schema);
+
+    create cast (cloudevents_egress as cloudevent)
+        with function cloudevents_egress_to_cloudevent(cloudevents_egress)
+        as implicit;
+
+    -- Publish an event
+    create function publish(e cloudevent) returns void
+        language plpgsql as
+    $publish$
+    begin
+        insert
+        into
+            cloudevents_egress
+        select
+            e.*;
+        return;
+    end;
+    $publish$;
+    execute format('alter function publish set search_path to %I,public', schema);
+
+    --- NOTICE publisher
+    create function notice_publisher() returns trigger
+        language plpgsql
+    as
+    $notice_publisher$
+    begin
+        if tg_argv[0] = 'json' then
+            raise notice '%', to_json(new::cloudevent);
+        end if;
+        return new;
+    end;
+    $notice_publisher$;
+    execute format('alter function notice_publisher set search_path to %I,public', schema);
+
+    create trigger notice_publisher
+        after insert
+        on cloudevents_egress
+        for each row
+    execute function notice_publisher(json);
+    alter table cloudevents_egress
+        disable trigger notice_publisher;
+
+    -- Create NOTICE publisher
+    create function create_notice_publisher() returns name
+        language plpgsql as
+    $create_notice_publisher$
+    begin
+        alter table cloudevents_egress
+            enable trigger notice_publisher;
+        return 'notice_publisher'::name;
+    end;
+    $create_notice_publisher$;
+    execute format('alter function create_notice_publisher set search_path to %I,public', schema);
+
+    -- Delete any named publisher
+    create function delete_publisher(publisher name) returns void
+        language plpgsql as
+    $delete_publisher$
+    begin
+        if publisher = 'notice_publisher' then
+            alter table cloudevents_egress
+                disable trigger notice_publisher;
+        end if;
+        return;
+    end;
+    $delete_publisher$;
+    execute format('alter function delete_publisher set search_path to %I,public', schema);
+
+end;
+$$;

--- a/extensions/omni_cloudevents/tests/test.yaml
+++ b/extensions/omni_cloudevents/tests/test.yaml
@@ -114,8 +114,20 @@ tests:
       error: duplicate key value violates unique constraint "cloudevents_egress_pkey"
 
 - name: notice publisher
+  commit: true
   steps:
     - select create_notice_publisher()
     - query: select publish(cloudevent(id => '1', source => 'a.b.c', type => 'org.omnigres.test', ts => '4713-01-01 00:00:00+00 BC'))
+      notices: []
+  notices:
+  - "{\"id\":\"1\",\"source\":\"a.b.c\",\"specversion\":\"1.0\",\"type\":\"org.omnigres.test\",\"time\":\"4713-01-01T00:00:00+00:00 BC\"}"
+
+- query: delete from omni_cloudevents.cloudevents_egress
+  commit: true
+
+- name: notice publisher (uncommitted)
+  steps:
+    - select create_notice_publisher(publish_uncommitted => true)
+    - query: select publish(cloudevent(id => '1', source => 'a.b.c', type => 'org.omnigres.test', ts => '4713-01-01 00:00:00+00 BC'))
       notices:
-      - "{\"id\":\"1\",\"source\":\"a.b.c\",\"specversion\":\"1.0\",\"type\":\"org.omnigres.test\",\"time\":\"4713-01-01T00:00:00+00:00 BC\"}"
+        - "{\"id\":\"1\",\"source\":\"a.b.c\",\"specversion\":\"1.0\",\"type\":\"org.omnigres.test\",\"time\":\"4713-01-01T00:00:00+00:00 BC\"}"

--- a/extensions/omni_cloudevents/tests/test.yaml
+++ b/extensions/omni_cloudevents/tests/test.yaml
@@ -1,0 +1,121 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    timezone: UTC
+  init:
+  - create extension omni_cloudevents cascade
+  - set search_path to omni_cloudevents, public
+
+tests:
+
+- name: cloudevent creation
+  query: select id, source, specversion, type, datacontenttype, datschema,subject,time,data,datatype from cloudevent(id => '1', source => 'a.b.c', type => 'org.omnigres.test', ts => '4713-01-01 00:00:00+00 BC')
+  results:
+  - id: 1
+    source: a.b.c
+    specversion: 1.0
+    type: org.omnigres.test
+    datacontenttype: null
+    datschema: null
+    subject: null
+    time: 4713-01-01 00:00:00+00 BC
+    data: null
+    datatype: bytea
+
+- name: cloudevent creation (JSON)
+  query: select id, source, specversion, type, datacontenttype, datschema,subject,time,data,datatype from cloudevent(id => 'f67cb6ad-7c1b-4582-ad7b-c8f9c0dc15a2'::uuid, source => 'a.b.c', type => 'org.omnigres.test', ts => '4713-01-01 00:00:00+00 BC')
+  results:
+    - id: f67cb6ad-7c1b-4582-ad7b-c8f9c0dc15a2
+      source: a.b.c
+      specversion: 1.0
+      type: org.omnigres.test
+      datacontenttype: null
+      datschema: null
+      subject: null
+      time: 4713-01-01 00:00:00+00 BC
+      data: null
+      datatype: bytea
+
+- name: cloudevent to JSON
+  query: select to_json(cloudevent(id => '1', source => 'a.b.c', type => 'org.omnigres.test', ts => '4713-01-01 00:00:00+00 BC')) as json
+  results:
+    - json:
+        id: 1
+        source: a.b.c
+        specversion: 1.0
+        type: org.omnigres.test
+        time: 4713-01-01T00:00:00+00:00 BC
+
+- name: cloudevent to JSON (JSON data)
+  query: select to_json(cloudevent(id => '1', source => 'a.b.c', type => 'org.omnigres.test', data => json_build_object('a','b'), ts => '4713-01-01 00:00:00+00 BC')) as json
+  results:
+    - json:
+        id: 1
+        source: a.b.c
+        specversion: 1.0
+        type: org.omnigres.test
+        time: 4713-01-01T00:00:00+00:00 BC
+        data:
+          a: b
+
+- name: cloudevent to JSON (String data)
+  query: select to_json(cloudevent(id => '1', source => 'a.b.c', type => 'org.omnigres.test', data => 'hello'::text, ts => '4713-01-01 00:00:00+00 BC')) as json
+  results:
+    - json:
+        id: 1
+        source: a.b.c
+        specversion: 1.0
+        type: org.omnigres.test
+        time: 4713-01-01T00:00:00+00:00 BC
+        data: hello
+
+- name: cloudevent to JSON (binary data)
+  query: select to_json(cloudevent(id => '1', source => 'a.b.c', type => 'org.omnigres.test', data => convert_to('hello', 'utf8'), ts => '4713-01-01 00:00:00+00 BC')) as json
+  results:
+    - json:
+        id: 1
+        source: a.b.c
+        specversion: 1.0
+        type: org.omnigres.test
+        time: 4713-01-01T00:00:00+00:00 BC
+        data: XHg2ODY1NmM2YzZm
+
+- name: cloudevent to JSONB
+  query: select to_jsonb(cloudevent(id => '1', source => 'a.b.c', type => 'org.omnigres.test', ts => '4713-01-01 00:00:00+00 BC')) as json
+  results:
+    - json:
+        id: 1
+        source: a.b.c
+        specversion: 1.0
+        type: org.omnigres.test
+        time: 4713-01-01T00:00:00+00:00 BC
+
+- name: publish
+  steps:
+    - select publish(cloudevent(id => '1', source => 'a.b.c', type => 'org.omnigres.test', ts => '4713-01-01 00:00:00+00 BC'))
+    - query: select * from cloudevents_egress
+      results:
+      - id: 1
+        source: a.b.c
+        specversion: 1.0
+        type: org.omnigres.test
+        datacontenttype: null
+        datschema: null
+        subject: null
+        time: 4713-01-01 00:00:00+00 BC
+        data: null
+        datatype: bytea
+
+- name: duplicate
+  steps:
+    - select publish(cloudevent(id => '1', source => 'a.b.c', type => 'org.omnigres.test', ts => '4713-01-01 00:00:00+00 BC'))
+    - select publish(cloudevent(id => '1', source => 'a.b.c.d', type => 'org.omnigres.test', ts => '4713-01-01 00:00:00+00 BC'))
+    - query: select publish(cloudevent(id => '1', source => 'a.b.c', type => 'org.omnigres.test', ts => '4713-01-01 00:00:00+00 BC'))
+      error: duplicate key value violates unique constraint "cloudevents_egress_pkey"
+
+- name: notice publisher
+  steps:
+    - select create_notice_publisher()
+    - query: select publish(cloudevent(id => '1', source => 'a.b.c', type => 'org.omnigres.test', ts => '4713-01-01 00:00:00+00 BC'))
+      notices:
+      - "{\"id\":\"1\",\"source\":\"a.b.c\",\"specversion\":\"1.0\",\"type\":\"org.omnigres.test\",\"time\":\"4713-01-01T00:00:00+00:00 BC\"}"

--- a/versions.txt
+++ b/versions.txt
@@ -2,6 +2,7 @@ omni=0.2.5
 omni_aws=0.1.2
 omni_auth=0.1.3
 omni_containers=0.2.0
+omni_cloudevents=0.1.0
 omni_credentials=0.1.0
 omni_http=0.1.0
 omni_httpc=0.1.4


### PR DESCRIPTION
Or, rather, the lack of universality. How do we know what kind of event is this event?

Solition: add initial support for CloudEvents

It's simple and its getting some support and use throughout the industry.

At this point, this is a proof-of-concept that allows for basic publishing of events, with publishers such as "NOTICE publisher" handling their delivery.