### PR TITLE
Problem: Build was breaking due to deprecated action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
       if: matrix.os == 'warp-macos-14-arm64-6x'
       run: TMPDIR=$RUNNER_TEMP USER=$(whoami) ctest --timeout 1000 --force-new-ctest-process  --repeat until-pass:10 --output-on-failure -j $(nproc) -C ${{matrix.build_type}} -E '(minio|containers)'
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: ${{ matrix.os }}-${{ matrix.pgver }}-regression.diffs


### PR DESCRIPTION
More info at https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Solution: Use actions/upload-artifact@v4

cherry-picked from @diogob's work