### PR TITLE
Problem: deploying files from a filesystem in a different database

### DIFF
--- a/extensions/omni_vfs/CHANGELOG.md
+++ b/extensions/omni_vfs/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 * Filesystem writing capabilities (`omni_vfs.write`) [#712](https://github.com/omnigres/omnigres/pull/712)
+* Remote Filesystem (`remote_fs`) to access filesystems in other databases [#755](https://github.com/omnigres/omnigres/pull/755)
 
 ## [0.1.2] - 2024-09-27
 

--- a/extensions/omni_vfs/CMakeLists.txt
+++ b/extensions/omni_vfs/CMakeLists.txt
@@ -22,7 +22,7 @@ add_postgresql_extension(
         SCHEMA omni_vfs
         RELOCATABLE false
         DEPENDS_ON libpgaug
-        REQUIRES omni_vfs_types_v1
+        REQUIRES omni_vfs_types_v1 dblink
         TESTS_REQUIRE omni_os
         SOURCES omni_vfs.c local_fs.c pg_path_v15.c)
 

--- a/extensions/omni_vfs/docs/reference.md
+++ b/extensions/omni_vfs/docs/reference.md
@@ -210,6 +210,22 @@ The [API](#api) described above works for `omni_vfs.table_fs` files as well. It 
 
     Although `omni_vfs.table_fs` can handle millions of files, it is recommended not to have more than few hundred files in one single directory to ensure optimal listing performance.
 
+### `omni_vfs.remote_fs` (remote file system)
+
+Remote filesystem takes a connection string (just like `dblink` does) and a snippet of SQL that
+defines a filesystem remotely:
+
+```postgresql
+select omni_vfs.remote_fs('dbname=otherdb host=127.0.0.1', $$omni_vfs.local_fs('/path')$$)
+```
+
+All normal VFS operations called over this filesystem are proxied to that remote connection.
+
+!!! tip "Performance considerations"
+
+    At this time, connections are not reused, and every time a call is made, a new connection
+    is established.
+
 ### Runtime backend dispatch
 
 In a real application, to make it possible to use different backends, one can create a file system "factory" function dependent on the environment they are in. For example, when in development, it can look like this:

--- a/extensions/omni_vfs/migrate/6_remote_fs.sql
+++ b/extensions/omni_vfs/migrate/6_remote_fs.sql
@@ -1,0 +1,11 @@
+create type remote_fs as
+(
+    connstr text,
+    constructor text
+);
+
+/*{% include "../src/remote_fs.sql" %}*/
+/*{% include "../src/remote_fs_list.sql" %}*/
+/*{% include "../src/remote_fs_file_info.sql" %}*/
+/*{% include "../src/remote_fs_read.sql" %}*/
+/*{% include "../src/remote_fs_write.sql" %}*/

--- a/extensions/omni_vfs/migrate/remote_fs_checks.sql
+++ b/extensions/omni_vfs/migrate/remote_fs_checks.sql
@@ -1,0 +1,10 @@
+-- Checks
+
+do
+$$
+    begin
+        if not omni_vfs_types_v1.is_valid_fs('remote_fs') then
+            raise exception 'remote_fs is not a valid vfs';
+        end if;
+    end;
+$$ language plpgsql;

--- a/extensions/omni_vfs/src/remote_fs.sql
+++ b/extensions/omni_vfs/src/remote_fs.sql
@@ -1,0 +1,6 @@
+create function remote_fs(connstr text, constructor text) returns remote_fs
+    language sql
+as
+$$
+select row (connstr, constructor)::omni_vfs.remote_fs
+$$;

--- a/extensions/omni_vfs/src/remote_fs_file_info.sql
+++ b/extensions/omni_vfs/src/remote_fs_file_info.sql
@@ -1,0 +1,8 @@
+create function file_info(fs remote_fs, path text) returns omni_vfs_types_v1.file_info
+    language sql as
+$$
+select *
+from
+    dblink(fs.connstr, format('select omni_vfs.file_info((%1$s), %2$L)', fs.constructor,
+                              path)) t(f omni_vfs_types_v1.file_info)
+$$;

--- a/extensions/omni_vfs/src/remote_fs_list.sql
+++ b/extensions/omni_vfs/src/remote_fs_list.sql
@@ -1,0 +1,8 @@
+create function list(fs remote_fs, path text, fail_unpermitted boolean default true) returns setof omni_vfs_types_v1.file
+    language sql as
+$$
+select *
+from
+    dblink(fs.connstr, format('select omni_vfs.list((%1$s), %2$L, %3$L)', fs.constructor,
+                              path, fail_unpermitted)) t(f omni_vfs_types_v1.file)
+$$;

--- a/extensions/omni_vfs/src/remote_fs_read.sql
+++ b/extensions/omni_vfs/src/remote_fs_read.sql
@@ -1,0 +1,9 @@
+create function read(fs remote_fs, path text, file_offset bigint default 0,
+                     chunk_size int default null) returns bytea
+    language sql as
+$$
+select *
+from
+    dblink(fs.connstr, format('select omni_vfs.read((%1$s), %2$L, %3$L, %4$L)', fs.constructor,
+                              path, file_offset, chunk_size)) t(data bytea)
+$$;

--- a/extensions/omni_vfs/src/remote_fs_write.sql
+++ b/extensions/omni_vfs/src/remote_fs_write.sql
@@ -1,0 +1,9 @@
+create function write(fs remote_fs, path text, content bytea, create_file boolean default false,
+                      append boolean default false) returns bigint
+    language sql as
+$$
+select *
+from
+    dblink(fs.connstr, format('select omni_vfs.write((%1$s), %2$L, %3$L, %4$L, %5$L)', fs.constructor,
+                              path, content, create_file, append)) t(r bigint)
+$$;

--- a/extensions/omni_vfs/tests/local_fs.yml
+++ b/extensions/omni_vfs/tests/local_fs.yml
@@ -31,6 +31,8 @@ tests:
     kind: file
   - name: path_functions.yml
     kind: file
+  - name: remote_fs.yml
+    kind: file
   - name: table_fs.yml
     kind: file
 
@@ -58,6 +60,8 @@ tests:
   - name: local_fs.yml
     kind: file
   - name: path_functions.yml
+    kind: file
+  - name: remote_fs.yml
     kind: file
   - name: table_fs.yml
     kind: file

--- a/extensions/omni_vfs/tests/remote_fs.yml
+++ b/extensions/omni_vfs/tests/remote_fs.yml
@@ -1,0 +1,110 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_vfs cascade
+  - create extension omni_os cascade
+  - create extension omni_var cascade
+
+tests:
+
+- name: can create a local filesystem
+  query: |
+    select omni_var.set_session('fs', omni_vfs.remote_fs('dbname=yregress user=yregress host=127.0.0.1 port = ' || current_setting('port'),
+    $$omni_vfs.local_fs('../../../../extensions/omni_vfs/tests')$$))
+
+- name: can list files in a directory
+  query: |
+    select * from omni_vfs.list(omni_var.get_session('fs', null::omni_vfs.remote_fs), '')
+    order by name
+  results:
+  - name: deleted.yml
+    kind: file
+  - name: empty
+    kind: dir
+  - name: local_fs.yml
+    kind: file
+  - name: path_functions.yml
+    kind: file
+  - name: remote_fs.yml
+    kind: file
+  - name: table_fs.yml
+    kind: file
+
+- name: can list a file
+  query: select * from omni_vfs.list(omni_var.get_session('fs', null::omni_vfs.remote_fs), 'remote_fs.yml')
+  results:
+  - kind: file
+    name: remote_fs.yml
+
+- name: list skips a non-existent file
+  query: select * from omni_vfs.list(omni_var.get_session('fs', null::omni_vfs.remote_fs), 'local_fs_does_not_exist.yml')
+  results: [ ]
+
+- name: recursively list
+  query: |
+    select * from omni_vfs.list_recursively(omni_var.get_session('fs', null::omni_vfs.remote_fs), '.')
+    order by name
+  results:
+  - name: deleted.yml
+    kind: file
+  - name: empty
+    kind: dir
+  - name: empty/.keepme
+    kind: file
+  - name: local_fs.yml
+    kind: file
+  - name: path_functions.yml
+    kind: file
+  - name: remote_fs.yml
+    kind: file
+  - name: table_fs.yml
+    kind: file
+
+- name: recursive listing respects path
+  query: |
+    select * from omni_vfs.list_recursively(omni_var.get_session('fs', null::omni_vfs.remote_fs), 'empty')
+    order by name
+  results:
+  - name: .keepme
+    kind: file
+
+- name: can get file info
+  query: select size > 0 as non_zero, kind from omni_vfs.file_info(omni_var.get_session('fs', null::omni_vfs.remote_fs), 'remote_fs.yml')
+  results:
+  - non_zero: true
+    kind: file
+
+- name: can read file
+  query: select length(convert_from(omni_vfs.read(omni_var.get_session('fs', null::omni_vfs.remote_fs), 'remote_fs.yml'), 'utf8')) > 0 as result
+  results:
+  - result: true
+
+- name: creating a file in a remote filesystem
+  query: |
+    with filesystems as (select 'omni_vfs_local_fs_test_' || gen_random_uuid() || '/test'                    as filename,
+                                omni_vfs.remote_fs('dbname=yregress user=yregress host=127.0.0.1 port = ' || current_setting('port'),
+                                $$omni_vfs.local_fs((select value from omni_os.env where variable = 'TMPDIR'))$$) as fs),
+         written as (select fs, filename, omni_vfs.write(fs, filename, 'hello world', create_file => true) as bytes
+                     from filesystems)
+    select convert_from(omni_vfs.read(fs, filename), 'utf-8') as content,
+           bytes = octet_length('hello world')                as fully_written
+    from written
+  results:
+  - content: hello world
+    fully_written: true
+
+- name: appending a file in a remote filesystem
+  query: |
+    with filesystems as (select 'omni_vfs_local_fs_test_' || gen_random_uuid() || '/test'                    as filename,
+                                omni_vfs.remote_fs('dbname=yregress user=yregress host=127.0.0.1 port = ' || current_setting('port'),
+                                                   $$omni_vfs.local_fs((select value from omni_os.env where variable = 'TMPDIR'))$$) as fs),
+         written as (select fs, filename, omni_vfs.write(fs, filename, 'hello world', create_file => true) as bytes
+                     from filesystems),
+         appended as (select fs, filename, omni_vfs.write(fs, filename, '!', append => true) + bytes as bytes
+                      from written)
+    select convert_from(omni_vfs.read(fs, filename), 'utf-8') as content,
+           bytes = octet_length('hello world!')               as fully_written
+    from appended
+  results:
+  - content: hello world!
+    fully_written: true


### PR DESCRIPTION
We have a case where we have to copy files from one filesystem to another (table_fs) in a different database just so that database can use the files.

However, that puts a lot of burden onto those who implement it. See `omni_schema.assemble_schema` for an example of that.

Solution: allow for remote file system access

As long as you can access a database over dblink, simply proxy calls to that other database. Let's call it a "remote filesystem"

The design may not yet be ideal. I am in particular not 100% happy with the idea of the "constructor" that we pass as a string to be able to indicate a filesystem remotely. It's probably not the most terrible thing, but it irks me as any text being passed to the other side. But that's dblink for you – it does that anyway. The crux of this problem is that technically file systems are not registered in the database (they _may be_, but that's an implementation detail.)

There's a consideration to introduce "mountable" global filesystem that will somehow glue all possible filesystems together, providing a global registration of all of them at mountpoints. But we don't have it yet and we don't know if it will be the only way to access mounted filesystems or not.

I had an idea that maybe we can create the type locally and then convert it into a constructor, but that's complicated: the constructors are allowed to create database objects or insert/update records. We might not want that done locally.

We may consider finding other ways to encode constructors that are better than just passing a string to inject.

So let's just try to get going with the minimal possible thing.