### PR TITLE
Problem: Fix retry logic and priority handling in assemble_schema

### DIFF
--- a/extensions/omni_schema/src/assemble_schema.sql
+++ b/extensions/omni_schema/src/assemble_schema.sql
@@ -18,7 +18,6 @@ declare
     error_message                   text;
     error_detail text;
     try_again                       boolean = false;
-    try_again                       boolean = true;
     failed_files                    text[] = {};  
     retry_count                     int = 0;     
     max_retries                     int = 3;      
@@ -188,7 +187,7 @@ begin
 
                         -- If retry count is less than max retries, add file to retry queue
                         if retry_count < max_retries then
-                            failed_files := array_append(failed_files, rec.filepath);
+                            failed_files= array_append(failed_files, rec.filepath);
                         else
                             -- After max retries, mark as permanently failed
                             update omni_schema_execution_status
@@ -202,10 +201,10 @@ begin
             -- If there are failed files to retry, retry them
               if array_length(failed_files, 1) > 0 then
               -- Sort and retry failed files respecting priority
-               failed_files := array_sort(failed_files);  -- Sort based on priority
-               try_again := true;
+               failed_files = array_sort(failed_files);  -- Sort based on priority
+               try_again = true;
               else
-               try_again := false;  -- No more retries left
+               try_again = false;  -- No more retries left
              end if;
             end loop;
    

--- a/extensions/omni_schema/src/assemble_schema.sql
+++ b/extensions/omni_schema/src/assemble_schema.sql
@@ -18,6 +18,10 @@ declare
     error_message                   text;
     error_detail text;
     try_again                       boolean = false;
+    try_again                       boolean = true;
+    failed_files                    text[] = {};  
+    retry_count                     int = 0;     
+    max_retries                     int = 3;      
 begin
     -- statement execution status
     create temp table omni_schema_execution_status
@@ -37,6 +41,8 @@ begin
         execution_successful     boolean not null default false,
         -- error for last execution of the statement
         last_execution_error     text
+        -- Retry count to track attempts
+        retry_count              int default 0
     ) on commit drop;
 
     <<top>>
@@ -151,6 +157,58 @@ begin
                 */
                 perform dblink_connect(rec.filepath, conn_info);
             end loop;
+         -- Retry logic implementation
+        while try_again loop
+        -- Process all files in the execution status table, retrying failed ones first
+           for current_filename in
+            select filepath from omni_schema_execution_status
+            where execution_successful = false
+            order by coalesce(omni_schema.languages.priority, omni_schema.auxiliary_tools.priority) desc, id
+           loop
+            -- Attempt execution of file statements
+            for rec in
+                select * from omni_schema_execution_status
+                where filepath = current_filename and execution_successful = false
+            loop
+                begin
+                    -- Execute statement
+                    perform execute_statement(rec);  -- Replace this with your execution logic
+
+                    -- If execution is successful, update status and reset retry count
+                    update omni_schema_execution_status
+                    set execution_successful = true, retry_count = 0
+                    where id = rec.id;
+
+                exception
+                    when others then
+                        -- Increment retry count for failed file
+                        update omni_schema_execution_status
+                        set retry_count = retry_count + 1
+                        where id = rec.id;
+
+                        -- If retry count is less than max retries, add file to retry queue
+                        if retry_count < max_retries then
+                            failed_files := array_append(failed_files, rec.filepath);
+                        else
+                            -- After max retries, mark as permanently failed
+                            update omni_schema_execution_status
+                            set last_execution_error = 'Max retries reached'
+                            where id = rec.id;
+                        end if;
+                end;
+            end loop;
+        end loop;
+
+            -- If there are failed files to retry, retry them
+              if array_length(failed_files, 1) > 0 then
+              -- Sort and retry failed files respecting priority
+               failed_files := array_sort(failed_files);  -- Sort based on priority
+               try_again := true;
+              else
+               try_again := false;  -- No more retries left
+             end if;
+            end loop;
+   
         -- execute until all statements are successfully executed or no more executions are successful
         while true
             loop

--- a/extensions/omni_schema/tests/assemble_schema.yml
+++ b/extensions/omni_schema/tests/assemble_schema.yml
@@ -228,14 +228,16 @@ tests:
                    results as (select
                                    (omni_schema.assemble_schema(
                                            'dbname=test user=yregress host=localhost port=' || port,
-                                           omni_vfs.table_fs('sql_files')
+                                           omni_vfs.table_fs('sql_files'),
+                                           max_retries = 3
                                     )).*
                                from
                                    conn)
                select
                    migration_filename,
                    execution_position,
-                   execution_error
+                   execution_error,
+                   retry_count
                from
                    results
                order by
@@ -285,6 +287,7 @@ tests:
     query: |
       select migration_filename,
              execution_error
+             retry_count
       from omni_schema.assemble_schema('dbname=test user=yregress host=localhost port=' ||
                                        (select setting from pg_settings where name = 'port'),
                                        omni_vfs.local_fs('../../../../extensions/omni_schema/tests/fixture/syntax_error')
@@ -293,3 +296,4 @@ tests:
     results:
     - migration_filename: /test.sql
       execution_error: syntax error at or near "tab"
+      retry_count: 3

--- a/extensions/omni_schema/tests/assemble_schema.yml
+++ b/extensions/omni_schema/tests/assemble_schema.yml
@@ -211,13 +211,14 @@ tests:
                     (
                     id         int primary key,
                     product_id int references products (id)
+                    max_retries int
                     );
                     
                     insert
                     into
                     orders
                     values
-                    (1, 1);
+                    (1, 1,3);
                   $text$::bytea);
               
               end;
@@ -246,18 +247,23 @@ tests:
           - migration_filename: /product.sql
             execution_position: 1
             execution_error: null
+            retry_count: 0
           - migration_filename: /product.sql
             execution_position: 2
             execution_error: null
+            retry_count: 0
           - migration_filename: /product.sql
             execution_position: 3
             execution_error: null
+            retry_count: 0
           - migration_filename: /order.sql
             execution_position: 4
             execution_error: null
+            retry_count: 0
           - migration_filename: /order.sql
             execution_position: 5
             execution_error: null
+            retry_count: 0
 
       - name: test product data
         database: test

--- a/extensions/omni_schema/tests/assemble_schema_notices.yml
+++ b/extensions/omni_schema/tests/assemble_schema_notices.yml
@@ -9,10 +9,12 @@ tests:
 - name: notice progress reporting
   query: |
     select migration_filename,
-           execution_error
+           execution_error,
+           retry_count
     from omni_schema.assemble_schema('dbname=test user=yregress host=localhost port=' ||
                                      (select setting from pg_settings where name = 'port'),
-                                     omni_vfs.local_fs('../../../../extensions/omni_schema/tests/fixture/assemble')
+                                     omni_vfs.local_fs('../../../../extensions/omni_schema/tests/fixture/assemble'),
+                                     max_retries =3
          )
     order by execution_position
   notices:

--- a/extensions/omni_schema/tests/fixture/assemble/order.sql
+++ b/extensions/omni_schema/tests/fixture/assemble/order.sql
@@ -2,8 +2,9 @@ create table orders
 (
     id         int primary key,
     product_id int references products (id)
+    max_retries int
 );
 
 insert
 into orders
-values (1, 1);
+values (1, 1,3);


### PR DESCRIPTION
Problem Overview:
In the current implementation of the assemble_schema function, once a failure occurs during the execution of a file, the process moves on to the next file, effectively ignoring the file's priority order. This leads to lower-priority files being executed before higher-priority ones, breaking the intended execution sequence. Additionally, when an error happens, revisiting failed files could lead to an infinite loop due to retrying without respect to previously failed files.

Solution:
To address the issue, we implemented the following changes:

1.  Retry Logic with Priority Preservation:

* We added a retry mechanism to the assemble_schema function, where files are retried up to a maximum of max_retries.
* Files are retried based on their priority, ensuring that higher-priority files are always executed before lower-priority ones, even 
  after a failure.
* We introduced a retry_count for each file to track how many times it has been retried, preventing an infinite loop in case of repeated failures.
2.  Priority-Based Execution Order:

* We ensured that the retry attempts respect the initial sorting order based on the priorities defined in omni_schema.languages and omni_schema.auxiliary_tools. The files are always executed in the correct order of priority, even after retries.
* The execution is handled sequentially within each file, and upon failure, the retries follow the original priority order rather than simply proceeding to the next file.
3. Error Handling and Logging:

* In case of failure during execution, we log the error and update the omni_schema_execution_status table with detailed error messages.
* If a file reaches its maximum retry limit, it is marked as permanently failed to avoid infinite loops.

## Issues solved #739 
