### PR TITLE
Problem: installing extensions into Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,14 @@ cmake --build build --parallel
 make -j psql_<COMPONENT_NAME> # for example, `psql_omni_containers`
 ```
 
+To install extensions into your target Postgres:
+
+```shell
+cmake --build build --parallel --target install_extensions
+# Or, individually,
+cmake --build build --parallel --target install_<COMPONENT_NAME>_extension
+```
+
 ### Troubleshooting
 
 <details>


### PR DESCRIPTION
Doing this manually with `cp` is not fun, but that's the only option we have right now, after `package_extensions` is done.

Solution: introduce `install_extensions` and `install_EXT_extension` targets

These will copy extensions into Postgres' designated directories.