### PR TITLE
Problem: inja renderer uses C++ 20's ends_with

### DIFF
--- a/misc/inja/inja.cpp
+++ b/misc/inja/inja.cpp
@@ -4,13 +4,18 @@
 
 #include "inja.hpp"
 
+static bool ends_with(const std::string& str, const std::string& suffix) {
+    if (suffix.size() > str.size()) return false;
+    return std::equal(suffix.rbegin(), suffix.rend(), str.rbegin());
+}
+
 int main(int argc, char **argv) {
     if (argc == 2) {
         char *filename = argv[1];
         inja::Environment env;
         nlohmann::json data;
         std::string_view s(filename);
-        if (std::string(filename).ends_with(".sql")) {
+        if (ends_with(filename, ".sql")) {
             env.set_line_statement("--##");
             env.set_expression("/*{{", "}}*/"); // Expressions
             env.set_comment("/*{#", "#}*/"); // Comments


### PR DESCRIPTION
The ends_with is introduced by C++20, which is not available by default in distro like EL8

Solution: replace the function with a bespoke version to work around it