### PR TITLE
Problem: unable to see which Python packages are installed

### DIFF
--- a/extensions/omni_python/CHANGELOG.md
+++ b/extensions/omni_python/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.0] - TBD
 
+### Added
+
+* Listing installed packages [#776](https://github.com/omnigres/omnigres/pull/776) 
+
 ## [0.1.1] - 2025-01-08
 
 ### Changed

--- a/extensions/omni_python/migrate/7_packages.sql
+++ b/extensions/omni_python/migrate/7_packages.sql
@@ -1,0 +1,8 @@
+create function installed_packages() returns table (name text, version text)
+    language plpython3u
+as
+$$
+/*{% include "../src/installed_packages.py" %}*/
+$$;
+
+create view installed_package as select * from installed_packages();

--- a/extensions/omni_python/src/installed_packages.py
+++ b/extensions/omni_python/src/installed_packages.py
@@ -1,0 +1,47 @@
+import io
+import contextlib
+import os
+import tempfile
+
+site_packages = os.path.expanduser(
+    plpy.execute(plpy.prepare("""
+                     select coalesce(
+                        (select value from omni_python.config where name = 'site_packages'),
+                        (select (setting || '/.omni_python/default') as value from pg_settings where name = 'data_directory'))
+                        as value
+       """))[0]['value'])
+
+if not os.path.exists(site_packages):
+    os.makedirs(site_packages)
+
+index = plpy.execute(
+    plpy.prepare(
+        "select (select value from omni_python.config where name = 'extra_pip_index_url') as value"))[0][
+    'value']
+
+find_links = plpy.execute(
+    plpy.prepare(
+        "select array_agg(value) as value from (select value from omni_python.config where name = 'pip_find_links' union all select * from omni_python.wheel_paths()) t"))[
+                 0][
+                 'value'] or []
+
+os.makedirs(site_packages, exist_ok=True)
+stderr_str = io.StringIO()
+stdout_str = io.StringIO()
+with contextlib.redirect_stdout(stdout_str), contextlib.redirect_stderr(stderr_str):
+    try:
+        from pip._internal.cli.main import main as pip
+
+        rc = pip(["freeze", "--path", site_packages])
+        if rc != 0:
+            raise SystemExit(rc)
+    except SystemExit as e:
+        plpy.error("pip failure", detail=stderr_str.getvalue())
+
+result = [
+    {"name": name, "version": version}
+    for line in stdout_str.getvalue().strip().split("\n")
+    for name, version in [line.split("==")]
+]
+
+return result

--- a/extensions/omni_python/tests/omni_python.yml
+++ b/extensions/omni_python/tests/omni_python.yml
@@ -12,6 +12,12 @@ instance:
 
 tests:
 
+- name: installed packages
+  query: select * from omni_python.installed_package
+  results:
+  - name: omni_python
+    version: 0.1.0
+
 - name: error
   steps:
   - query: select * from omni_python.create_functions($1)


### PR DESCRIPTION
This becomes problematic when we introspect into the database to see what needs to be installed, especially during migrations.

Solution: expose `omni_python.installed_package`

This will also allow us to track changes if we snapshot it.