### PR TITLE
Problem: omni_python package installation is virtually invisible

### DIFF
--- a/extensions/omni_python/CHANGELOG.md
+++ b/extensions/omni_python/CHANGELOG.md
@@ -11,6 +11,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Listing installed packages [#776](https://github.com/omnigres/omnigres/pull/776) 
 
+### Changed
+
+* Make package installation process more visible [#777](https://github.com/omnigres/omnigres/pull/777)
+
 ## [0.1.1] - 2025-01-08
 
 ### Changed

--- a/extensions/omni_python/src/install_requirements.py
+++ b/extensions/omni_python/src/install_requirements.py
@@ -29,13 +29,24 @@ requirements_txt = tempfile.mktemp()
 with open(requirements_txt, 'w') as f:
     f.write(requirements)
 
+class PipOutputHandler:
+    def __init__(self):
+        pass
+
+    def write(selfself, text):
+        plpy.notice(text.strip('\n'))
+
+    def flush(self):
+        pass
+
 os.makedirs(site_packages, exist_ok=True)
 stderr_str = io.StringIO()
-with contextlib.redirect_stderr(stderr_str):
+stdout_handler = PipOutputHandler()
+with contextlib.redirect_stdout(stdout_handler), contextlib.redirect_stderr(stderr_str):
     try:
         from pip._internal.cli.main import main as pip
 
-        rc = pip(["install", "--upgrade", "-r", requirements_txt, "--target", site_packages]
+        rc = pip(["install", "--disable-pip-version-check", "--upgrade", "-r", requirements_txt, "--target", site_packages]
                  + (["--extra-index-url", index] if index is not None else [])
                  + [item for x in find_links for item in ("--find-links", x)]
                  )


### PR DESCRIPTION
It's only printed on the stdout, and so remotely connected clients don't see anything, and it might take time to install packages.

Solution: make it visible by redirecting output to notices

This is still not perfect, but it's a good start!