### PR TITLE
Problem: sending HTTP response before committing the transaction

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -15,6 +15,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * omni_httpd.handler is no longer a function but a procedure [#715](https://github.com/omnigres/omnigres/pull/715)
 
+### Fixed
+
+* Response body is no longer sent before committing the transaction [#778](https://github.com/omnigres/omnigres/pull/778)
+
 ## [0.2.9] - 2025-01-17
 
 ### Fixed


### PR DESCRIPTION
This may present a timing problem when we want to query recently modified data based on the fact that the response has already been sent.

We've observed this in sporadic test failures.

Solution: ensure we commit first

This is not yet perfect case coverage as this doesn't include WebSocket sending as it will send messages eager before transanction is committed.

This generally raises a good question: should we apply the same transactional guarantees to outbound WebSocket messages? Should we provide an option for this, defaulting to either choice?