### PR TITLE
Problem: HTTP responses always use OK as the reason

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.0] - TBD
 
+### Fixed
+
+* HTTP response should contain correct status code reasons [#781](https://github.com/omnigres/omnigres/pull/781)
+
 ## [0.3.0] - 2025-02-04
 
 ### Added

--- a/extensions/omni_httpd/http_status_reasons.h
+++ b/extensions/omni_httpd/http_status_reasons.h
@@ -1,0 +1,78 @@
+#ifndef HTTP_STATUS_REASONS_H
+#define HTTP_STATUS_REASONS_H
+
+static const char *http_status_reasons[512] = {
+    /* Informational 1xx */
+    [100] = "Continue",
+    [101] = "Switching Protocols",
+    [102] = "Processing",
+    [103] = "Early Hints",
+
+    /* Successful 2xx */
+    [200] = "OK",
+    [201] = "Created",
+    [202] = "Accepted",
+    [203] = "Non-Authoritative Information",
+    [204] = "No Content",
+    [205] = "Reset Content",
+    [206] = "Partial Content",
+    [207] = "Multi-Status",
+    [208] = "Already Reported",
+    [226] = "IM Used",
+
+    /* Redirection 3xx */
+    [300] = "Multiple Choices",
+    [301] = "Moved Permanently",
+    [302] = "Found",
+    [303] = "See Other",
+    [304] = "Not Modified",
+    [305] = "Use Proxy",
+    /* 306 is no longer used */
+    [307] = "Temporary Redirect",
+    [308] = "Permanent Redirect",
+
+    /* Client Error 4xx */
+    [400] = "Bad Request",
+    [401] = "Unauthorized",
+    [402] = "Payment Required",
+    [403] = "Forbidden",
+    [404] = "Not Found",
+    [405] = "Method Not Allowed",
+    [406] = "Not Acceptable",
+    [407] = "Proxy Authentication Required",
+    [408] = "Request Timeout",
+    [409] = "Conflict",
+    [410] = "Gone",
+    [411] = "Length Required",
+    [412] = "Precondition Failed",
+    [413] = "Payload Too Large",
+    [414] = "URI Too Long",
+    [415] = "Unsupported Media Type",
+    [416] = "Range Not Satisfiable",
+    [417] = "Expectation Failed",
+    [418] = "I'm a teapot",
+    [421] = "Misdirected Request",
+    [422] = "Unprocessable Entity",
+    [423] = "Locked",
+    [424] = "Failed Dependency",
+    [425] = "Too Early",
+    [426] = "Upgrade Required",
+    [428] = "Precondition Required",
+    [429] = "Too Many Requests",
+    [431] = "Request Header Fields Too Large",
+    [451] = "Unavailable For Legal Reasons",
+
+    /* Server Error 5xx */
+    [500] = "Internal Server Error",
+    [501] = "Not Implemented",
+    [502] = "Bad Gateway",
+    [503] = "Service Unavailable",
+    [504] = "Gateway Timeout",
+    [505] = "HTTP Version Not Supported",
+    [506] = "Variant Also Negotiates",
+    [507] = "Insufficient Storage",
+    [508] = "Loop Detected",
+    [510] = "Not Extended",
+    [511] = "Network Authentication Required"};
+
+#endif // HTTP_STATUS_REASONS_H

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -68,6 +68,8 @@
 #error "only evloop is supported, ensure H2O_USE_LIBUV is not set to 1"
 #endif
 
+#include "http_status_reasons.h"
+
 h2o_multithread_receiver_t handler_receiver;
 h2o_multithread_queue_t *handler_queue;
 
@@ -929,6 +931,7 @@ static int handler(handler_message_t *msg) {
       FlushErrorState();
 
       req->res.status = 500;
+      req->res.reason = http_status_reasons[req->res.status];
       h2o_queue_send_inline(&msg->payload.http.msg, H2O_STRLIT("Internal server error"));
       goto cleanup;
     }
@@ -964,6 +967,8 @@ static int handler(handler_message_t *msg) {
           if (isnull) {
             req->res.status = 200;
           }
+
+          req->res.reason = http_status_reasons[req->res.status];
 
           bool content_length_specified = false;
           long long content_length = 0;
@@ -1080,6 +1085,7 @@ static int handler(handler_message_t *msg) {
         // Commit before sending a response
         CommitTransactionCommand();
         req->res.status = 204;
+        req->res.reason = http_status_reasons[req->res.status];
         h2o_queue_send_inline(&msg->payload.http.msg, "", 0);
       }
       break;

--- a/extensions/omni_httpd/tests/http.yml
+++ b/extensions/omni_httpd/tests/http.yml
@@ -93,10 +93,12 @@ tests:
       (select effective_port from omni_httpd.listeners where port = 0) || '/test?q=1')))
     select
     response.status,
+    response.message,
     convert_from(response.body, 'utf-8')::json as body
     from response
   results:
   - status: 404
+    message: Not Found
     body:
       method: GET
       path: /test


### PR DESCRIPTION
This looks a bit weird:

```
HTTP/1.1 403 OK
```

Solution: lookup correct status reason in a dictionary