### PR TITLE
Problem: A build from scratch on a Debian system errors when compiling omni_web

### DIFF
--- a/extensions/omni_web/urlpattern.cpp
+++ b/extensions/omni_web/urlpattern.cpp
@@ -1,20 +1,18 @@
-// clang-format off
-#include <postgres.h>
-#include <fmgr.h>
-// clang-format on
-
 #include <ada.h>
 #include <ada_c.h>
 #include <ada_regex.h>
 
 extern "C" {
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+
 #include <nodes/execnodes.h>
 #include <utils/builtins.h>
 
 #include "urlpattern.h"
 }
-
-#include <iostream>
 
 using regex_provider = ada::pcre2_regex_provider;
 


### PR DESCRIPTION
There is a conflict between gettext imported from libintl for ada_url and the gettext defined in c.h in PostgreSQL's headers.

The relevant part of the error:

```
/usr/include/libintl.h:39:14: error: expected unqualified-id before ‘const’
   39 | extern char *gettext (const char *__msgid)
      |              ^~~~~~~
...
gmake[2]: *** [extensions/omni_web/CMakeFiles/omni_web.dir/build.make:121: extensions/omni_web/CMakeFiles/omni_web.dir/urlpattern.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:6951: extensions/omni_web/CMakeFiles/omni_web.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

Solution: Move the PostgreSQL headers to after the ada headers into the extern C block.