### PR TITLE
The view omni_schema.role is not in 6NF 

### DIFF
--- a/extensions/omni_schema/src/meta/catalog.sql
+++ b/extensions/omni_schema/src/meta/catalog.sql
@@ -1275,24 +1275,61 @@ create view trigger as
  *****************************************************************************/
 create view role as
    select role_id(pgr.rolname) as id,
-          pgr.rolname::text  as name,
-          pgr.rolsuper       as superuser,
-          pgr.rolinherit     as inherit,
-          pgr.rolcreaterole  as create_role,
-          pgr.rolcreatedb    as create_db,
-          pgr.rolcanlogin    as can_login,
-          pgr.rolreplication as replication,
-          pgr.rolconnlimit   as connection_limit,
-          '********'::text   as password,
-          pgr.rolvaliduntil  as valid_until
+          pgr.rolname::text  as name
    from pg_roles pgr
-   inner join pg_authid pga
-           on pgr.oid = pga.oid
-    union
+    union all
    select role_id('0'::oid::regrole::text) as id,
-    'PUBLIC' as name,
-    null, null, null, null, null, null, null, null, null;
+    'PUBLIC' as name;
 
+create view role_superuser as
+   select role_id(pgr.rolname) as id
+   from pg_roles pgr
+   where pgr.rolsuper;
+
+create view role_inherit as
+   select role_id(pgr.rolname) as id
+   from pg_roles pgr
+   where pgr.rolinherit;
+
+create view role_create_role as
+   select role_id(pgr.rolname) as id
+   from pg_roles pgr
+   where pgr.rolcreaterole;
+
+create view role_create_db as
+   select role_id(pgr.rolname) as id
+   from pg_roles pgr
+   where pgr.rolcreatedb;
+
+create view role_can_login as
+   select role_id(pgr.rolname) as id
+   from pg_roles pgr
+   where pgr.rolcanlogin;
+
+create view role_replication as
+   select role_id(pgr.rolname) as id
+   from pg_roles pgr
+   where pgr.rolreplication;
+
+create view role_connection_limit as
+   select role_id(pgr.rolname) as id,
+          pgr.rolconnlimit   as connection_limit
+   from pg_roles pgr;
+
+create view role_valid_until as
+   select role_id(pgr.rolname) as id,
+          pgr.rolvaliduntil   as valid_until
+   from pg_roles pgr;
+
+create view role_setting as
+    select role_setting_id(pgr.rolname, pgd.datname, split_part(setting, '=', 1)) as id,
+           role_id(pgr.rolname) as role_id,
+           split_part(setting, '=', 1) as setting_name,
+           split_part(setting, '=', 2) as setting_value
+    from pg_db_role_setting pgrs
+        join pg_roles pgr on pgr.oid = pgrs.setrole
+        left join pg_database pgd on pgd.oid = pgrs.setdatabase,
+        unnest(pgrs.setconfig) as setting;
 
 /******************************************************************************
  * role_inheritance

--- a/extensions/omni_schema/src/meta/identifiers.sql
+++ b/extensions/omni_schema/src/meta/identifiers.sql
@@ -63,6 +63,8 @@ create type relation_id as (schema_name text,name text);
 create function relation_id(schema_name text,name text) returns relation_id as $_$ select row(schema_name,name)::relation_id $_$ immutable language sql;
 create type role_id as (name text);
 create function role_id(name text) returns role_id as $_$ select row(name)::role_id $_$ immutable language sql;
+create type role_setting_id as (role_name text, database_name text, setting_name text);
+create function role_setting_id(role_name text, database_name text, setting_name text) returns role_setting_id as $_$ select row(role_name,database_name,setting_name)::role_setting_id $_$ immutable language sql;
 create type row_id as (schema_name text,relation_name text,pk_column_names text[],pk_values text[]);
 create function row_id(schema_name text,relation_name text,pk_column_names text[],pk_values text[]) returns row_id as $_$ select row(schema_name,relation_name,pk_column_names,pk_values)::row_id $_$ immutable language sql;
 create type schema_id as (name text);

--- a/extensions/omni_schema/tests/meta_role.yml
+++ b/extensions/omni_schema/tests/meta_role.yml
@@ -1,0 +1,14 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+    - create extension omni_schema cascade
+
+tests:
+
+- name: created role shows up with expected values
+  steps:
+    - query: create role test;
+    - query: select id, name from omni_schema.role where id = omni_schema.role_id('test');
+      results:
+      - id: (test)
+        name: test  

--- a/extensions/omni_schema/tests/meta_role_can_login.yml
+++ b/extensions/omni_schema/tests/meta_role_can_login.yml
@@ -1,0 +1,19 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+    - create extension omni_schema cascade
+
+tests:
+
+- name: created role does not show up without login
+  steps:
+    - query: create role test_without_login nologin;
+    - query: select id from omni_schema.role_can_login where id = omni_schema.role_id('test_without_login');
+      results: []
+
+- name: created role shows up with expected values when it can login
+  steps:
+    - query: create role test_with_login login;
+    - query: select id from omni_schema.role_can_login where id = omni_schema.role_id('test_with_login');
+      results:
+      - id: (test_with_login)

--- a/extensions/omni_schema/tests/meta_role_connection_limit.yml
+++ b/extensions/omni_schema/tests/meta_role_connection_limit.yml
@@ -1,0 +1,14 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+    - create extension omni_schema cascade
+
+tests:
+
+- name: created role shows up with expected values
+  steps:
+    - query: create role test_connection_limit connection limit 1;
+    - query: select id, connection_limit from omni_schema.role_connection_limit where id = omni_schema.role_id('test_connection_limit');
+      results:
+      - id: (test_connection_limit)
+        connection_limit: 1

--- a/extensions/omni_schema/tests/meta_role_create_db.yml
+++ b/extensions/omni_schema/tests/meta_role_create_db.yml
@@ -1,0 +1,19 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+    - create extension omni_schema cascade
+
+tests:
+
+- name: created role does not show up without createdb
+  steps:
+    - query: create role test_without_createdb nocreatedb;
+    - query: select id from omni_schema.role_create_db where id = omni_schema.role_id('test_without_createdb');
+      results: []
+
+- name: created role shows up with expected values when it can create db
+  steps:
+    - query: create role test_with_createdb createdb;
+    - query: select id from omni_schema.role_create_db where id = omni_schema.role_id('test_with_createdb');
+      results:
+      - id: (test_with_createdb)

--- a/extensions/omni_schema/tests/meta_role_create_role.yml
+++ b/extensions/omni_schema/tests/meta_role_create_role.yml
@@ -1,0 +1,19 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+    - create extension omni_schema cascade
+
+tests:
+
+- name: created role does not show up without createrole
+  steps:
+    - query: create role test_without_createrole nocreaterole;
+    - query: select id from omni_schema.role_create_role where id = omni_schema.role_id('test_without_createrole');
+      results: []
+
+- name: created role shows up with expected values when it can create db
+  steps:
+    - query: create role test_with_createrole createrole;
+    - query: select id from omni_schema.role_create_role where id = omni_schema.role_id('test_with_createrole');
+      results:
+      - id: (test_with_createrole)

--- a/extensions/omni_schema/tests/meta_role_inherit.yml
+++ b/extensions/omni_schema/tests/meta_role_inherit.yml
@@ -1,0 +1,19 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+    - create extension omni_schema cascade
+
+tests:
+
+- name: created role does not show up without inherit
+  steps:
+    - query: create role test_without_inherit noinherit;
+    - query: select id from omni_schema.role_inherit where id = omni_schema.role_id('test_without_inherit');
+      results: []
+
+- name: created role shows up with expected values when it can create db
+  steps:
+    - query: create role test_with_inherit inherit;
+    - query: select id from omni_schema.role_inherit where id = omni_schema.role_id('test_with_inherit');
+      results:
+      - id: (test_with_inherit)

--- a/extensions/omni_schema/tests/meta_role_replication.yml
+++ b/extensions/omni_schema/tests/meta_role_replication.yml
@@ -1,0 +1,19 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+    - create extension omni_schema cascade
+
+tests:
+
+- name: created role does not show up without replication
+  steps:
+    - query: create role test_without_replication noreplication;
+    - query: select id from omni_schema.role_replication where id = omni_schema.role_id('test_without_replication');
+      results: []
+
+- name: created role shows up with expected values when it can create db
+  steps:
+    - query: create role test_with_replication replication;
+    - query: select id from omni_schema.role_replication where id = omni_schema.role_id('test_with_replication');
+      results:
+      - id: (test_with_replication)

--- a/extensions/omni_schema/tests/meta_role_setting.yml
+++ b/extensions/omni_schema/tests/meta_role_setting.yml
@@ -1,0 +1,34 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+    - create extension omni_schema cascade
+
+tests:
+
+- name: created role shows up with expected values for different settings
+  steps:
+    - query: create role test_with_settings
+    - query: alter role test_with_settings set work_mem to '11MB'
+    - query: alter role test_with_settings set log_min_messages to 'debug'
+    - query: select id, setting_name, setting_value from omni_schema.role_setting where id in (omni_schema.role_setting_id('test_with_settings',null::text,'work_mem'), omni_schema.role_setting_id('test_with_settings',null::text,'log_min_messages')) order by id
+      results:
+      - id: "(test_with_settings,,log_min_messages)"
+        setting_name: log_min_messages
+        setting_value: debug
+      - id: "(test_with_settings,,work_mem)"
+        setting_name: work_mem
+        setting_value: 11MB    
+
+- name: created role shows up with expected values for different databases
+  steps:
+    - query: create role test_with_settings
+    - query: alter role test_with_settings in database template1 set work_mem to '11MB'
+    - query: alter role test_with_settings set work_mem to '11MB'
+    - query: select id, setting_name, setting_value from omni_schema.role_setting where setting_name = 'work_mem' order by id
+      results:
+      - id: "(test_with_settings,template1,work_mem)"
+        setting_name: work_mem
+        setting_value: 11MB 
+      - id: "(test_with_settings,,work_mem)"
+        setting_name: work_mem
+        setting_value: 11MB 

--- a/extensions/omni_schema/tests/meta_role_superuser.yml
+++ b/extensions/omni_schema/tests/meta_role_superuser.yml
@@ -1,0 +1,19 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+    - create extension omni_schema cascade
+
+tests:
+
+- name: created role does not show up without superuser
+  steps:
+    - query: create role test_without_superuser nosuperuser;
+    - query: select id from omni_schema.role_superuser where id = omni_schema.role_id('test_without_superuser');
+      results: []
+
+- name: created role shows up with expected values when it can create db
+  steps:
+    - query: create role test_with_superuser superuser;
+    - query: select id from omni_schema.role_superuser where id = omni_schema.role_id('test_with_superuser');
+      results:
+      - id: (test_with_superuser)

--- a/extensions/omni_schema/tests/meta_role_valid_until.yml
+++ b/extensions/omni_schema/tests/meta_role_valid_until.yml
@@ -1,0 +1,14 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+    - create extension omni_schema cascade
+
+tests:
+
+- name: created role shows up with expected values
+  steps:
+    - query: create role test_valid_until valid until '2024-01-01 00:00:00';
+    - query: select id, valid_until::timestamp from omni_schema.role_valid_until where id = omni_schema.role_id('test_valid_until');
+      results:
+      - id: (test_valid_until)
+        valid_until: '2024-01-01 00:00:00'


### PR DESCRIPTION
## Problem
The view omni_schema.role is not in 6NF making a diff between rows harder.

## Solution

Normalize it.
Note that there is a special case for the `role_setting` view.
Since each array item in `pg_db_role_setting.setconfig` is added or removed by a distinct `ALTER ROLE` command I created one line in `role_setting` for each config key.
