### PR TITLE
Problem: Postgres 13 is too old

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     continue-on-error: ${{ matrix.pgver == 'master' }}
     strategy:
       matrix:
-        pgver: [ 17, 16, 15, 14, 13, master ]
+        pgver: [ 17, 16, 15, 14, master ]
         os: [ warp-ubuntu-2204-x64-4x, warp-macos-14-arm64-6x ]
         build_type: [Debug, Release]
         exclude:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         platform: [ amd64, arm64 ]
-        pg: [ 17, 16, 15, 14, 13 ]
+        pg: [ 17, 16, 15, 14 ]
 
     if: github.repository == 'omnigres/omnigres'
     runs-on: ${{ fromJSON('["warp-ubuntu-2204-x64-4x", "warp-ubuntu-2204-arm64-16x"]')[matrix.platform == 'arm64'] }}

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -67,7 +67,6 @@ if(NOT DEFINED PG_CONFIG)
     set(PGVER_ALIAS_16 16.7)
     set(PGVER_ALIAS_15 15.11)
     set(PGVER_ALIAS_14 14.16)
-    set(PGVER_ALIAS_13 13.19)
 
     # commit
     if ("${PGVER}" MATCHES "^${sha1re}$")


### PR DESCRIPTION
We keep running into its limitations. It stops being supported in Nov 2025, so in about 9 months.

Solution: drop supporting it now

This will redirect energy required to support it to something more useful.

Note that this doesn't change some of the syntax or conditional compilation that pertains to Postgres 13. We just stop building and testing on it. Soon enough, some extensions will stop working on it.