### PR TITLE
Problem: serving static files using omni_httpd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,12 @@ RUN cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DPGVER=${PG} /omni
 RUN make -j ${BUILD_PARALLEL_LEVEL} all
 RUN make package_extensions
 
+FROM squidfunk/mkdocs-material AS docs
+COPY --chown=${UID} . /docs
+RUN pip install -r docs/requirements.txt
+RUN mkdocs build -d /output
+ENTRYPOINT ["/bin/sh"]
+
 # plrust build
 #FROM postgres:${PG}-${DEBIAN_VER_PG}  AS plrust
 #ARG PLRUST_VERSION
@@ -145,6 +151,7 @@ done
 unset OMNI_SO_FILE
 EOF
 RUN rm -rf /omni
+COPY --from=docs /output /omni-docs
 ENTRYPOINT ["omnigres-entrypoint.sh"]
 CMD ["postgres"]
 EXPOSE 22

--- a/docker/initdb-slim/005-http-handler.sql.templ
+++ b/docker/initdb-slim/005-http-handler.sql.templ
@@ -1,0 +1,33 @@
+create extension omni_mimetypes;
+
+select omni_httpd.instantiate_static_file_handler(schema => 'public');
+
+create table redirecting_router
+(
+    like omni_httpd.urlpattern_router,
+    location text
+);
+
+create function redirecting_handler(req omni_httpd.http_request, router redirecting_router) returns omni_httpd.http_outcome
+    return omni_httpd.http_response(status => 302, headers => array [omni_http.http_header('location', router.location)]);
+
+insert into redirecting_router (match, location, handler) values (omni_httpd.urlpattern('/docs'), '/docs/', 'redirecting_handler'::regproc);
+
+create table static_file_router
+(
+    like omni_httpd.urlpattern_router,
+    fs omni_vfs.local_fs
+);
+
+create function docs_handler(req omni_httpd.http_request, router static_file_router) returns omni_httpd.http_outcome
+    language plpgsql as
+$$
+declare
+begin
+    req.path := regexp_replace(req.path, '^/docs/', '/', '');
+    return static_file_handler(req, router.fs);
+end;
+$$;
+
+
+insert into static_file_router (match, handler, fs) values (omni_httpd.urlpattern('/docs/*'), 'docs_handler'::regproc, omni_vfs.local_fs('/omni-docs'));

--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 * Core routing changed to a router mechanism with URLPattern support [#783](https://github.com/omnigres/omnigres/pull/783)
+* Static file handler uses the new router mechanism [#795](https://github.com/omnigres/omnigres/pull/795)
 
 ## [0.3.0] - 2025-02-04
 

--- a/extensions/omni_httpd/docs/static_file.md
+++ b/extensions/omni_httpd/docs/static_file.md
@@ -3,42 +3,58 @@ static assets through `omni_vfs` virtual filesystem later.
 
 ## Requirements
 
-The following extensions are required:
+The following extensions are required for this functionality:
 
 * omni_vfs
 * omni_mimetypes
 
-
 ## Setup
 
-As discussed in `omni_vfs` documentation, one needs to define a mount point. 
+To get the handler provisioned, one need to call `instantiate_static_file_handler`:
 
 ```postgresql
-create function mount_point() 
-    returns omni_vfs.local_fs
-    language sql as
-$$
-select omni_vfs.local_fs('/path/to/dir')
-$$
+select omni_httpd.instantiate_static_file_handler(schema => 'public');
 ```
 
-This example above returns a local filesystem-based VFS. In production, you 
-may want to consider other filesystems.
+This will create the `static_file_handler` function in the `public` schema. Its name can be configured
+by passing `name` argument with a desired function name.
 
-Now, we want to update our listener handler to serve this filesystem 
-alongside with some other endpoints:
+## Configuring 
+
+First, we'll define a static file router relation for the type of the virtual file
+system we need (in this example, `omni_vfs.local_fs`):
 
 ```postgresql
- update omni_httpd.handlers
- set
-     query =
-(select
-    omni_httpd.cascading_query(name, query order by priority desc nulls last)
- from (select * from omni_httpd.static_file_handlers('mount_point', 0)
-      union (values
-                 ('test',
-                  $$ select omni_httpd.http_response('passed') from request where request.path = '/test'$$, 1))) routes)
+create table static_file_router
+(
+    like omni_httpd.urlpattern_router,
+    fs omni_vfs.local_fs
+);
 ```
 
-The above connects `mount_point()` filesystem and defines a handler for 
-`/test` (with a higher priority).
+Now, we can implement the handler for the router:
+
+```postgresql
+create function fs_handler(req omni_httpd.http_request, router static_file_router)
+    returns omni_httpd.http_outcome
+    return static_file_handler(req, router.fs);
+```
+
+This function will take the request path as is, and it will try to find it in the given file system. 
+
+!!! tip "Directory listing"
+
+    `static_file_handler` also takes an optional boolean `listing` argument that will make it
+    generate a list of files in a directory if there's no `index.html` present. It's disabled by default.
+
+Finally, we need to provision a routing entry in the router:
+
+```postgresql
+insert
+into
+    static_file_router (match, handler, fs)
+values
+    (omni_httpd.urlpattern('/assets/*?'), 'docs_handler'::regproc,
+     omni_vfs.local_fs('/path/to/files'));
+```
+Now, all requests to `/assets/*` will be served the local filesystem pointing to `/path/to/files`.

--- a/extensions/omni_httpd/migrate/12_handlers.sql
+++ b/extensions/omni_httpd/migrate/12_handlers.sql
@@ -1,0 +1,2 @@
+drop function static_file_handlers;
+/*{% include "../src/instantiate_static_file_handler.sql" %}*/

--- a/extensions/omni_httpd/src/instantiate_static_file_handler.sql
+++ b/extensions/omni_httpd/src/instantiate_static_file_handler.sql
@@ -1,0 +1,33 @@
+create function instantiate_static_file_handler(schema name default '@extschema@',
+                                                name name default 'static_file_handler') returns void
+    language plpgsql as
+$$
+declare
+    old_search_path text := current_setting('search_path');
+begin
+    -- check for required extensions
+    perform from pg_extension where extname = 'omni_vfs';
+    if not found then
+        raise exception 'omni_vfs extension is required to be installed';
+    end if;
+
+    perform from pg_extension where extname = 'omni_mimetypes';
+    if not found then
+        raise exception 'omni_mimetypes extension is required to be installed';
+    end if;
+
+    perform set_config('search_path', schema::text, true);
+
+    /*{% include "static_file_handler.sql" %}*/
+
+    if name != 'static_file_handler' then
+        execute format('alter procedure static_file_handler rename to %I', name);
+    end if;
+
+    create table static_file_handler_router (
+
+    );
+
+    perform set_config('search_path', old_search_path, true);
+end;
+$$;

--- a/extensions/omni_httpd/src/static_file_handler.sql
+++ b/extensions/omni_httpd/src/static_file_handler.sql
@@ -1,0 +1,70 @@
+create
+    or
+    replace function static_file_handler(request omni_httpd.http_request,
+                                         fs anyelement, path text default '', listing boolean default false)
+    returns omni_httpd.http_outcome
+    language plpgsql as
+$static_file_handler$
+declare
+    outcome omni_httpd.http_outcome;
+begin
+    --- File
+    if request.method = 'GET' and
+       (omni_vfs.file_info(fs, path || request.path)).kind = 'file' then
+        select
+            omni_httpd.http_response(
+                    omni_vfs.read(fs, path || request.path),
+                    headers => array [omni_http.http_header('content-type',
+                                                            coalesce(mime_types.name, 'application/octet-stream'))]::omni_http.http_header[])
+        from
+                (select)                                            _
+                left join omni_mimetypes.file_extensions on request.path like '%%.' || file_extensions.extension
+                left join omni_mimetypes.mime_types_file_extensions mtfe on mtfe.file_extension_id = file_extensions.id
+                left join omni_mimetypes.mime_types on mtfe.mime_type_id = mime_types.id
+        into outcome;
+    end if;
+
+    if outcome is not null then
+        return outcome;
+    end if;
+
+    --- Directory
+    if request.method = 'GET' and
+       (omni_vfs.file_info(fs, path || request.path)).kind = 'dir' and
+       (omni_vfs.file_info(fs, path || request.path || '/index.html')).kind = 'file' then
+        select
+            omni_httpd.http_response(
+                    omni_vfs.read(fs, path || request.path || '/index.html'),
+                    headers => array [omni_http.http_header('content-type', 'text/html')]::omni_http.http_header[])
+        into outcome;
+    end if;
+
+    if outcome is not null then
+        return outcome;
+    end if;
+
+    --- File listing
+
+    if listing and request.method = 'GET' and
+       (omni_vfs.file_info(fs, path || request.path)).kind = 'dir' and
+       (omni_vfs.file_info(fs, path || request.path || '/index.html')) is not distinct from null then
+        select
+            omni_httpd.http_response(
+                    (select
+                         string_agg('<a href="' || case when request.path = '/' then '/' else request.path || '/' end ||
+                                    name ||
+                                    '">' || name || '</a>', '<br>')
+                     from
+                         omni_vfs.list(fs, path || request.path)),
+                    headers => array [omni_http.http_header('content-type', 'text/html')]::omni_http.http_header[])
+
+        into outcome;
+    end if;
+
+    if outcome is not null then
+        return outcome;
+    end if;
+
+    return omni_httpd.http_response(status => 404);
+end;
+$static_file_handler$;

--- a/extensions/omni_httpd/tests/static_file.yml
+++ b/extensions/omni_httpd/tests/static_file.yml
@@ -10,37 +10,21 @@ instance:
   - create extension omni_httpc cascade
   - create extension omni_vfs cascade
   - create extension omni_mimetypes
+  - select omni_httpd.instantiate_static_file_handler(schema => current_schema)
   - |
-    create function mount_point() returns omni_vfs.local_fs language sql
-    as
-    $$
-    select omni_vfs.local_fs('../../../../extensions/omni_httpd/tests/static')
-    $$
-  - name: provision the server
-    query: |
-      update omni_httpd.handlers
-        set
-        query = (select
-                   omni_httpd.cascading_query(name, query order by priority desc nulls last)
-                 from (select * from omni_httpd.static_file_handlers('mount_point', 0, listing => true)
-                       union (values
-                      ('test',
-                       $$ select omni_httpd.http_response('passed') from request where request.path = '/test'$$, 1))) routes)
+    create table static_file_router
+    (
+        like omni_httpd.urlpattern_router,
+        fs omni_vfs.local_fs,
+        path text,
+        listing boolean 
+    )
+  - |
+     create function static_handler(req omni_httpd.http_request, r static_file_router) 
+         returns omni_httpd.http_outcome return static_file_handler(req, r.fs, path => r.path, listing => r.listing)
+  - insert into static_file_router (match, handler, fs, path, listing) values (omni_httpd.urlpattern('/*?'), 'static_handler'::regproc, omni_vfs.local_fs('../../../../extensions/omni_httpd/tests/static'), '', true)
 
 tests:
-
-- name: handle API endpoint
-  query: |
-    with response as (select * from omni_httpc.http_execute(
-           omni_httpc.http_request('http://127.0.0.1:' ||
-                                   (select effective_port from omni_httpd.listeners) || '/test')))
-    select
-      response.status,
-      convert_from(response.body, 'utf-8') as body
-      from response
-  results:
-  - status: 200
-    body: passed
 
 - name: handle file
   query: |
@@ -58,6 +42,17 @@ tests:
       - content-type: application/json
     body:
       test: passed
+
+- name: handle file not being found
+  query: |
+    with response as (select * from omni_httpc.http_execute(
+           omni_httpc.http_request('http://127.0.0.1:' ||
+                                   (select effective_port from omni_httpd.listeners) || '/notfound.json')))
+    select
+      response.status
+      from response
+  results:
+  - status: 404
 
 - name: handle directory with index.html
   query: |
@@ -90,3 +85,18 @@ tests:
     headers:
     - content-type: text/html
     body: <a href="/files/test.json">test.json</a>
+
+- name: no listing if disabled
+  transaction: false
+  steps:
+    - update static_file_router set listing = false
+    - query: |
+        with response as (select * from omni_httpc.http_execute(
+               omni_httpc.http_request('http://127.0.0.1:' ||
+                                       (select effective_port from omni_httpd.listeners) || '/files')))
+        select
+          response.status
+          from response
+      results:
+      - status: 404
+    - update static_file_router set listing = true


### PR DESCRIPTION
We have an older version of the static file handler, however, it is designed for the soon-to-be-removed cascading query API.

Solution: implement a handler for the new routing API

As an example, we include /docs browser in the container image.