### PR TITLE
Problem: no response from false websocket_handler

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * HTTP response should contain correct status code reasons [#781](https://github.com/omnigres/omnigres/pull/781)
+* Rejected WebSocket requests are sent an HTTP response [#797](https://github.com/omnigres/omnigres/pull/797)
 
 ### Changed
 

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -1369,12 +1369,10 @@ static int handler(handler_message_t *msg) {
       if (is_websocket_upgrade) {
         // Commit before sending a response
         CommitTransactionCommand();
-        if (isnull) {
-          h2o_queue_abort(&msg->payload.http.msg);
+        if (!isnull && DatumGetBool(outcome)) {
+          h2o_queue_upgrade_to_websocket(&msg->payload.http.msg);
         } else {
-          if (DatumGetBool(outcome)) {
-            h2o_queue_upgrade_to_websocket(&msg->payload.http.msg);
-          }
+          h2o_queue_abort(&msg->payload.http.msg);
         }
 
         break;

--- a/extensions/omni_httpd/tests/websocket.yml
+++ b/extensions/omni_httpd/tests/websocket.yml
@@ -1,0 +1,32 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+  init:
+  - set session omni_httpd.init_port = 0
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  # FIXME: waiting for two reloads is working around a startup bug in omni_httpd
+  - call omni_httpd.wait_for_configuration_reloads(2)
+
+tests:
+
+- name: websocket upgrade requests rejected by default
+  query: |
+    SELECT status
+         , (SELECT json_agg(json_build_object(h.name, h.value))
+              FROM unnest(response.headers) h
+             WHERE h.name != 'server') as headers
+      FROM omni_httpc.http_execute(
+             omni_httpc.http_request('http://127.0.0.1:' || (SELECT effective_port FROM omni_httpd.listeners) || '/',
+                                     'GET',
+                                     array[omni_http.http_header('connection', 'Upgrade'),
+                                           omni_http.http_header('upgrade', 'websocket'),
+                                           omni_http.http_header('sec-websocket-version', '13'),
+                                           omni_http.http_header('sec-websocket-key', 'dGhlIHNhbXBsZSBub25jZQ==')])) response
+  results:
+  # FIXME probably not the right status code
+  - status: 201
+    headers:
+    - connection: close
+    - content-length: 0


### PR DESCRIPTION
If `omni_httpd.websocket_handler()` returns false, no HTTP response is sent. And it seems like the worker just hangs for some reason -- it never responds to future requests -- even if the connection is closed by the peer.

However, if the handler returns null, it does send an HTTP response that does not upgrade the connection to a WebSocket.

But the comment for the handler indicates that any non-true value should be treated the same:

    If it returns anything but true, the connection is rejected.

Solution: send a response in any case

This change should send an HTTP even if false is returned and only upgrade if the handler returns true.

I'm still not sure why the worker seemed to not receive further requests when it failed to send a response here. (Though omni_httpd.stop and start would restart them.) Even when the connection was closed by the peer, I don't think the worker was closing its file descriptor for the socket. But this might have something to do with how the h2o library works that I'm not familiar with.