### PR TITLE
Problem: sum type equality comparison is slow

### DIFF
--- a/extensions/omni_types/CHANGELOG.md
+++ b/extensions/omni_types/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.3] - TBD
 
+### Fixed
+
+* Improved sum type equality comparison performance [#801](https://github.com/omnigres/omnigres/pull/801)
+
 ## [0.3.2] - 2024-02-18
 
 ### Fixed


### PR DESCRIPTION
We keep looking up the variant and the variant comparison functions a lot.

Solution: cache these

Bound to a xmin, we keep a cache of what we know about the types. This is still
imperfect because we don't preserve the cache across the xmin boundary where we
could have. For that, we would to need to implement a relcache handler in
omni_types to refresh the cache whenever the underlying table changes.


Also, the cache is only used in variant lookup but not in in/out functions.