### PR TITLE
Problem: recent change to executor start hook

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.6] - TBD
 
+### Fixed
+
+* Support for the upcoming Postgres 18 [#804](https://github.com/omnigres/omnigres/pull/804)
+
 ## [0.2.5] - 2025-01-23
 
 ### Added

--- a/extensions/omni/hook_harness.c
+++ b/extensions/omni/hook_harness.c
@@ -52,9 +52,14 @@ MODULE_FUNCTION void default_planner(omni_hook_handle *handle, Query *parse,
 
 MODULE_FUNCTION void default_executor_start(omni_hook_handle *handle, QueryDesc *queryDesc,
                                             int eflags) {
-  return saved_hooks[omni_hook_executor_start] == NULL
-             ? standard_ExecutorStart(queryDesc, eflags)
-             : ((ExecutorStart_hook_type)saved_hooks[omni_hook_executor_start])(queryDesc, eflags);
+  handle->returns.bool_value =
+#if PG_MAJORVERSION_NUM >= 18
+#else
+      true;
+#endif
+      saved_hooks[omni_hook_executor_start] == NULL
+          ? standard_ExecutorStart(queryDesc, eflags)
+          : ((ExecutorStart_hook_type)saved_hooks[omni_hook_executor_start])(queryDesc, eflags);
 }
 
 MODULE_FUNCTION void default_executor_run(omni_hook_handle *handle, QueryDesc *queryDesc,
@@ -179,11 +184,19 @@ MODULE_FUNCTION PlannedStmt *omni_planner_hook(Query *parse, const char *query_s
   return iterate_hooks(planner, parse, query_string, cursorOptions, boundParams).PlannedStmt_value;
 }
 
+#if PG_MAJORVERSION_NUM >= 18
+MODULE_FUNCTION bool omni_executor_start_hook(QueryDesc *queryDesc, int eflags) {
+  load_pending_modules();
+
+  return iterate_hooks(executor_start, queryDesc, eflags).bool_value;
+}
+#else
 MODULE_FUNCTION void omni_executor_start_hook(QueryDesc *queryDesc, int eflags) {
   load_pending_modules();
 
   iterate_hooks(executor_start, queryDesc, eflags);
 }
+#endif
 
 MODULE_FUNCTION void omni_executor_run_hook(QueryDesc *queryDesc, ScanDirection direction,
                                             uint64 count

--- a/extensions/omni/omni_common.h
+++ b/extensions/omni/omni_common.h
@@ -178,7 +178,11 @@ MODULE_FUNCTION void omni_check_password_hook(const char *username, const char *
                                               PasswordType password_type, Datum validuntil_time,
                                               bool validuntil_null);
 
+#if PG_MAJORVERSION_NUM >= 18
+MODULE_FUNCTION bool omni_executor_start_hook(QueryDesc *queryDesc, int eflags);
+#else
 MODULE_FUNCTION void omni_executor_start_hook(QueryDesc *queryDesc, int eflags);
+#endif
 
 MODULE_FUNCTION PlannedStmt *omni_planner_hook(Query *parse, const char *query_string,
                                                int cursorOptions, ParamListInfo boundParams);


### PR DESCRIPTION
In [525392d](https://github.com/postgres/postgres/commit/525392d5727f469e9a5882e1d728917a4be56147), ExecutorStart_hook has changed its signature and `omni` no longer compiles on master.

Solution: accommodate the change

We'll return valid being true for prior versions.