### PR TITLE
Problem: omni_httpd leaks file descriptors

### DIFF
--- a/extensions/omni_httpd/event_loop.c
+++ b/extensions/omni_httpd/event_loop.c
@@ -172,24 +172,30 @@ static inline void prepare_req_for_reprocess(h2o_req_t *req) {
   req->conn->ctx->proxy.client_ctx.max_buffer_size = H2O_SOCKET_INITIAL_INPUT_BUFFER_SIZE * 2;
 }
 
+typedef struct on_ws_message_data {
+  websocket_uuid_t ws_uuid;
+  int unix_socket;
+} on_ws_message_data_t;
+
 static void on_ws_message(h2o_websocket_conn_t *conn,
                           const struct wslay_event_on_msg_recv_arg *arg) {
-  char *uuid = (char *)conn->data;
-  if (conn->data != NULL && (arg == NULL || arg->opcode == WSLAY_CONNECTION_CLOSE)) {
+  on_ws_message_data_t *data = (on_ws_message_data_t  *)conn->data;
+
+  if (data != NULL && arg == NULL) {
     handler_message_t *msg = malloc(sizeof(*msg));
     msg->super = (h2o_multithread_message_t){{NULL}};
     msg->type = handler_message_websocket_close;
-    memcpy(msg->payload.websocket_close.uuid, uuid, sizeof(msg->payload.websocket_close.uuid));
+    memcpy(msg->payload.websocket_close.uuid, data->ws_uuid, sizeof(msg->payload.websocket_close.uuid));
 
     h2o_multithread_send_message(&handler_receiver, &msg->super);
 
-    // Remove the socket
-    struct sockaddr_un server;
-    websocket_unix_domain_socket(conn->data, &server, true);
+    // Close & remove the socket
+    close(data->unix_socket);
+    unlink_websocket_unix_socket(&data->ws_uuid);
+
     // Mark this connection as closed and dispose the UUID
-    if (arg == NULL) {
-      h2o_websocket_close(conn);
-    }
+    h2o_websocket_close(conn);
+
     free(conn->data);
     conn->data = NULL;
     return;
@@ -203,7 +209,7 @@ static void on_ws_message(h2o_websocket_conn_t *conn,
     msg->payload.websocket_message.message = (uint8_t *)malloc(arg->msg_length);
     msg->payload.websocket_message.message_len = arg->msg_length;
     memcpy(msg->payload.websocket_message.message, arg->msg, arg->msg_length);
-    memcpy(msg->payload.websocket_message.uuid, uuid, sizeof(msg->payload.websocket_open.uuid));
+    memcpy(msg->payload.websocket_message.uuid, data->ws_uuid, sizeof(msg->payload.websocket_open.uuid));
 
     h2o_multithread_send_message(&handler_receiver, &msg->super);
   }
@@ -252,24 +258,31 @@ static void format_uuid_rfc4122(char *dst, uint8_t *octets, uint8_t version) {
 
   /* '\0' is set by h2o_hex_encode() */
 }
-int websocket_unix_domain_socket(websocket_uuid_t *uuid, struct sockaddr_un *server_addr,
-                                 bool producer) {
+
+int websocket_unix_socket_path(struct sockaddr_un *addr, websocket_uuid_t *uuid) {
+#define SOCK_PREFIX "/omni_httpd.sock."
+#define RFC4122_UUID_LEN 36
+
   extern char **temp_dir; // from omni_httpd
-  int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  const int len_with_sock_prefix = strlen(*temp_dir) + sizeof(SOCK_PREFIX) - 1;
 
-  memset(server_addr, 0, sizeof(struct sockaddr_un));
-  server_addr->sun_family = AF_UNIX;
+  if (len_with_sock_prefix + RFC4122_UUID_LEN + 1 > sizeof(addr->sun_path))
+    return -EINVAL;
 
-  snprintf(server_addr->sun_path, sizeof(server_addr->sun_path), "%s/omni_httpd.sock.", *temp_dir);
-  int len = strlen(server_addr->sun_path);
+  snprintf(addr->sun_path, sizeof(addr->sun_path), "%s" SOCK_PREFIX, *temp_dir);
 
-  format_uuid_rfc4122(server_addr->sun_path + len, *uuid, 4);
+  format_uuid_rfc4122(addr->sun_path + len_with_sock_prefix, *uuid, 4);
 
-  if (producer) {
-    unlink(server_addr->sun_path);
-  }
+  return 0;
+}
 
-  return fd;
+int unlink_websocket_unix_socket(websocket_uuid_t *uuid) {
+  struct sockaddr_un addr = { 0 };
+
+  if (websocket_unix_socket_path(&addr, uuid) < 0)
+    return -EINVAL;
+
+  return unlink(addr.sun_path);
 }
 
 static void on_message(h2o_multithread_receiver_t *receiver, h2o_linklist_t *messages) {
@@ -324,19 +337,35 @@ static void on_message(h2o_multithread_receiver_t *receiver, h2o_linklist_t *mes
       break;
     }
     case MSG_KIND_UPGRADE_TO_WEBSOCKET: {
-      h2o_websocket_conn_t *websocket_conn =
-          h2o_upgrade_to_websocket(req, reqmsg->ws_client_key, reqmsg, on_ws_message);
-      websocket_conn->data = malloc(sizeof(reqmsg->ws_uuid));
-      memcpy(websocket_conn->data, reqmsg->ws_uuid, sizeof(reqmsg->ws_uuid));
+      on_ws_message_data_t *data = malloc(sizeof(on_ws_message_data_t));
+      // if (!data) ???
 
-      // Create a Unix domain socket
-      struct sockaddr_un server_addr;
-      int server_fd = websocket_unix_domain_socket(&reqmsg->ws_uuid, &server_addr, true);
-      bind(server_fd, (struct sockaddr *)&server_addr, sizeof(struct sockaddr_un));
-      listen(server_fd, SOMAXCONN);
+      memcpy(data->ws_uuid, reqmsg->ws_uuid, sizeof(reqmsg->ws_uuid));
+
+      // Create and listen on a Unix domain socket
+      struct sockaddr_un server_addr = { .sun_family = AF_UNIX };
+
+      if (   websocket_unix_socket_path(&server_addr, &reqmsg->ws_uuid) < 0
+          || (data->unix_socket = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {
+        /* todo log errors? */
+        free(data);
+        goto done;
+      }
+
+      if (   bind(data->unix_socket, (struct sockaddr *)&server_addr, sizeof(struct sockaddr_un)) < 0
+          || listen(data->unix_socket, SOMAXCONN) < 0) {
+        /* todo log errors? */
+        close(data->unix_socket);
+        free(data);
+        goto done;
+      }
+
+      h2o_websocket_conn_t *websocket_conn =
+          h2o_upgrade_to_websocket(req, reqmsg->ws_client_key, data, on_ws_message);
+      assert(websocket_conn->data == data);
 
       h2o_socket_t *sock =
-          h2o_evloop_socket_create(worker_event_loop, server_fd, H2O_SOCKET_FLAG_DONT_READ);
+          h2o_evloop_socket_create(worker_event_loop, data->unix_socket, H2O_SOCKET_FLAG_DONT_READ);
       sock->data = websocket_conn;
 
       h2o_socket_read_start(sock, on_accept_ws_unix);
@@ -430,6 +459,7 @@ void on_accept(h2o_socket_t *listener, const char *err) {
   }
 
   if ((sock = h2o_evloop_socket_accept(listener)) == NULL) {
+    /* NO ERROR HANDLING FIXME LULZ */
     return;
   }
   h2o_accept(listener_accept_ctx(listener), sock);

--- a/extensions/omni_httpd/event_loop.h
+++ b/extensions/omni_httpd/event_loop.h
@@ -182,9 +182,22 @@ void h2o_queue_upgrade_to_websocket(request_message_t *msg);
 void event_loop_register_receiver();
 
 /**
- * Prepares a UNIX domain socket for WebSocket producer/consumer
+ * Sets addr->sun_path to a temporary socket path for the given uuid.
+ *
+ * This may subtly modify the given uuid.
+ *
+ * Returns 0 on success or -EINVAL if the socket path is too long.
  */
-int websocket_unix_domain_socket(websocket_uuid_t *uuid, struct sockaddr_un *server_addr,
-                                 bool producer);
+int websocket_unix_socket_path(struct sockaddr_un *addr, websocket_uuid_t *uuid);
+
+/**
+ * unlink(2) the temporary socket path for the given uuid.
+ *
+ * This may subtly modify the given uuid.
+ *
+ * Returns 0 on success or -EINVAL if the socket path is too long or -1 and
+ * sets errno if unlink fails.
+ */
+int unlink_websocket_unix_socket(websocket_uuid_t *uuid);
 
 #endif // OMNI_HTTPD_EVENT_LOOP_H

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -741,8 +741,10 @@ static cvec_fd_fd accept_fds(char *socket_name) {
 
   socket_fd = socket(PF_UNIX, SOCK_STREAM, 0);
   if (socket_fd < 0) {
-    ereport(ERROR, errmsg("can't create sharing socket"));
+    int e = errno;
+    ereport(ERROR, errmsg("can't create sharing socket"), errdetail(strerror(e)));
   }
+
   int err = fcntl(socket_fd, F_SETFL, fcntl(socket_fd, F_GETFL, 0) | O_NONBLOCK);
   if (err != 0) {
     ereport(ERROR, errmsg("Error setting O_NONBLOCK: %s", strerror(err)));
@@ -1556,8 +1558,9 @@ static int handler(handler_message_t *msg) {
       MemoryContextSwitchTo(memory_context);
       WITH_TEMP_MEMCXT {
         ErrorData *error = CopyErrorData();
-        ereport(WARNING, errmsg("Error executing omni_httpd.on_websocket_message"),
-                errdetail("%s: %s", error->message, error->detail));
+        const char *fn = msg->type == handler_message_websocket_open ? "Error executing omni_httpd.websocket_on_open"
+                                                                     : "Error executing omni_httpd.websocket_on_close";
+        ereport(WARNING, errmsg(fn), errdetail("%s: %s", error->message, error->detail));
       }
 
       FlushErrorState();

--- a/extensions/omni_httpd/master_worker.c
+++ b/extensions/omni_httpd/master_worker.c
@@ -129,7 +129,8 @@ void prepare_share_fd() {
 
   socket_fd = socket(PF_UNIX, SOCK_STREAM, 0);
   if (socket_fd < 0) {
-    ereport(ERROR, errmsg("can't create sharing socket"));
+    int e = errno;
+    ereport(ERROR, errmsg("can't create sharing socket: %s", strerror(e)));
   }
 
   int enable = 1;

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -559,44 +559,59 @@ static inline bool sh_uuid_eq(struct sockethash_hash *tb, const pg_uuid_t a, con
 Datum websocket_send(PG_FUNCTION_ARGS, int8 kind) {
   if (PG_ARGISNULL(0)) {
     ereport(ERROR, errmsg("socket can't be null"));
+    PG_RETURN_VOID();
   }
   if (PG_ARGISNULL(1)) {
     ereport(ERROR, errmsg("data can't be null"));
+    PG_RETURN_VOID();
   }
 
-  static sockethash_hash *sockethash = NULL;
-  if (sockethash == NULL) {
-    sockethash = sockethash_create(TopMemoryContext, 8192, NULL);
-  }
   pg_uuid_t *uuid = PG_GETARG_UUID_P(0);
   struct varlena *payload = PG_GETARG_VARLENA_PP(1);
 
-  bool found;
-  SocketHashEntry *entry = sockethash_insert(sockethash, *uuid, &found);
-  if (!found) {
-    struct sockaddr_un server_addr;
-    entry->fd = websocket_unix_domain_socket(&uuid->data, &server_addr, false);
+  int sock;
+  struct sockaddr_un server_addr = { .sun_family = AF_UNIX };
 
-    // Connect to the server
-    if (connect(entry->fd, (struct sockaddr *)&server_addr, sizeof(struct sockaddr_un)) < 0) {
-      char *s = strerror(errno);
-      ereport(ERROR, errmsg("connect %s", s));
-    }
+  if (websocket_unix_socket_path(&server_addr, &uuid->data) < 0) {
+    ereport(ERROR, errmsg("websocket_unix_socket_path"), errdetail("socket path too long"));
+    PG_RETURN_VOID();
   }
-  int client_fd = entry->fd;
+
+  if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {
+    const int e = errno;
+    ereport(ERROR, errmsg("socket"), errdetail(strerror(e)));
+    PG_RETURN_VOID();
+  }
+
+  if (connect(sock, (struct sockaddr *)&server_addr, sizeof(struct sockaddr_un)) < 0) {
+    const int e = errno;
+    ereport(ERROR, errmsg("connect"), errdetail(strerror(e)));
+    close(sock);
+    PG_RETURN_VOID();
+  }
 
   // Send a message to the server
   struct {
     int8_t kind;
     size_t length;
   } __attribute__((packed)) msg = {.kind = kind, .length = VARSIZE_ANY_EXHDR(payload)};
-  if (send(client_fd, &msg, sizeof(msg), 0) < 0) {
-    ereport(ERROR, errmsg("send"));
-  }
-  if (send(client_fd, VARDATA_ANY(payload), msg.length, 0) < 0) {
-    ereport(ERROR, errmsg("send"));
+
+  struct iovec iov[2];
+  iov[0].iov_base = &msg;
+  iov[0].iov_len = sizeof(msg);
+  iov[1].iov_base = VARDATA_ANY(payload);
+  iov[1].iov_len = msg.length;
+
+  struct msghdr sendhdr = { 0 };
+  sendhdr.msg_iov = iov;
+  sendhdr.msg_iovlen = 2;
+
+  if (sendmsg(sock, &sendhdr, 0) < 0) {
+    int e = errno;
+    ereport(ERROR, errmsg("sendmsg"), errdetail(strerror(e)));
   }
 
+  close(sock);
   PG_RETURN_VOID();
 }
 


### PR DESCRIPTION
WebSockets cause omni_httpd to leak file descriptors, mainly through the unix socket proxy tunnel thingy and but also not closing the TCP connection. Eventually, it runs out of file descriptors and cannot accept new connections. It can be particularly troublesome if accept() fails with "Too many open files" and gets stuck trying again and again failing each time indefinitely. I think better error handling and reporting would valuable in future work.

Solution: close file descriptors for opened sockets

1. `on_ws_message` might not call h2o_websocket_close on the TCP socket for a WebSocket

   `on_ws_message` would see `arg->opcode == WSLAY_CONNECTION_CLOSE` and `free(conn->data)` and assign it to NULL.

   Then `on_ws_message` would see `arg == NULL` but not enter the branch to call `h2o_websocket_close()` because data is NULL at that point.

   This only frees the data and closes the socket when when `arg == NULL`.

2. When a postgres connection process calls `websocket_send` from a SQL query, it needs to forward the message to whatever httpd worker holds the underlying connection for that WebSocket.

   In doing so it opens a socket but never closes it, it stores it in a collection to re-use it later but it does eventually leak and long running connection processes can run into problems for this reason.

   This change simply closes the socket each time and removes the collection where open sockets were stored. This does have negative performance impact in terms of speed but positively impacts performance as the process is not doomed to run out of file descriptors. :)

   The two `send()` calls have been replaced with one `sendmsg()` using scatter-gather but I'm not sure this helps with speed all that much. (There is a lot of noise when I try to measure this extension on my machine.)

   So there is certainly room for a more efficient design, maybe one that includes the collection but is length limited and closes least recent sockets.

3. Also in `on_ws_message`, the unix listen socket for accepting connections from `websocket_send` was not being closed. The unix socket is opened when the WebSocket is upgraded. With this change, the file descriptor is copied to a `on_ws_message_data_t` structure pointed to by the h2o connection where it can be closed by `on_ws_message` when the WebSocket is closed.

Finally, h2o provides uuids for connections through `const char *h2o_conn_get_uuid(h2o_conn_t *)`. It may be simpler to use that and remove the uuid generation and formatting code in this extension. As far as I know, once an HTTP connection is upgraded to a WebSocket, it cannot be used for any other HTTP requests. Even in HTTP2 which supports streaming, once it's upgraded, it stops being whatever it was and the connection is a WebSocket from then on. So from what I understand, it's not as if more than one WebSocket can run on one TCP connection; it can't be upgraded again in a separate stream. So if the WebSocket uuid is just the connection uuid, it would still remain unique across WebSockets.