### PR TITLE
Problem: omni fails to build on master Postgres (🚀 omni 0.2.7)

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2025-02-24
+
+### Fixed
+
+* Support for the upcoming Postgres 18 [#811](https://github.com/omnigres/omnigres/pull/811)
+
 ## [0.2.6] - 2025-02-20
 
 ### Fixed
@@ -129,3 +135,5 @@ Initial release following a few months of iterative development.
 [0.2.5]: [https://github.com/omnigres/omnigres/pull/763]
 
 [0.2.6]: [https://github.com/omnigres/omnigres/pull/803]
+
+[0.2.7]: [https://github.com/omnigres/omnigres/pull/811]

--- a/extensions/omni/omni.c
+++ b/extensions/omni/omni.c
@@ -211,10 +211,14 @@ static void register_lwlock(const omni_handle *handle, LWLock *lock, const char 
   }
 }
 
-#if PG_MAJORVERSION_NUM >= 13 && PG_MAJORVERSION_NUM <= 18
+#if PG_MAJORVERSION_NUM >= 13 && PG_MAJORVERSION_NUM < 18
 #define LW_FLAG_HAS_WAITERS ((uint32)1 << 30)
 #define LW_FLAG_RELEASE_OK ((uint32)1 << 29)
 #define LW_FLAG_LOCKED ((uint32)1 << 28)
+#elif PG_MAJORVERSION_NUM == 18
+#define LW_FLAG_HAS_WAITERS ((uint32)1 << 31)
+#define LW_FLAG_RELEASE_OK ((uint32)1 << 30)
+#define LW_FLAG_LOCKED ((uint32)1 << 29)
 #else
 #error "Check these constants for this version of Postgres"
 #endif

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
-omni=0.2.6
+omni=0.2.7
 omni_aws=0.1.2
 omni_auth=0.1.3
 omni_containers=0.2.0


### PR DESCRIPTION
Solution: update internal flag values

[cd3ccf88aacb43b7232d6834dc886ff8538c6ce8](https://github.com/postgres/postgres/commit/cd3ccf88aacb43b7232d6834dc886ff8538c6ce8) changed these and tests started failing.