### PR TITLE
add explain function to omni_sql extension

### DIFF
--- a/extensions/omni_sql/migrate/8_explain.sql
+++ b/extensions/omni_sql/migrate/8_explain.sql
@@ -1,0 +1,6 @@
+create function explain(statement) returns json
+as
+'MODULE_PATHNAME',
+'explain'
+    language c strict
+               immutable;

--- a/extensions/omni_sql/omni_sql.h
+++ b/extensions/omni_sql/omni_sql.h
@@ -27,4 +27,6 @@ bool omni_sql_is_returning_statement(List *stmts);
 
 bool omni_sql_is_replace_statement(List *stmts);
 
+Datum explain(PG_FUNCTION_ARGS);
+
 #endif // OMNI_SQL_H

--- a/extensions/omni_sql/tests/omni_sql/explain.yml
+++ b/extensions/omni_sql/tests/omni_sql/explain.yml
@@ -1,0 +1,26 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_sql cascade
+
+tests:
+
+- name: explain select
+  query: select omni_sql.explain('select 1')
+  results:
+  - explain: [{"Plan":{"Node Type":"Result","Parallel Aware":false,"Startup Cost":0.00,"Total Cost":0.01,"Plan Rows":1,"Plan Width":4}}]
+
+- name: explain insert
+  query: select omni_sql.explain('insert into test_table values (1)')
+  results:
+  - explain: [{"Plan":{"Node Type":"Insert","Parallel Aware":false,"Startup Cost":0.00,"Total Cost":0.01,"Plan Rows":1,"Plan Width":4}}]
+
+- name: explain update
+  query: select omni_sql.explain('update test_table set value = 2 where value = 1')
+  results:
+  - explain: [{"Plan":{"Node Type":"Update","Parallel Aware":false,"Startup Cost":0.00,"Total Cost":0.01,"Plan Rows":1,"Plan Width":4}}]
+
+- name: explain delete
+  query: select omni_sql.explain('delete from test_table where value = 1')
+  results:
+  - explain: [{"Plan":{"Node Type":"Delete","Parallel Aware":false,"Startup Cost":0.00,"Total Cost":0.01,"Plan Rows":1,"Plan Width":4}}]


### PR DESCRIPTION
Fixes #807

Implement an `explain` function in the `omni_sql` extension to return the execution plan in JSON format.

* Add a new function `explain` in `extensions/omni_sql/omni_sql.c` that takes a SQL statement as input and returns the execution plan in JSON format.
* Declare the `explain` function in `extensions/omni_sql/omni_sql.h`.
* Create a new migration file `extensions/omni_sql/migrate/8_explain.sql` to add the `explain` function in the database.
* Add tests for the `explain` function in `extensions/omni_sql/tests/omni_sql/explain.yml` to verify the output with different SQL statements.

