### PR TITLE
fix: ensure file_info returns directory for root in table_fs

### DIFF
--- a/extensions/omni_vfs/src/file_info_table_fs.sql
+++ b/extensions/omni_vfs/src/file_info_table_fs.sql
@@ -5,7 +5,16 @@ as
 $$
 
 with
-    match(id) as (select table_fs_file_id(fs, path))
+    match(id) as (
+        select 
+            case 
+                when omni_vfs.canonicalize_path(path, absolute => true) = '/' then 
+                    (select id from table_fs_files where filesystem_id = fs.id and filename = '' and depth = 1)
+                else 
+                    table_fs_file_id(fs, path)
+            end
+    )
+
 select
     coalesce(length(d.data), 0) as size,
     d.created_at,
@@ -15,6 +24,8 @@ select
 from
     table_fs_files                f
     inner join match              m on f.id = m.id
+     -- Use a left join because the root directory entry might not have associated data in table_fs_file_data.
+    left join table_fs_file_data  d on m.id = d.file_id
     inner join table_fs_file_data d on m.id = d.file_id
 where
     filesystem_id = fs.id

--- a/extensions/omni_vfs/tests/table_fs.yml
+++ b/extensions/omni_vfs/tests/table_fs.yml
@@ -428,3 +428,15 @@ tests:
     results:
     - data1: 0x75706461746564
       data2: 0x7365636f6e64
+
+- name: file_info for root directory
+  steps:
+  - name: create filesystem
+    query: |
+      select omni_vfs.table_fs('root_test')
+  
+  - name: file_info for root directory
+    query: |
+      select kind from omni_vfs.file_info(omni_vfs.table_fs('root_test'), '/')
+    results:
+    - kind: dir


### PR DESCRIPTION
Omni_vfs.file_info(table_fs, '/') previously returned NULL, which was inconsistent with local_fs behavior. This update ensures it correctly returns a non-null value describing it as a directory.


/claim https://github.com/omnigres/omnigres/issues/796
close https://github.com/omnigres/omnigres/issues/796