### PR TITLE
Problem: generializing omni_credentials

### DIFF
--- a/extensions/omni_credentials/CHANGELOG.md
+++ b/extensions/omni_credentials/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.0] - TBD
 
+### Added
+
+* Credentials now have kind, principal and scope [#826](https://github.com/omnigres/omnigres/pull/826)
+
 ## [0.1.0] - 2024-12-26
 
 Initial release

--- a/extensions/omni_credentials/docs/credentials.md
+++ b/extensions/omni_credentials/docs/credentials.md
@@ -16,10 +16,24 @@
 ## Core Architecture
 
 The central object of interest is the `credentials` view (instantiated into `omni_credentials` schema by default), it
-only contains `name` and `value` columns that represent credential name
-and value.
+contains `name` and `value` columns that represent credential name and value. To help with producing a more unified,
+shareable credential ecosystem, we add few more columns
+
+|      **Name** | Type            | Description                                                                                                                                                                                                                   |
+|--------------:|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|      **name** | text            | An identifier for the credential.                                                                                                                                                                                             |
+|     **value** | bytea           | Credential data (such as an API key, password, or token)                                                                                                                                                                      |
+|      **kind** | credential_kind | An enumerated type that categorizes the credential. Common values might include `api_key`, `api_secret`, `password`, etc., with a default of `credential` for generic cases.                                                  |
+| **principal** | regrole         | Specifies the authenticated entity (the principal) for whom the credential is intended. Uses Postgres rolese, defaulting to the current user, ensuring the credential is tied to an identity.                                 |
+|     **scope** | jsonb           | A JSON object defining the domain or resource constraints where the credential is valid. For example, `{ "all": true }` (default) indicates a wildcard scope, while more structured scopes can specify domains or conditions. |
 
 You can simply query and update it as you see fit. Behind the scene, it will propage changes as necessary.
+
+## Encryption & Access Control
+
+The `credentials` view is based on the `encrypted_credentials` view that has `value` encrypted and is a
+Row-Level Security-enabled relation. The default policy on it requires current user to have a grant for the
+role of `principal` (`encrypted_credentials_principal` policy). Additional policies can be provisioned.
 
 ## Credential Encryption
 

--- a/extensions/omni_credentials/src/instantiate.sql
+++ b/extensions/omni_credentials/src/instantiate.sql
@@ -12,45 +12,137 @@ begin
         unique (environment_variable)
     );
 
-    insert into credentials_config (environment_variable) values (env_var);
+    insert
+    into
+        credentials_config (environment_variable)
+    values (env_var);
+
+    create type credential_kind as enum ('credential','api_key','api_secret','password', 'token', 'token[jwt]', 'token[oauth]', 'ssh','certificate', 'otp', 'saml_assertion');
 
     create table encrypted_credentials
     (
-        name  text  not null unique,
-        value bytea not null
+        name      text            not null,
+        value     bytea           not null,
+        kind      credential_kind not null default 'credential',
+        principal regrole         not null default current_user::regrole,
+        scope     jsonb           not null default '{
+          "all": true
+        }'
     );
+    alter table encrypted_credentials
+        enable row level security;
+    create policy encrypted_credentials_principal on encrypted_credentials
+        using (pg_has_role(current_user, principal, 'USAGE'));
 
-    create function credentials_master_password() returns text
-        language sql
-    as
-    $sql$
-    select value
-    from omni_os.env
-             inner join credentials_config on true
-    where variable = environment_variable
-    $sql$;
-    execute format('alter function credentials_master_password set search_path to %I', schema);
+    create unique index encrypted_credentials_uniq
+        on encrypted_credentials (name, kind, principal, scope);
+
+    create function decrypt_credential(credential bytea) returns text
+        security definer
+    begin
+        atomic
+        select
+            pgp_sym_decrypt(credential, value)
+        from
+            omni_os.env
+            inner join credentials_config on true
+        where
+            variable = environment_variable;
+    end;
+
+    create function encrypt_credential(credential text) returns bytea
+        security definer
+    begin
+        atomic
+        select
+            pgp_sym_encrypt(credential, value)
+        from
+            omni_os.env
+            inner join credentials_config on true
+        where
+            variable = environment_variable;
+    end;
 
 
-    create view credentials as
-    select name,
-           pgp_sym_decrypt(value, credentials_master_password()) as value
-    from encrypted_credentials;
+    if current_setting('server_version_num')::int / 10000 > 14 then
+        create view credentials with (security_barrier, security_invoker) as
+            select
+                name,
+                decrypt_credential(value) as value,
+                kind,
+                principal,
+                scope
+            from
+                encrypted_credentials;
+    else
+        create function _credentials_view()
+            returns table
+                    (
+                        name      text,
+                        value     text,
+                        kind      credential_kind,
+                        principal regrole,
+                        scope     jsonb
+                    )
+            security invoker
+        begin
+            atomic
+            select
+                name,
+                decrypt_credential(value) as value,
+                kind,
+                principal,
+                scope
+            from
+                encrypted_credentials;
+        end;
+        create view credentials with (security_barrier) as
+            select * from _credentials_view();
+    end if;
+
+    alter table credentials
+        alter column kind set default 'credential';
+    alter table credentials
+        alter column principal set default current_user::regrole;
+    alter table credentials
+        alter column scope set default '{"all": true}';
 
     create function credentials_update() returns trigger
         security definer
         language plpgsql as
     $code$
     begin
+        if tg_op = 'DELETE' then
+            delete
+            from
+                encrypted_credentials
+            where
+                name = old.name and
+                kind = old.kind and
+                principal = old.principal and
+                scope = old.scope;
+            return old;
+        end if;
         if old is distinct from null then
             update encrypted_credentials
-            set value = pgp_sym_encrypt(new.value, credentials_master_password()),
-                name  = new.name
-            where name = old.name;
+            set
+                value = encrypt_credential(new.value),
+                name  = new.name,
+                kind = new.kind,
+                principal = new.principal,
+                scope = new.scope
+            where
+                name = old.name and
+                kind = old.kind and
+                principal = old.principal and
+                scope = old.scope;
         else
             insert
-            into encrypted_credentials (name, value)
-            values (new.name, pgp_sym_encrypt(new.value, credentials_master_password()));
+            into
+                encrypted_credentials (name, value, kind, principal, scope)
+            values
+                (new.name, encrypt_credential(new.value), new.kind, new.principal,
+                 new.scope);
         end if;
         return new;
     end;
@@ -58,7 +150,7 @@ begin
     execute format('alter function credentials_update set search_path to %I,public', schema);
 
     create trigger credentials_update
-        instead of update or insert
+        instead of update or insert or delete
         on credentials
         for each row
     execute function credentials_update();

--- a/extensions/omni_credentials/src/instantiate_file_store.sql
+++ b/extensions/omni_credentials/src/instantiate_file_store.sql
@@ -28,11 +28,12 @@ begin
             like encrypted_credentials
         ) on commit drop;
         execute format('copy __new_encrypted_credentials__ from %L', filename);
+        raise notice '%', pg_read_file(filename);
 
-        insert into encrypted_credentials (name, value)
-        select name, value
+        insert into encrypted_credentials (name, value, kind, principal, scope)
+        select name, value, kind, principal, scope
         from __new_encrypted_credentials__
-        on conflict (name) do update set value = excluded.value;
+        on conflict (name, kind, principal, scope) do update set value = excluded.value;
         return true;
     exception
         when others then return false;

--- a/extensions/omni_credentials/tests/credentials.yaml
+++ b/extensions/omni_credentials/tests/credentials.yaml
@@ -8,6 +8,59 @@ instance:
 
 tests:
 
+- name: default metadata
+  steps:
+  - insert into creds.credentials (name, value) values ('a', 'b')
+  - query: select kind, principal, scope from creds.credentials
+    results:
+      - kind: credential
+        principal: yregress
+        scope:
+          all: true
+
+- name: RLS
+  steps:
+  - insert into creds.credentials (name, value) values ('a', 'b')
+  - create role other_role
+  - grant usage on schema creds to other_role
+  - grant select on all tables in schema creds to other_role
+  - grant insert on table creds.credentials to other_role
+  - set local role other_role
+  - query: select kind, principal, scope from creds.credentials
+    results: []
+  - insert into creds.credentials (name, value) values ('a', 'b')
+  - query: select kind, principal, scope from creds.credentials
+    results:
+      - kind: credential
+        principal: other_role
+        scope:
+          all: true
+
+- name: updating credential
+  steps:
+  - "insert into creds.credentials (name, value, scope) values ('a', 'b', '{\"for\": \"some\"}'), ('a', 'b', '{\"all\": true}')"
+  - "update creds.credentials set scope = '{}' where scope = '{\"all\": true}'"
+  - query: select kind, principal, scope from creds.credentials order by scope
+    results:
+      - kind: credential
+        principal: yregress
+        scope: {}
+      - kind: credential
+        principal: yregress
+        scope:
+          for: some
+
+- name: deleting credential
+  steps:
+  - "insert into creds.credentials (name, value, scope) values ('a', 'b', '{\"for\": \"some\"}'), ('a', 'b', '{\"all\": true}')"
+  - "delete from creds.credentials where scope = '{\"all\": true}'"
+  - query: select kind, principal, scope from creds.credentials order by scope
+    results:
+      - kind: credential
+        principal: yregress
+        scope:
+          for: some
+
 - name: encrypts credentials on insert
   steps:
   - insert into creds.credentials (name, value) values ('a', 'b')
@@ -31,7 +84,7 @@ tests:
 
 - name: credentials are unique
   query: insert into creds.credentials (name, value) values ('a', 'b'), ('a','c')
-  error: duplicate key value violates unique constraint "encrypted_credentials_name_key"
+  error: duplicate key value violates unique constraint "encrypted_credentials_uniq"
 
 - name: credential removal cleans up encrypted credentials
   steps:

--- a/extensions/omni_credentials/tests/credentials_file_store.yaml
+++ b/extensions/omni_credentials/tests/credentials_file_store.yaml
@@ -19,7 +19,7 @@ tests:
   - select pg_stat_file('creds.txt')
   - query: select octet_length(pg_read_file('creds.txt'))
     results:
-    - octet_length: 140
+    - octet_length: 174
 
 - name: does not update credentials in a file store during transaction
   commit: true
@@ -27,18 +27,18 @@ tests:
   - insert into creds.credentials (name, value) values ('b', 'c')
   - query: select octet_length(pg_read_file('creds.txt'))
     results:
-    - octet_length: 140
+    - octet_length: 174
 
 - name: but it does update credentials in a file store after the transaction
   query: select octet_length(pg_read_file('creds.txt'))
   results:
-  - octet_length: 280
+  - octet_length: 348
 
 - name: imports credentials from a file store
   commit: true
   steps:
   - select omni_credentials.instantiate_file_store(filename => 'creds.txt', schema => 'creds1')
-  - query: select * from creds1.credentials
+  - query: select name, value from creds1.credentials
     results:
     - name: a
       value: b
@@ -56,7 +56,7 @@ tests:
 - name: but it does if explicitly reloaded
   steps:
   - select creds.credential_file_store_reload(filename) from creds.credential_file_stores
-  - query: select * from creds.credentials where name = 'c'
+  - query: select name, value from creds.credentials where name = 'c'
     results:
     - name: c
       value: d


### PR DESCRIPTION
When we want to use them across different subsystems and extensions, they lack specificity. It's just an encrypted key/value store.

It's not clear what naming convention should be used, for example.

Solution: expand the concept to include further metadata

"What kind of credential?" – `kind`
"Who can have access to it?" – `principal`
"What is the scope of the credential?" – `scope`

This will allow much better "notation". Since we're getting all these details, it now makes sense to enable RLS on this table and by default, filter by principal. Users can add more policies to it. The reason why this metadata is not factored out is so that RLS _can_ be used there without sub-queries.