### PR TITLE
Problem: omni_vfs.file_info for table_fs on root 

### DIFF
--- a/extensions/omni_vfs/src/file_info_table_fs.sql
+++ b/extensions/omni_vfs/src/file_info_table_fs.sql
@@ -15,7 +15,7 @@ select
 from
     table_fs_files                f
     inner join match              m on f.id = m.id
-    inner join table_fs_file_data d on m.id = d.file_id
+    left join table_fs_file_data d on m.id = d.file_id
 where
     filesystem_id = fs.id
 $$;

--- a/extensions/omni_vfs/tests/local_fs.yml
+++ b/extensions/omni_vfs/tests/local_fs.yml
@@ -88,6 +88,12 @@ tests:
   - non_zero: true
     kind: file
 
+- name: can get root directory info
+  query: select size > 0 as non_zero, kind from omni_vfs.file_info(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), '/')
+  results:
+  - non_zero: true
+    kind: dir
+
 - name: file info on a non-existent file
   query: select omni_vfs.file_info(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), 'does not exist')
   results:

--- a/extensions/omni_vfs/tests/table_fs.yml
+++ b/extensions/omni_vfs/tests/table_fs.yml
@@ -428,3 +428,9 @@ tests:
     results:
     - data1: 0x75706461746564
       data2: 0x7365636f6e64
+
+- name: can get root directory info
+  query: select size > 0 as non_zero, kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/')
+  results:
+  - non_zero: true
+    kind: dir

--- a/extensions/omni_vfs/tests/table_fs.yml
+++ b/extensions/omni_vfs/tests/table_fs.yml
@@ -226,6 +226,22 @@ tests:
     results:
     - file_info: null
   
+  - name: can get root directory info
+    query: select kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/')
+    results:
+    - kind: dir
+
+  - name: can get directory info
+    steps:
+    - name: create directory
+      query: |
+        select omni_vfs.write(omni_vfs.table_fs('fs'), '/to/test', 'hello world', create_file => true)
+    
+    - name: get directory info
+      query: select kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/to')
+      results:
+      - kind: dir
+
   - name: all file timestamps are equal
     query: |
       select created_at = all(array[created_at, accessed_at, modified_at]) as equal
@@ -429,8 +445,3 @@ tests:
     - data1: 0x75706461746564
       data2: 0x7365636f6e64
 
-- name: can get root directory info
-  query: select size > 0 as non_zero, kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/')
-  results:
-  - non_zero: true
-    kind: dir


### PR DESCRIPTION
Problem takes place because the file_info function was using an inner join with table_fs_file_data. 

Since directories don't have entries in this table, the query returned no results (all null values) when attempting to retrieve directory information.

Solution: Changed the query to use left join instead of inner join when joining to table_fs_file_data. This ensures that directories are included in the results even without corresponding data entries on table_fs_file_data, preserving the `kind` field while allowing data-specific fields to be null where appropriate.

This change makes it possible to call `omni_vfs.file_info(fs, directory)` on any directory, not just root