### PR TITLE
Problem: omni_vfs.file_info for table_fs on root

### DIFF
--- a/extensions/omni_vfs/CHANGELOG.md
+++ b/extensions/omni_vfs/CHANGELOG.md
@@ -9,7 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-* Return 'dir' as type when calling omni_vfs.file_info(dir)
+* Return 'dir' as type when calling omni_vfs.file_info(dir) [#834][https://github.com/omnigres/omnigres/pull/834]
 
 ## [0.2.1] - 2025-02-12
 

--- a/extensions/omni_vfs/CHANGELOG.md
+++ b/extensions/omni_vfs/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.2] - TBD
 
+### Fixed
+
+* Return 'dir' as type when calling omni_vfs.file_info(dir)
+
 ## [0.2.1] - 2025-02-12
 
 ### Fixed

--- a/extensions/omni_vfs/src/file_info_table_fs.sql
+++ b/extensions/omni_vfs/src/file_info_table_fs.sql
@@ -15,7 +15,7 @@ select
 from
     table_fs_files                f
     inner join match              m on f.id = m.id
-    inner join table_fs_file_data d on m.id = d.file_id
+    left join table_fs_file_data d on m.id = d.file_id
 where
     filesystem_id = fs.id
 $$;

--- a/extensions/omni_vfs/tests/local_fs.yml
+++ b/extensions/omni_vfs/tests/local_fs.yml
@@ -88,6 +88,12 @@ tests:
   - non_zero: true
     kind: file
 
+- name: can get root directory info
+  query: select size > 0 as non_zero, kind from omni_vfs.file_info(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), '/')
+  results:
+  - non_zero: true
+    kind: dir
+
 - name: file info on a non-existent file
   query: select omni_vfs.file_info(omni_vfs.local_fs('../../../../extensions/omni_vfs/tests'), 'does not exist')
   results:

--- a/extensions/omni_vfs/tests/table_fs.yml
+++ b/extensions/omni_vfs/tests/table_fs.yml
@@ -428,3 +428,9 @@ tests:
     results:
     - data1: 0x75706461746564
       data2: 0x7365636f6e64
+
+- name: can get root directory info
+  query: select size > 0 as non_zero, kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/')
+  results:
+  - non_zero: true
+    kind: dir

--- a/extensions/omni_vfs/tests/table_fs.yml
+++ b/extensions/omni_vfs/tests/table_fs.yml
@@ -225,22 +225,6 @@ tests:
     query: select omni_vfs.file_info(omni_vfs.table_fs('fs'), 'does not exist')
     results:
     - file_info: null
-  
-  - name: can get root directory info
-    query: select kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/')
-    results:
-    - kind: dir
-
-  - name: can get directory info
-    steps:
-    - name: create directory
-      query: |
-        select omni_vfs.write(omni_vfs.table_fs('fs'), '/to/test', 'hello world', create_file => true)
-    
-    - name: get directory info
-      query: select kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/to')
-      results:
-      - kind: dir
 
   - name: all file timestamps are equal
     query: |
@@ -332,6 +316,23 @@ tests:
     results:
     - count: 1
 
+- name: can get directory and root directory info
+  steps:
+  - name: create dir
+    query: |
+      insert into omni_vfs.table_fs_files (filesystem_id, filename, kind)
+      values 
+      ((omni_vfs.table_fs('fs')).id, '/dir', 'dir')
+      
+  - name: get directory info
+    query: select kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/dir')
+    results:
+    - kind: dir
+
+  - name: can get root directory info
+    query: select kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/')
+    results:
+    - kind: dir
 
 - name: insert data entry for a dir failure
   steps:

--- a/extensions/omni_vfs/tests/table_fs.yml
+++ b/extensions/omni_vfs/tests/table_fs.yml
@@ -226,6 +226,22 @@ tests:
     results:
     - file_info: null
   
+  - name: can get root directory info
+    query: select kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/')
+    results:
+    - kind: dir
+
+  - name: can get directory info
+    steps:
+    - name: create directory
+      query: |
+        select omni_vfs.write(omni_vfs.table_fs('fs'), '/to/test', 'hello world', create_file => true)
+    
+    - name: get directory info
+      query: select kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/to')
+      results:
+      - kind: dir
+
   - name: all file timestamps are equal
     query: |
       select created_at = all(array[created_at, accessed_at, modified_at]) as equal
@@ -429,8 +445,3 @@ tests:
     - data1: 0x75706461746564
       data2: 0x7365636f6e64
 
-- name: can get root directory info
-  query: select size > 0 as non_zero, kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/')
-  results:
-  - non_zero: true
-    kind: dir

--- a/extensions/omni_vfs/tests/table_fs.yml
+++ b/extensions/omni_vfs/tests/table_fs.yml
@@ -334,6 +334,11 @@ tests:
     results:
     - kind: dir
 
+  - name: returns null on non-existent directory
+    query: select kind from omni_vfs.file_info(omni_vfs.table_fs('fs'), '/test')
+    results:
+    - kind: null
+
 - name: insert data entry for a dir failure
   steps:
   - name: create dir


### PR DESCRIPTION
/claim #796 

Problem takes place because the file_info function was using an inner join with table_fs_file_data.

Since directories don't have entries in this table, the query returned no results (all null values) when attempting to retrieve directory information.

Solution: Changed the query to use left join instead of inner join when joining to table_fs_file_data. This ensures that directories are included in the results even without corresponding data entries on table_fs_file_data, preserving the kind field while allowing data-specific fields to be null where appropriate.

This change makes it possible to call `omni_vfs.file_info(fs, directory)` on any directory, not just root