### PR TITLE
Problem: omni_httpd locking up backend when used in recovery mode (🚀 omni 0.2.8)

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8] - 2025-03-22
+
+### Fixed
+
+* Don't wait for background worker startup in recovery if they are scheduled for after recovery is finished [#837](https://github.com/omnigres/omnigres/pull/837)
+
 ## [0.2.7] - 2025-02-24
 
 ### Fixed
@@ -137,3 +143,5 @@ Initial release following a few months of iterative development.
 [0.2.6]: [https://github.com/omnigres/omnigres/pull/803]
 
 [0.2.7]: [https://github.com/omnigres/omnigres/pull/811]
+
+[0.2.8]: [https://github.com/omnigres/omnigres/pull/837]

--- a/extensions/omni/omni.c
+++ b/extensions/omni/omni.c
@@ -970,8 +970,13 @@ static void do_start_bgworker(XactEvent event, void *arg) {
     RegisterDynamicBackgroundWorker(&payload->bgworker, &bgw_handle);
     payload->handle->registered = true;
     if (!payload->options.dont_wait) {
-      pid_t pid;
-      WaitForBackgroundWorkerStartup(bgw_handle, &pid);
+      if (payload->bgworker.bgw_start_time == BgWorkerStart_RecoveryFinished &&
+          RecoveryInProgress()) {
+        // don't wait, it's not going to start at this time
+      } else {
+        pid_t pid;
+        WaitForBackgroundWorkerStartup(bgw_handle, &pid);
+      }
     }
     payload->handle->bgw_handle = *bgw_handle;
   }

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
-omni=0.2.7
+omni=0.2.8
 omni_aws=0.1.2
 omni_auth=0.1.3
 omni_containers=0.2.0


### PR DESCRIPTION
Solution: don't wait for background worker startup in recovery _if_ the background worker is registered to be started after recovery is finished.

Added STANDBY env variable for running `psql_` targets in standby (recovery) mode.