### PR TITLE
Problem: omni_sqlite would crash on mixed return types

### DIFF
--- a/extensions/omni_sqlite/CHANGELOG.md
+++ b/extensions/omni_sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * Cppgres dependency has been updated to avoid potential bugs [#849](https://github.com/omnigres/omnigres/pull/849)
+* Mixed-type query results should produce an error, not an undefined
+  behavior [#850](https://github.com/omnigres/omnigres/pull/850)
 
 ## [0.1.2] - 2025-04-08
 

--- a/extensions/omni_sqlite/omni_sqlite.cpp
+++ b/extensions/omni_sqlite/omni_sqlite.cpp
@@ -160,15 +160,36 @@ postgres_function(
 #include "__generator.hpp"
 #endif
 
-std::generator<cppgres::record> query_results(int sqlite_rc, int column_count, sqlite3_stmt *stmt,
-                                              cppgres::tuple_descriptor td) {
+std::generator<cppgres::record> query_results(int sqlite_rc, std::vector<int> types,
+                                              sqlite3_stmt *stmt, cppgres::tuple_descriptor td) {
   if (sqlite_rc == SQLITE_ROW) {
     do {
       CHECK_FOR_INTERRUPTS();
       std::vector<cppgres::nullable_datum> datums;
-      for (int i = 0; i < column_count; i++) {
+      for (int i = 0; i < types.size(); i++) {
         auto value = sqlite3_column_value(stmt, i);
         auto value_type = sqlite3_value_type(value);
+        if (value_type != SQLITE_NULL && value_type != types[i]) {
+          auto type_printer = [](int type) {
+            switch (type) {
+            case SQLITE_INTEGER:
+              return "integer";
+            case SQLITE_FLOAT:
+              return "float";
+            case SQLITE_BLOB:
+              return "blob";
+            case SQLITE_TEXT:
+              return "text";
+            case SQLITE_NULL:
+              return "null";
+            default:
+              return "unknown";
+            }
+          };
+          throw std::runtime_error(
+              cppgres::fmt::format("column {} type mismatch, expected {}, got {}", i,
+                                   type_printer(types[i]), type_printer(value_type)));
+        }
         switch (value_type) {
         case SQLITE_INTEGER:
           datums.emplace_back(
@@ -219,10 +240,13 @@ postgres_function(sqlite_query, ([](cppgres::expanded_varlena<sqlite> db, std::s
                     cppgres::tuple_descriptor td(column_count);
 
                     int rc = sqlite3_step(stmt);
+                    std::vector<int> column_types;
+
                     if (rc == SQLITE_ROW || rc == SQLITE_DONE) {
 
                       for (int i = 0; i < column_count; i++) {
                         auto column_type = sqlite3_column_type(stmt, i);
+                        column_types.push_back(column_type);
                         auto column_name = sqlite3_column_name(stmt, i);
                         td.set_name(i, cppgres::name(column_name));
                         switch (column_type) {
@@ -245,7 +269,7 @@ postgres_function(sqlite_query, ([](cppgres::expanded_varlena<sqlite> db, std::s
                       }
                     }
 
-                    return query_results(rc, column_count, stmt, std::move(td));
+                    return query_results(rc, std::move(column_types), stmt, std::move(td));
                   }));
 
 postgres_function(sqlite_serialize, ([](cppgres::expanded_varlena<sqlite> db) {

--- a/extensions/omni_sqlite/tests/test.yaml
+++ b/extensions/omni_sqlite/tests/test.yaml
@@ -57,3 +57,26 @@ tests:
                                         row (1, 'hi!'));
   results:
   - sqlite_exec: "PRAGMA foreign_keys=OFF;\nBEGIN TRANSACTION;\nCREATE TABLE a (i int, t text);\nINSERT INTO a(rowid,i,t) VALUES(1,1,'hi!');\nCOMMIT;\n"
+
+- name: returning mixed types
+  query: |
+    select *
+    from omni_sqlite.sqlite_query($$create table a(i banana); insert into a values('a'),(1)$$::omni_sqlite.sqlite,
+                                  'select * from a'::text) t(b text)
+  error: "exception: column 0 type mismatch, expected text, got integer"
+
+- name: returning mixed types but with trailing nulls
+  query: |
+    select *
+    from omni_sqlite.sqlite_query($$create table a(i banana); insert into a values('a'),(null)$$::omni_sqlite.sqlite,
+                                  'select * from a'::text) t(b text)
+  results:
+  - b: a
+  - b: null
+
+- name: returning mixed types but with leading nulls
+  query: |
+    select *
+    from omni_sqlite.sqlite_query($$create table a(i banana); insert into a values(null),('a')$$::omni_sqlite.sqlite,
+                                  'select * from a'::text) t(b text)
+  error: "exception: expected and returned records do not match"


### PR DESCRIPTION
If a column starts with type TEXT but then becomes INTEGER, that's
undefined behavior – could return something that looks like a string (by
pure chance), or could crash the backend.
    
Solution: track and error out on type mismatch