### PR TITLE
Problem: using `set role` in omni_httpd handlers

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.3] - TBD
 
+### Fixed
+
+* Restore role upon handler termination [#852](https://github.com/omnigres/omnigres/pull/852)
+
 ## [0.4.2] - 2025-03-07
 
 ### Fixed

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -1118,6 +1118,10 @@ static int handler(handler_message_t *msg) {
   // Execute handler
   CurrentMemoryContext = HandlerContext;
 
+  Oid user_id;
+  int security_ctx;
+  GetUserIdAndSecContext(&user_id, &security_ctx);
+
   switch (msg->type) {
   case handler_message_http: {
     h2o_req_t *req = msg->payload.http.msg.req;
@@ -1634,6 +1638,9 @@ cleanup:
   }
 
   MemoryContextReset(HandlerContext);
+
+  SetUserIdAndSecContext(user_id, security_ctx);
+
 release:
 
   return 0;

--- a/extensions/omni_httpd/tests/role_change.yml
+++ b/extensions/omni_httpd/tests/role_change.yml
@@ -1,0 +1,108 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 64
+  init:
+  - set session omni_httpd.no_init = true
+  - create role another
+  - grant yregress to another
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - call omni_httpd.wait_for_configuration_reloads(1)
+  - insert into omni_httpd.listeners (address, port)
+    values ('127.0.0.1', 0)
+  - call omni_httpd.wait_for_configuration_reloads(1)
+  - |
+    create or replace procedure set_handler(outcome out omni_httpd.http_outcome)
+        language plpgsql as
+    $$
+    begin
+        set role another;
+        outcome := omni_httpd.http_response(current_user::text);
+    end;
+    $$
+  - |
+    create or replace procedure set_handler_err(outcome out omni_httpd.http_outcome)
+        language plpgsql as
+    $$
+    begin
+        set role another;
+        raise exception 'fail';
+    end;
+    $$
+  - |
+    create or replace procedure root_handler(outcome out omni_httpd.http_outcome)
+        language plpgsql as
+    $$
+    begin
+        outcome := omni_httpd.http_response(current_user::text);
+    end;
+    $$
+  - |
+    create table my_router
+    (
+        like omni_httpd.urlpattern_router
+    )
+  - |
+    insert into my_router (match, handler)
+    values (omni_httpd.urlpattern('/set-role'), 'set_handler'::regproc),
+           (omni_httpd.urlpattern('/set-role-err'), 'set_handler_err'::regproc),
+           (omni_httpd.urlpattern('/'), 'root_handler'::regproc)
+
+
+tests:
+
+- name: can set role
+  query: |
+    with response as (select *
+                      from omni_httpc.http_execute(
+                              omni_httpc.http_request('http://127.0.0.1:' ||
+                                                      (select effective_port from omni_httpd.listeners where port = 0) ||
+                                                      '/set-role')))
+    select response.status,
+           convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    body: another
+
+- name: but then role resets
+  query: |
+    with response as (select *
+                      from omni_httpc.http_execute(
+                              omni_httpc.http_request('http://127.0.0.1:' ||
+                                                      (select effective_port from omni_httpd.listeners where port = 0) ||
+                                                      '/')))
+    select response.status,
+           convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    body: yregress
+
+- name: set role but then error
+  query: |
+    with response as (select *
+                      from omni_httpc.http_execute(
+                              omni_httpc.http_request('http://127.0.0.1:' ||
+                                                      (select effective_port from omni_httpd.listeners where port = 0) ||
+                                                      '/set-role-err')))
+    select response.status
+    from response
+  results:
+  - status: 500
+
+- name: but then role resets (again)
+  query: |
+    with response as (select *
+                      from omni_httpc.http_execute(
+                              omni_httpc.http_request('http://127.0.0.1:' ||
+                                                      (select effective_port from omni_httpd.listeners where port = 0) ||
+                                                      '/')))
+    select response.status,
+           convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    body: yregress


### PR DESCRIPTION
This is sometimes necessary because currently Postgres does not allow roles to be changed using `security definer` in procedures (as opposed to functions)

Soluton: ensure we reset the security context
to what it was before the change