### PR TITLE
Problem: httpd handler argument `omni_httpd.http_response` with no `out`

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * Restore role upon handler termination [#852](https://github.com/omnigres/omnigres/pull/852)
+* Don't crash when expected handler attribtues have no argmode [#853](https://github.com/omnigres/omnigres/pull/853)
 
 ## [0.4.2] - 2025-03-07
 

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -1008,7 +1008,7 @@ static bool prepare_routers() {
               routes[NumRoutes].tuple_index = argpos;
             } else if (allargtypes[arg] == http_request_oid()) {
               routes[NumRoutes].http_request_index = argpos;
-            } else if (allargtypes[arg] == http_outcome_oid()) {
+            } else if (allargtypes[arg] == http_outcome_oid() && allargmodes) {
               if (allargmodes[arg] == 'b') {
                 routes[NumRoutes].http_outcome_index = argpos;
                 routes[NumRoutes].handler = false;

--- a/extensions/omni_httpd/tests/router.yml
+++ b/extensions/omni_httpd/tests/router.yml
@@ -49,9 +49,18 @@ instance:
     select omni_httpd.http_response(format('%s', test is null))
     $$
   - |
+    create procedure invalid_resp_arg_handler(outcome omni_httpd.http_outcome)
+        language plpgsql
+    as
+    $$
+    begin
+    end;
+    $$;
+  - |
     insert into my_router (match, handler) values
       (omni_httpd.urlpattern('/'), 'root_handler'::regproc),
       (omni_httpd.urlpattern('/no_req'), 'no_req_handler'::regproc),
+      (omni_httpd.urlpattern('/invalid_resp_arg'), 'invalid_resp_arg_handler'::regproc),
       (omni_httpd.urlpattern('/no_outcome'), 'no_outcome_handler'::regproc),
       (omni_httpd.urlpattern('/function'), 'function_handler'::regproc),
       (omni_httpd.urlpattern('/tuple'), 'tuple_handler'::regproc),


### PR DESCRIPTION
When presented with no argument mode, it'll simply crash. Not good.

Solution: check if there's any argmode at all