### PR TITLE
Problem: can't use `security definer` procedures in omni_httpd

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.3] - TBD
 
+### Added
+
+* Configuring handler roles without the use of `security definer` [#855](https://github.com/omnigres/omnigres/pull/855)
+
 ### Fixed
 
 * Restore role upon handler termination [#852](https://github.com/omnigres/omnigres/pull/852)

--- a/extensions/omni_httpd/docs/security.md
+++ b/extensions/omni_httpd/docs/security.md
@@ -11,7 +11,30 @@
     We are eager to add support for such hardening (perhaps as an opt-in if it 
     significantly decreases performance). Please consider
     [contributing](https://github.com/omnigres/omnigres/pulls).
-    
-`omni_httpd` relies on Postgres security primitives. In order to enforce a role on
-a handler, it must be made `security definer` and has to be owned by the role it is
-intended to be running under.
+
+In order to enforce a role on a handler, use `omni_httpd.handler` table to specify a mapping of a handler
+to a specific role.
+
+!!! warning "Sandboxing procedural handlers with roles"
+
+    **Please note** that currently there's an outstanding issue of procedures (as opposed to functions)
+    still allowing for accidental or deliberate role changes within. One of the main reasons to use
+    procedures is their capability to be non-atomic. However, due to current Postgres' design,
+    this prevents us from using security contexts in procedures.
+
+    So, code like this will change the role to `another_role`, regardless of pre-configured role,
+    breaking out of the sandbox of the specified role.
+
+    ```postgresql
+     create or replace procedure my_handler(outcome out omni_httpd.http_outcome)
+        language plpgsql as
+    $$
+    begin
+        --- ....
+        set role another_role;
+        --- ...
+    end;
+    $$ 
+    ```
+
+    Functions are **not** subject to this limitation.

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -376,9 +376,10 @@ void http_worker(Datum db_oid) {
     SPI_connect();
 
     // Find tables of a certain type
-    router_query = SPI_prepare("select router_relation, match_col_idx, handler_col_idx, "
-                               "priority_col_idx from omni_httpd.available_routers",
-                               0, (Oid[0]){});
+    router_query =
+        SPI_prepare("select router_relation, match_col_idx, handler_col_idx, "
+                    "priority_col_idx, handler_col_name from omni_httpd.available_routers",
+                    0, (Oid[0]){});
     if (router_query == NULL) {
       ereport(ERROR, errmsg("can't prepare query"));
     }
@@ -794,6 +795,7 @@ struct Router {
   Oid oid;
   int match_index;
   int handler_index;
+  Name handler_column_name;
   int priority_index;
 };
 
@@ -823,6 +825,7 @@ struct Route {
   bool returns_outcome;
   Datum tuple;
   Form_pg_proc proc;
+  Oid role;
 };
 
 static struct Route *routes = NULL;
@@ -882,10 +885,20 @@ static bool prepare_routers() {
     bool priority_index_is_null = false;
     Datum priority_index = SPI_getbinval(data, SPI_tuptable->tupdesc, 4, &priority_index_is_null);
 
+    bool handler_col_name_is_null = false;
+    Datum handler_col_name =
+        SPI_getbinval(data, SPI_tuptable->tupdesc, 5, &handler_col_name_is_null);
+    if (!handler_col_name_is_null) {
+      MemoryContext old = MemoryContextSwitchTo(RouterMemoryContext);
+      handler_col_name = datumTransfer(handler_col_name, false, NAMEDATALEN);
+      MemoryContextSwitchTo(old);
+    }
+
     routers[NumRouters].oid = DatumGetObjectId(taboid);
     routers[NumRouters].match_index = DatumGetInt32(match_index);
     routers[NumRouters].handler_index = DatumGetInt32(handler_index);
     routers[NumRouters].priority_index = priority_index_is_null ? 0 : DatumGetInt32(priority_index);
+    routers[NumRouters].handler_column_name = DatumGetName(handler_col_name);
 
     // Figure out the underlying table's type OID
     Oid tabtypoid = InvalidOid;
@@ -900,10 +913,12 @@ static bool prepare_routers() {
     bool found;
     RouterQueryHashEntry *entry = routerqueryhash_insert(routerqueryhash, taboid, &found);
     if (!found) {
-      char *query =
-          psprintf("select t, t.* from %s.%s t",
-                   quote_identifier(get_namespace_name(get_rel_namespace(routers[NumRouters].oid))),
-                   quote_identifier(get_rel_name(routers[NumRouters].oid)));
+      char *query = psprintf(
+          "select t, handler_role.role, t.* from %s.%s t left join omni_httpd.handler_role on "
+          "handler_role.handler = t.%s",
+          quote_identifier(get_namespace_name(get_rel_namespace(routers[NumRouters].oid))),
+          quote_identifier(get_rel_name(routers[NumRouters].oid)),
+          quote_identifier(NameStr(*routers[NumRouters].handler_column_name)));
 
       entry->plan = SPI_prepare(query, 0, NULL);
       SPI_keepplan(entry->plan);
@@ -911,20 +926,20 @@ static bool prepare_routers() {
 
     if (SPI_OK_SELECT == SPI_execute_plan(entry->plan, NULL, NULL, true, 0)) {
 
-      if (SPI_gettypeid(SPI_tuptable->tupdesc, routers[NumRouters].match_index + 1) !=
+      if (SPI_gettypeid(SPI_tuptable->tupdesc, routers[NumRouters].match_index + 2) !=
           urlpattern_oid()) {
         SPI_finish();
         continue;
       }
 
-      if (SPI_gettypeid(SPI_tuptable->tupdesc, routers[NumRouters].handler_index + 1) !=
+      if (SPI_gettypeid(SPI_tuptable->tupdesc, routers[NumRouters].handler_index + 2) !=
           REGPROCEDUREOID) {
         SPI_finish();
         continue;
       }
 
       if (routers[NumRouters].priority_index > 0 &&
-          SPI_gettypeid(SPI_tuptable->tupdesc, routers[NumRouters].priority_index + 1) !=
+          SPI_gettypeid(SPI_tuptable->tupdesc, routers[NumRouters].priority_index + 2) !=
               route_priority_oid()) {
         SPI_finish();
         continue;
@@ -940,13 +955,16 @@ static bool prepare_routers() {
       for (int j = 0; j < SPI_tuptable->numvals; j++) {
         bool match_is_null;
         Datum match_data = SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc,
-                                         routers[NumRouters].match_index + 1, &match_is_null);
+                                         routers[NumRouters].match_index + 2, &match_is_null);
         bool handler_is_null;
         Datum handler_data = SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc,
-                                           routers[NumRouters].handler_index + 1, &handler_is_null);
+                                           routers[NumRouters].handler_index + 2, &handler_is_null);
         if (match_is_null || handler_is_null) {
           continue;
         }
+
+        bool role_is_null;
+        Datum role = SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 2, &role_is_null);
 
         Oid handler = DatumGetObjectId(handler_data);
 
@@ -964,12 +982,17 @@ static bool prepare_routers() {
                                                      HeapTupleHeaderGetTypMod(match_tup));
 
         routes[NumRoutes].router = &routers[NumRouters];
+        if (!role_is_null) {
+          routes[NumRoutes].role = DatumGetObjectId(role);
+        } else {
+          routes[NumRoutes].role = InvalidOid;
+        }
 
         if (!priority_index_is_null) {
           bool priority_is_null;
           Datum priority_data =
               SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc,
-                            routers[NumRouters].priority_index + 1, &priority_is_null);
+                            routers[NumRouters].priority_index + 2, &priority_is_null);
 
           routes[NumRoutes].priority = priority_is_null ? 0 : DatumGetInt32(priority_data);
         } else {
@@ -1331,6 +1354,19 @@ static int handler(handler_message_t *msg) {
           }
           if (routes[i].proc->prokind == PROKIND_PROCEDURE) {
             fcinfo->context = (fmNodePtr)non_atomic_call_context;
+          }
+          if (OidIsValid(routes[i].role)) {
+            // FIXME: we want to do `security_ctx | SECURITY_LOCAL_USERID_CHANGE` here
+            // but because `StartTransaction` requires security context to not be set
+            // we wouldn't be able to do this for multi-transactional procedures.
+            // Even though we can attempt to clear it upon transaction commit, there's
+            // no hook we can use to re-establish it after `StartTransaction`.
+            // So, for the time being, this means that accidentally or deliberately
+            // introduced role change will work just fine in procedures (but not in functions)
+            SetUserIdAndSecContext(routes[i].role,
+                                   routes[i].proc->prokind == PROKIND_PROCEDURE
+                                       ? 0
+                                       : security_ctx | SECURITY_LOCAL_USERID_CHANGE);
           }
           Datum result = FunctionCallInvoke(fcinfo);
           isnull = fcinfo->isnull;

--- a/extensions/omni_httpd/migrate/13_handler_role.sql
+++ b/extensions/omni_httpd/migrate/13_handler_role.sql
@@ -1,0 +1,28 @@
+alter event trigger refresh_available_routers disable;
+drop materialized view available_routers cascade;
+
+create materialized view available_routers as
+select c.oid::regclass                                                                as router_relation,
+       min(case when a.atttypid = 'omni_httpd.urlpattern'::regtype then a.attnum end) as match_col_idx,
+       min(case when a.atttypid = 'regprocedure'::regtype then a.attnum end)          as handler_col_idx,
+       min(case when a.atttypid = 'route_priority'::regtype then a.attnum end)        as priority_col_idx,
+       min(case when a.atttypid = 'regprocedure'::regtype then a.attname end)::name   as handler_col_name
+from pg_class c
+         join pg_attribute a
+              on a.attrelid = c.oid
+where a.attnum > 0       -- Skip system columns
+  and not a.attisdropped -- Skip dropped columns
+group by c.oid
+having count(*) filter (where a.atttypid = 'omni_httpd.urlpattern'::regtype) = 1
+   and count(*) filter (where a.atttypid = 'regprocedure'::regtype) = 1
+   and count(*) filter (where a.atttypid = 'route_priority'::regtype) = any (array [0, 1]);
+
+refresh materialized view available_routers;
+
+alter event trigger refresh_available_routers enable;
+
+create table handler_role
+(
+    handler regprocedure not null primary key,
+    role    regrole      not null
+);

--- a/extensions/omni_httpd/tests/role_change.yml
+++ b/extensions/omni_httpd/tests/role_change.yml
@@ -19,9 +19,44 @@ instance:
     $$
     begin
         set role another;
+        commit;
         outcome := omni_httpd.http_response(current_user::text);
     end;
     $$
+  - |
+    create or replace procedure set_handler_proc(outcome out omni_httpd.http_outcome)
+        language plpgsql as
+    $$
+    begin
+        set role yregress;
+        outcome := omni_httpd.http_response(current_user::text);
+    end;
+    $$
+  - insert into omni_httpd.handler_role
+    values ('set_handler_proc()', 'another')
+  - |
+    create or replace function set_handler_function()
+        returns omni_httpd.http_outcome
+        language plpgsql as
+    $$
+    begin
+        set role yregress;
+        return omni_httpd.http_response(current_user::text);
+    end;
+    $$
+  - insert into omni_httpd.handler_role
+    values ('set_handler_function()', 'another')
+  - |
+    create or replace procedure handler_with_role(outcome out omni_httpd.http_outcome)
+        language plpgsql as
+    $$
+    begin
+        commit;
+        outcome := omni_httpd.http_response(current_user::text);
+    end;
+    $$
+  - insert into omni_httpd.handler_role
+    values ('handler_with_role()', 'another')
   - |
     create or replace procedure set_handler_err(outcome out omni_httpd.http_outcome)
         language plpgsql as
@@ -47,7 +82,10 @@ instance:
   - |
     insert into my_router (match, handler)
     values (omni_httpd.urlpattern('/set-role'), 'set_handler'::regproc),
+           (omni_httpd.urlpattern('/set-role-proc'), 'set_handler_proc'::regproc),
+           (omni_httpd.urlpattern('/set-rolefunction'), 'set_handler_function'::regproc),
            (omni_httpd.urlpattern('/set-role-err'), 'set_handler_err'::regproc),
+           (omni_httpd.urlpattern('/handler-with-role'), 'handler_with_role'::regproc),
            (omni_httpd.urlpattern('/'), 'root_handler'::regproc)
 
 
@@ -104,5 +142,76 @@ tests:
            convert_from(response.body, 'utf-8') as body
     from response
   results:
+  - status: 200
+    body: yregress
+
+- name: can set role using `omni_httpd.handler_role`
+  query: |
+    with response as (select *
+                      from omni_httpc.http_execute(
+                              omni_httpc.http_request('http://127.0.0.1:' ||
+                                                      (select effective_port from omni_httpd.listeners where port = 0) ||
+                                                      '/handler-with-role')))
+    select response.status,
+           convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    body: another
+
+- name: but then role resets (again)
+  query: |
+    with response as (select *
+                      from omni_httpc.http_execute(
+                              omni_httpc.http_request('http://127.0.0.1:' ||
+                                                      (select effective_port from omni_httpd.listeners where port = 0) ||
+                                                      '/')))
+    select response.status,
+           convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    body: yregress
+
+- name: functions can't change the role
+  query: |
+    with response as (select *
+                      from omni_httpc.http_execute(
+                              omni_httpc.http_request('http://127.0.0.1:' ||
+                                                      (select effective_port from omni_httpd.listeners where port = 0) ||
+                                                      '/set-role-function')))
+    select response.status
+    from response
+  results:
+  - status: 500
+
+- name: and then role resets (again)
+  query: |
+    with response as (select *
+                      from omni_httpc.http_execute(
+                              omni_httpc.http_request('http://127.0.0.1:' ||
+                                                      (select effective_port from omni_httpd.listeners where port = 0) ||
+                                                      '/')))
+    select response.status,
+           convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    body: yregress
+
+- name: procedures SHOULDN'T but can change the role
+  # FIXME: (until we find a solution)
+  query: |
+    with response as (select *
+                      from omni_httpc.http_execute(
+                              omni_httpc.http_request('http://127.0.0.1:' ||
+                                                      (select effective_port from omni_httpd.listeners where port = 0) ||
+                                                      '/set-role-proc')))
+    select response.status,
+           convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  ## But we really DON'T WANT this – we just document this as current behavior
+  ## We _WANT_ this to fail
   - status: 200
     body: yregress


### PR DESCRIPTION
Problems start appearing when we try to use multi-transactional capabilities (the very reason we support procedures) as the case of security-definer procedures is not currently supported in Postgres.

Solution: introduce `handler_role` relation

This relation is external annotation of desires roles, as opposed to security definer.

We could have set this from security-definer procedure's owner information, but then `fmgr_security_definer` would kick in and modify the security context, which `StartTransaction` does not expect and will fail. So we're forced to externalize this.