### PR TITLE
Problem: docker builds are failing on CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,7 +63,6 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: 'v0.10.4'
           driver-opts: network=host
 
       # Login against a Docker registry except on PR


### PR DESCRIPTION
Cache export fails:

```
ERROR: failed to solve: error writing layer blob: error committing cache 396840: Failed to commit cache.
```

Solution: avoid pinning buildx

Thanks to the @WarpBuilds team!