### PR TITLE
Problem: having to run all the tests at all times

### DIFF
--- a/extensions/omni_test/CHANGELOG.md
+++ b/extensions/omni_test/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.0] - TBD
 
+### Added
+
+* Test filtering feature [#861](https://github.com/omnigres/omnigres/pull/861)
+
 ## [0.3.0] - 2025-03-28
 
 ### Added

--- a/extensions/omni_test/docs/guide.md
+++ b/extensions/omni_test/docs/guide.md
@@ -102,3 +102,17 @@ The results will conform to this structure:
 |    **start_time** | `timestamp` | The start time of the test.           |
 |      **end_time** | `timestamp` | The end time of the test.             |
 | **error_message** | `text`      | An error message, if the test failed. |
+
+### Filtering tests
+
+It's also possible to include only specific tests by using optional `filter` parameter to
+`run_tests`. It's used against function/procedure names and their comments using regular
+expressions.
+
+```postgresql
+select *
+from
+    omni_test.run_tests('myapp_test', filter => '^(?!.*@slow).*')
+```
+
+(The above will filter out tests with a `@slow` marker in their comment)

--- a/extensions/omni_test/src/instantiate.sql
+++ b/extensions/omni_test/src/instantiate.sql
@@ -56,7 +56,8 @@ begin
     $_omni_test_dropdb_helper$;
 
     -- Create test runner
-    create function run_tests(db name, out test_report test_report) returns setof test_report
+    create function run_tests(db name, out test_report test_report,
+                              filter text default null::text) returns setof test_report
         language plpgsql as
     $run_tests$
     declare
@@ -134,6 +135,9 @@ begin
                                (cardinality(proargtypes) = 0 and
                                    prorettype = 'omni_test.test'::regtype)
                            $sql$) t(prokind "char", proname name, nspname name, description text, proconfig text[])
+                where
+                    (filter is null) or
+                    ((proname || ' ' || coalesce(description, '')) ~ filter)
                 order by proname
                 loop
                     -- Clone the database

--- a/extensions/omni_test/tests/test.yaml
+++ b/extensions/omni_test/tests/test.yaml
@@ -104,3 +104,42 @@ tests:
       type: org.omnigres.omni_test.run.end.v1
       data:
         database: db1
+
+- name: run filtered tests
+  steps:
+  - query: select
+               name,
+               description,
+               error_message
+           from
+               omni_test.run_tests('db1', filter => 'Test 1')
+           order by
+               name
+    results:
+    - name: public.test1
+      description: Test 1
+      error_message: null
+
+- name: run filtered out tests
+  steps:
+  - query: select
+               name,
+               description,
+               error_message
+           from
+               omni_test.run_tests('db1', filter => '^(?!.*Error).*')
+           order by
+               name
+    results:
+    - name: public.test1
+      description: Test 1
+      error_message: null
+    - name: public.test2
+      description: Test 2
+      error_message: null
+    - name: public.test_fun
+      description: Test function
+      error_message: null
+    - name: public.tx_iso
+      description: Transaction isolation level setting
+      error_message: null


### PR DESCRIPTION
In shorter iteration cycles, it is desirable to focus only on failing tests, for example.

Solution: allow specifying a filter

In the future, we might want to separate planning and execution, this will allow for really fine-grained control.