### PR TITLE
Problem: omni_httpd middleware handlers run to completion

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.4] – TBD
 
+### Added
+
+* An ability to stop request handling in middleware handlers [#863](https://github.com/omnigres/omnigres/pull/863)
+
 ## [0.4.3] - 2025-04-31
 
 ### Added

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -1305,6 +1305,8 @@ static int handler(handler_message_t *msg) {
         isnull = true;
         int selected_handler = 0;
 
+        worker_should_stop_handling = false;
+
         for (int i = 0; i < NumRoutes; i++) {
           FmgrInfo flinfo;
 
@@ -1381,6 +1383,9 @@ static int handler(handler_message_t *msg) {
             }
           } else {
             isnull = true;
+          }
+          if (worker_should_stop_handling) {
+            break;
           }
           if (routes[i].handler) {
             break;
@@ -1681,3 +1686,5 @@ release:
 
   return 0;
 }
+
+bool worker_should_stop_handling;

--- a/extensions/omni_httpd/http_worker.h
+++ b/extensions/omni_httpd/http_worker.h
@@ -140,4 +140,6 @@ static h2o_evloop_t *handler_event_loop;
 #define HTTP_OUTCOME_ABORT 1
 #define HTTP_OUTCOME_PROXY 2
 
+extern bool worker_should_stop_handling;
+
 #endif // OMNIGRES_HTTP_WORKER_H

--- a/extensions/omni_httpd/migrate/14_handler_operations.sql
+++ b/extensions/omni_httpd/migrate/14_handler_operations.sql
@@ -1,0 +1,1 @@
+/*{% include "../src/stop_handling.sql" %}*/

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -65,6 +65,8 @@
 #include "fd.h"
 #include "omni_httpd.h"
 
+#include "http_worker.h"
+
 PG_MODULE_MAGIC;
 OMNI_MAGIC;
 
@@ -613,4 +615,10 @@ Datum start(PG_FUNCTION_ARGS) {
   start_master_worker(module_handle, master_worker_bgw,
                       immediate ? omni_timing_immediately : omni_timing_after_commit);
   PG_RETURN_VOID();
+}
+
+PG_FUNCTION_INFO_V1(stop_handling);
+Datum stop_handling(PG_FUNCTION_ARGS) {
+  worker_should_stop_handling = true;
+  PG_RETURN_BOOL(true);
 }

--- a/extensions/omni_httpd/src/stop_handling.sql
+++ b/extensions/omni_httpd/src/stop_handling.sql
@@ -1,0 +1,3 @@
+create function stop_handling() returns boolean
+    language 'c' as
+'MODULE_PATHNAME';

--- a/extensions/omni_httpd/tests/router_order.yml
+++ b/extensions/omni_httpd/tests/router_order.yml
@@ -1,0 +1,91 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 64
+  init:
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - call omni_httpd.wait_for_configuration_reloads(2)
+  - |
+    create table my_router (
+        like omni_httpd.urlpattern_router,
+        like omni_httpd.router_priority
+    )
+  - |
+    create procedure root_handler(request omni_httpd.http_request, out outcome omni_httpd.http_outcome) language plpgsql
+    as $$
+    begin
+      outcome := omni_httpd.http_response('ok');
+    end;
+    $$;
+  - |
+    create procedure always_last(request omni_httpd.http_request, out outcome omni_httpd.http_outcome) language plpgsql
+    as $$
+    begin
+      outcome := omni_httpd.http_response('last');
+      perform omni_httpd.stop_handling();
+    end;
+    $$;
+  - |
+    create procedure last_null(request omni_httpd.http_request, inout outcome omni_httpd.http_outcome) language plpgsql
+    as $$
+    begin
+      outcome := null;
+      perform omni_httpd.stop_handling();
+    end;
+    $$;
+  - |
+    create procedure not_last(request omni_httpd.http_request, inout outcome omni_httpd.http_outcome) language plpgsql
+    as $$
+    begin
+      outcome := omni_httpd.http_response('not last');
+    end;
+    $$;
+  - |
+    insert into my_router (match, handler, priority) values
+      (omni_httpd.urlpattern(null), 'root_handler'::regproc, 1),
+      (omni_httpd.urlpattern('/last'), 'always_last'::regproc, 10),
+      (omni_httpd.urlpattern('/not-last'), 'not_last'::regproc, 10)
+
+tests:
+
+- name: root handler
+  query: |
+    with response as (select * from omni_httpc.http_execute(
+      omni_httpc.http_request('http://127.0.0.1:' ||
+      (select effective_port from omni_httpd.listeners) || '/')))
+    select
+    response.status,
+    convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    body: ok
+
+- name: stop handling
+  query: |
+    with response as (select * from omni_httpc.http_execute(
+      omni_httpc.http_request('http://127.0.0.1:' ||
+      (select effective_port from omni_httpd.listeners) || '/last')))
+    select
+    response.status,
+    convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    body: last
+
+- name: do not stop handling by default
+  query: |
+    with response as (select * from omni_httpc.http_execute(
+      omni_httpc.http_request('http://127.0.0.1:' ||
+      (select effective_port from omni_httpd.listeners) || '/not-last')))
+    select
+    response.status,
+    convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    # we fall through to the root handler
+    body: ok


### PR DESCRIPTION
Sometimes, a middleware handler should stop. For example, there's an error; or an access has been denied.

Solution: introduce `stop_handling()` function

This function tells the runner to stop handling the request after the completion of this handler and serve the response as is.