### PR TITLE
Problem: after-handler middleware in omni_httpd

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -11,6 +11,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * An ability to stop request handling in middleware handlers [#863](https://github.com/omnigres/omnigres/pull/863)
 
+### Fixed
+
+* Middleware handlers lower in priority ("after") than handler should also be
+  executed [#864](https://github.com/omnigres/omnigres/pull/864)
+
 ## [0.4.3] - 2025-04-31
 
 ### Added

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -1306,8 +1306,13 @@ static int handler(handler_message_t *msg) {
         int selected_handler = 0;
 
         worker_should_stop_handling = false;
+        bool handler_invoked = false;
 
         for (int i = 0; i < NumRoutes; i++) {
+          // Skip handlers if a handler has been used already
+          if (routes[i].handler && handler_invoked) {
+            continue;
+          }
           FmgrInfo flinfo;
 
           if (OidIsValid(routes[i].method) && routes[i].method != method) {
@@ -1388,7 +1393,7 @@ static int handler(handler_message_t *msg) {
             break;
           }
           if (routes[i].handler) {
-            break;
+            handler_invoked = true;
           }
         }
 

--- a/extensions/omni_httpd/tests/router_order.yml
+++ b/extensions/omni_httpd/tests/router_order.yml
@@ -43,10 +43,21 @@ instance:
     end;
     $$;
   - |
+    create procedure after(request omni_httpd.http_request, inout outcome omni_httpd.http_outcome) language plpgsql
+    as $$
+    declare
+    response omni_httpd.http_response := outcome::omni_httpd.http_response;
+    begin
+      response.body = '(' || response.body || ')';
+      outcome := response;
+    end;
+    $$;
+  - |
     insert into my_router (match, handler, priority) values
       (omni_httpd.urlpattern(null), 'root_handler'::regproc, 1),
       (omni_httpd.urlpattern('/last'), 'always_last'::regproc, 10),
-      (omni_httpd.urlpattern('/not-last'), 'not_last'::regproc, 10)
+      (omni_httpd.urlpattern('/not-last'), 'not_last'::regproc, 10),
+      (omni_httpd.urlpattern('/after'), 'after'::regproc, -1)
 
 tests:
 
@@ -89,3 +100,17 @@ tests:
   - status: 200
     # we fall through to the root handler
     body: ok
+
+- name: after-handler middleware gets executed
+  query: |
+    with response as (select * from omni_httpc.http_execute(
+      omni_httpc.http_request('http://127.0.0.1:' ||
+      (select effective_port from omni_httpd.listeners) || '/after')))
+    select
+    response.status,
+    convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    # we fall through to the root handler
+    body: (ok)


### PR DESCRIPTION
If we need to change the response in any way after the handler was called, we can't really do much. This can be very useful for things like CORS handlers or anything that changes the response.

Solution: only stop processing "handlers" after one is executed but continue with the rest of middleware handlers

(We really should rename them to something more sensible – middleware "after" doesn't make sense logically)