### PR TITLE
Problem: loading extensions in presence of live backends

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -7,6 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.9] - TBD
 
+### Fixed
+
+* Ensure extensions are always loaded in live backends when installed in
+  others [#867](https://github.com/omnigres/omnigres/pull/867)
+
 ## [0.2.8] - 2025-03-22
 
 ### Fixed

--- a/extensions/omni/init.c
+++ b/extensions/omni/init.c
@@ -32,6 +32,10 @@ extern void deinitialize_backend(int code, Datum arg);
 
 MODULE_VARIABLE(int ServerVersionNum);
 
+static void syscache_invalidation(Datum arg, int cacheid, uint32 hashvalue) {
+  backend_force_reload = true;
+}
+
 /**
  * Shared preload initialization.
  */
@@ -166,6 +170,14 @@ void _PG_init() {
                             PG_VERSION_NUM / 10000, PG_VERSION_NUM % 100, ServerVersionNum / 10000,
                             ServerVersionNum % 100));
   }
+
+#if PG_MAJORVERSION_NUM >= 18
+  CacheRegisterSyscacheCallback(EXTENSIONOID, syscache_invalidation, 0);
+#endif
+  // There's a limitation to this. If an extension has no functions,
+  // it will not invalidate PROCOID. However, we also intercept extension utility
+  // statements, where we invalidate PROCOID upon such changes.
+  CacheRegisterSyscacheCallback(PROCOID, syscache_invalidation, 0);
 }
 
 /**

--- a/extensions/omni/test/tests/late_ext.yml
+++ b/extensions/omni/test/tests/late_ext.yml
@@ -1,0 +1,50 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+  init:
+  - create extension omni
+  - create extension dblink
+
+tests:
+
+- name: ensure module is not automatically registered
+  query: select
+             count(*)
+         from
+             omni.modules
+         where
+             path like '%/omni__test--1.so'
+  results:
+  - count: 0
+
+- name: create a separate backend
+  query: select
+             dblink_connect('another_session',
+                            'hostaddr=127.0.0.1 dbname=yregress user=yregress port=' || current_setting('port'))
+
+- name: create test extension
+  commit: true
+  query: create extension omni__test
+
+- name: _Omni_init() gets called locally
+  query: select omni__test.is_backend_initialized()
+  results:
+  - is_backend_initialized: true
+
+- name: the other backend sees the extension
+  query: select
+             true as result
+         from
+             pg_extension
+         where
+             extname = 'omni__test'
+  results:
+  - result: true
+
+- name: _Omni_init() gets called in the other backend, too
+  query: select *
+         from
+             dblink('another_session', 'select omni__test.is_backend_initialized()') as t(is_backend_initialized bool)
+  results:
+  - is_backend_initialized: true


### PR DESCRIPTION
If there are two backends, A and B and then A installs an extension, it will not always be initialized (`_Omni_init`) in B.

This is a fairly critical bug.

Solution: ensure we track respective invalidations

In Postgres 18, EXTENSIONOID is a syscache. Prior to that, we'll use PROCOID syscache as a proxy with a workaround for extensions that export no functions.