### PR TITLE
Problem: middleware nullifying outcome

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -15,6 +15,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Middleware handlers lower in priority ("after") than handler should also be
   executed [#864](https://github.com/omnigres/omnigres/pull/864)
+* Crash with middlewares nullifying outcome [#868](https://github.com/omnigres/omnigres/pull/868)
 
 ## [0.4.3] - 2025-04-31
 

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -1303,7 +1303,6 @@ static int handler(handler_message_t *msg) {
 
         // If no handler will be selected, go for null answer (no data)
         isnull = true;
-        int selected_handler = 0;
 
         worker_should_stop_handling = false;
         bool handler_invoked = false;
@@ -1322,8 +1321,6 @@ static int handler(handler_message_t *msg) {
           if (!match_urlpattern(&routes[i].match, req->path.base, req->path.len)) {
             continue;
           }
-
-          selected_handler++;
 
           fmgr_info(routes[i].proc->oid, &flinfo);
 
@@ -1351,8 +1348,7 @@ static int handler(handler_message_t *msg) {
             fcinfo->args[http_request_index].isnull = false;
           }
           if (http_outcome_index >= 0) {
-            fcinfo->args[http_outcome_index].isnull =
-                selected_handler == 1; // initial outcome is always null
+            fcinfo->args[http_outcome_index].isnull = isnull;
             fcinfo->args[http_outcome_index].value = outcome;
           }
           if (tuple_index >= 0) {

--- a/extensions/omni_httpd/tests/router_null_outcome.yml
+++ b/extensions/omni_httpd/tests/router_null_outcome.yml
@@ -1,0 +1,48 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 64
+  init:
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  - call omni_httpd.wait_for_configuration_reloads(2)
+  - |
+    create table my_router (
+        like omni_httpd.urlpattern_router,
+        like omni_httpd.router_priority
+    )
+  - |
+    create procedure root_handler(request omni_httpd.http_request, out outcome omni_httpd.http_outcome) language plpgsql
+    as $$
+    begin
+      outcome := omni_httpd.http_response('ok');
+    end;
+    $$;
+  - |
+    create procedure null_middleware(request omni_httpd.http_request, outcome inout omni_httpd.http_outcome) language plpgsql
+    as $$
+    begin
+    outcome := null;
+    end;
+    $$;
+  - |
+    insert into my_router (match, handler, priority) values
+      (omni_httpd.urlpattern('/*?'), 'root_handler'::regproc, 1),
+      (omni_httpd.urlpattern('/*?'), 'null_middleware'::regproc, 10),
+      (omni_httpd.urlpattern('/*?'), 'null_middleware'::regproc, 9)
+
+tests:
+
+- name: null-returning middleware doesn't crash
+  query: |
+    with response as (select * from omni_httpc.http_execute(
+      omni_httpc.http_request('http://127.0.0.1:' ||
+      (select effective_port from omni_httpd.listeners) || '/')))
+    select
+    response.status,
+    convert_from(response.body, 'utf-8') as body
+    from response
+  results:
+  - status: 200
+    body: ok


### PR DESCRIPTION
If non-first middleware nullifies `outcome`, omni_httpd worker crashes.

Solution: ensure we properly tracking nullity of outcome