### PR TITLE
Problem: omni starts working only when recovery is finished

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -11,6 +11,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Ensure extensions are always loaded in live backends when installed in
   others [#867](https://github.com/omnigres/omnigres/pull/867)
+* Enable extensions to operate in recovery mode if necessary [#870](https://github.com/omnigres/omnigres/pull/870)
 
 ## [0.2.8] - 2025-03-22
 

--- a/extensions/omni/init.c
+++ b/extensions/omni/init.c
@@ -146,7 +146,7 @@ void _PG_init() {
                                       .bgw_type = "omni startup",
                                       .bgw_flags = BGWORKER_SHMEM_ACCESS |
                                                    BGWORKER_BACKEND_DATABASE_CONNECTION,
-                                      .bgw_start_time = BgWorkerStart_RecoveryFinished,
+                                      .bgw_start_time = BgWorkerStart_ConsistentState,
                                       .bgw_restart_time = BGW_NEVER_RESTART,
                                       .bgw_function_name = "startup_worker",
                                       .bgw_notify_pid = 0};

--- a/extensions/omni/workers.c
+++ b/extensions/omni/workers.c
@@ -50,7 +50,7 @@ void startup_worker(Datum main_arg) {
     BackgroundWorker worker = {.bgw_flags =
                                    BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION,
                                .bgw_main_arg = ObjectIdGetDatum(db->oid),
-                               .bgw_start_time = BgWorkerStart_RecoveryFinished,
+                               .bgw_start_time = BgWorkerStart_ConsistentState,
                                .bgw_restart_time = BGW_NEVER_RESTART,
                                .bgw_function_name = "database_worker",
                                .bgw_notify_pid = MyProcPid};


### PR DESCRIPTION
However, this wouldn't work for supporting extensions that need to operate in inconsistent state (such as in replicas).

Solution: switch to ConsistentState