### PR TITLE
Problem: omni_worker fails to compile on Nix

### DIFF
--- a/extensions/omni_worker/CHANGELOG.md
+++ b/extensions/omni_worker/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-05-15
+
+### Fixed
+
+* Update oink library to fix potential compilation error [#873](https://github.com/omnigres/omnigres/pull/873)
+
 ## [0.1.0] - 2025-04-24
 
 Initial release
@@ -12,3 +18,5 @@ Initial release
 [Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_sqlite
 
 [0.1.0]: [https://github.com/omnigres/omnigres/pull/856]
+
+[0.1.1]: [https://github.com/omnigres/omnigres/pull/873]

--- a/versions.txt
+++ b/versions.txt
@@ -31,6 +31,6 @@ omni_var=0.3.0
 omni_vfs_types_v1=0.1.0
 omni_vfs=0.2.1
 omni_web=0.3.0
-omni_worker=0.1.0
+omni_worker=0.1.1
 omni_xml=0.1.2
 omni_yaml=0.1.0


### PR DESCRIPTION
```
In file included from /build/source/build/dep-bf2b3f73337260d99ddad54eaaa9c232c19ab69b/boost/interprocess/detail/managed_memory_impl.hpp:30:
/build/source/build/dep-bf2b3f73337260d99ddad54eaaa9c232c19ab69b/boost/interprocess/segment_manager.hpp:1055:41: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 1055 |          hdr = block_header_t::template from_first_header(reinterpret_cast<index_data_t*>((void*)((char*)buffer_ptr + front_space)));
      |                                         ^
In file included from /build/source/extensions/omni_worker/handlers.cpp:2:
/build/source/extensions/omni_worker/deps/oink.hpp:156:12: error: object of type 'arena' cannot be assigned because its copy assignment operator is implicitly deleted
  156 |     arena_ = other.arena_;
      |            ^
/build/source/extensions/omni_worker/deps/oink.hpp:77:30: note: copy assignment operator of 'arena' is implicitly deleted because field 'segment' has a deleted copy assignment operator
   77 |   bip::managed_shared_memory segment;
      |                              ^
/build/source/build/dep-bf2b3f73337260d99ddad54eaaa9c232c19ab69b/boost/interprocess/managed_shared_memory.hpp:102:4: note: 'operator=' has been explicitly marked deleted here
  102 |    BOOST_MOVABLE_BUT_NOT_COPYABLE(basic_managed_shared_memory)
      |    ^
/build/source/build/dep-bf2b3f73337260d99ddad54eaaa9c232c19ab69b/boost/move/core.hpp:303:7: note: expanded from macro 'BOOST_MOVABLE_BUT_NOT_COPYABLE'
  303 |       BOOST_MOVE_IMPL_NO_COPY_CTOR_OR_ASSIGN(TYPE)\
      |       ^
```

Solution: upgrade to a fixed version of oink

(see https://github.com/omnigres/oink/commit/8cb36cbc607a2ca8f3614725bf7c0e7ae1901304)