### PR TITLE
feat(omni_txn): Introduce a timeout parameter to retry

### DIFF
--- a/extensions/omni_txn/migrate/7_add_retry_timeout.sql
+++ b/extensions/omni_txn/migrate/7_add_retry_timeout.sql
@@ -1,0 +1,15 @@
+DROP FUNCTION omni_txn.retry(text, integer, boolean, boolean, record, boolean);
+
+CREATE FUNCTION omni_txn.retry(
+    stmts text,
+    max_attempts integer DEFAULT 10,
+    repeatable_read boolean DEFAULT false,
+    collect_backoff_values boolean DEFAULT false,
+    params record DEFAULT NULL,
+    linearize boolean DEFAULT false,
+    timeout_ms integer DEFAULT 0
+) RETURNS void
+    LANGUAGE C
+AS
+'MODULE_PATHNAME',
+'retry';

--- a/extensions/omni_txn/tests/retry.yml
+++ b/extensions/omni_txn/tests/retry.yml
@@ -33,6 +33,19 @@ instance:
 
 tests:
 
+- name: retry should time out
+  query: |
+    CREATE TABLE timeout_test (i int);
+    -- This will fail because another transaction is started by the test harness
+    -- to verify the outcome, creating a serialization failure.
+    -- The key is that it will keep retrying and should be stopped by the timeout.
+    SELECT omni_txn.retry(
+      $$UPDATE timeout_test SET i = i + 1; SELECT pg_sleep(0.02)$$,
+      max_attempts => 10,
+      timeout_ms => 50
+    );
+  error: 'transaction timed out after 50 ms'
+
 - name: other errors pass through
   transaction: false
   tests:


### PR DESCRIPTION
fixes: #669 

### Implemented Solution:
A `timeout_ms` parameter has been added to the `omni_txn.retry` function. This allows developers to specify a maximum duration for the entire retry process. If the elapsed time exceeds this timeout, the function will stop retrying and raise an error.

This change is backward-compatible. Existing calls to the function will continue to work as before, with the timeout defaulting to disabled.

### Changes:
- `extensions/omni_txn/retry.c`: Modified to include the timeout logic.
- `extensions/omni_txn/migrate/7_add_retry_timeout.sql`: New migration file to update the SQL function signature.
- `extensions/omni_txn/tests/retry.yml`: Added a new test case to verify the timeout functionality.

Happy to iterate to get the best solution possible.
