### PR TITLE
Problem: no testing against Postgres 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     continue-on-error: ${{ matrix.pgver == 'master' }}
     strategy:
       matrix:
-        pgver: [ 17, 16, 15, 14, master ]
+        pgver: [ 18, 17, 16, 15, 14, master ]
         os: [ warp-ubuntu-2404-x64-4x, warp-macos-14-arm64-6x ]
         build_type: [Debug, Release]
         exclude:

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -63,6 +63,7 @@ if(NOT DEFINED PG_CONFIG)
     endif()
 
     # If the version is not known, try resolving the alias
+    set(PGVER_ALIAS_18 18beta2)
     set(PGVER_ALIAS_17 17.5)
     set(PGVER_ALIAS_16 16.9)
     set(PGVER_ALIAS_15 15.13)
@@ -83,13 +84,13 @@ if(NOT DEFINED PG_CONFIG)
         if (NOT _POSTGRESQL_ANNOUNCED_${PGVER_ALIAS})
             message(STATUS "Resolved PostgreSQL version alias ${PGVER} to ${PGVER_ALIAS}")
         endif ()
-    elseif ("${PGVER}" MATCHES "[0-9]+.[0-9]+")
+    elseif ("${PGVER}" MATCHES "[0-9]+(.[0-9]+|beta[0-9]+)")
         set(PGVER_ALIAS "${PGVER}")
     else()
         set(PGVER_ALIAS "${PGVER_ALIAS_${PGVER}}")
 
         # If it still can't be resolved, fail
-        if("${PGVER_ALIAS}" MATCHES "[0-9]+.[0-9]+")
+        if ("${PGVER_ALIAS}" MATCHES "[0-9]+(.[0-9]+|beta[0-9]+)")
             if(NOT _POSTGRESQL_ANNOUNCED_${PGVER_ALIAS})
                 message(STATUS "Resolved PostgreSQL version alias ${PGVER} to ${PGVER_ALIAS}")
             endif()


### PR DESCRIPTION
It hasn't been released yet, but betas are already out.

We have been testing against master, so it should be fine, but master is tracking 19 now.

Solution: allow for beta versions and add to CI