### PR TITLE
Problem: HTTP static file server is not cache-efficient

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.9] - TBD
 
+### Added
+
+* Support for `ETag` in static file handler [#888](https://github.com/omnigres/omnigres/pull/888)
+
 ## [0.4.8] - 2025-06-03
 
 ### Fixed

--- a/extensions/omni_httpd/src/instantiate_static_file_handler.sql
+++ b/extensions/omni_httpd/src/instantiate_static_file_handler.sql
@@ -6,6 +6,11 @@ declare
     old_search_path text := current_setting('search_path');
 begin
     -- check for required extensions
+    perform from pg_extension where extname = 'pgcrypto';
+    if not found then
+        raise exception 'pgcrypto extension is required to be installed';
+    end if;
+
     perform from pg_extension where extname = 'omni_vfs';
     if not found then
         raise exception 'omni_vfs extension is required to be installed';

--- a/extensions/omni_httpd/src/static_file_handler.sql
+++ b/extensions/omni_httpd/src/static_file_handler.sql
@@ -7,29 +7,14 @@ create
     language plpgsql as
 $static_file_handler$
 declare
-    outcome omni_httpd.http_outcome;
+    outcome       omni_httpd.http_outcome;
+    file_content  bytea;
+    etag          text;
+    if_none_match text;
+    mime_type     text;
 begin
     if path is null then
         path := request.path;
-    end if;
-    --- File
-    if request.method = 'GET' and
-       (omni_vfs.file_info(fs, fs_path || path)).kind = 'file' then
-        select
-            omni_httpd.http_response(
-                    omni_vfs.read(fs, fs_path || path),
-                    headers => array [omni_http.http_header('content-type',
-                                                            coalesce(mime_types.name, 'application/octet-stream'))]::omni_http.http_header[])
-        from
-                (select)                                            _
-                    left join omni_mimetypes.file_extensions on path like '%%.' || file_extensions.extension
-                left join omni_mimetypes.mime_types_file_extensions mtfe on mtfe.file_extension_id = file_extensions.id
-                left join omni_mimetypes.mime_types on mtfe.mime_type_id = mime_types.id
-        into outcome;
-    end if;
-
-    if outcome is not null then
-        return outcome;
     end if;
 
     --- Directory
@@ -37,11 +22,49 @@ begin
        ((path = '/') or
         (omni_vfs.file_info(fs, fs_path || path)).kind = 'dir') and
        (omni_vfs.file_info(fs, fs_path || path || '/index.html')).kind = 'file' then
+        path := path || '/index.html';
+    end if;
+
+    --- File
+    if request.method = 'GET' and
+       (omni_vfs.file_info(fs, fs_path || path)).kind = 'file' then
+        file_content := omni_vfs.read(fs, fs_path || path);
+        etag := '"' || encode(digest(file_content, 'sha256'), 'hex') || '"';
+        if_none_match := omni_http.http_header_get(request.headers, 'if-none-match');
+
         select
-            omni_httpd.http_response(
-                    omni_vfs.read(fs, fs_path || path || '/index.html'),
-                    headers => array [omni_http.http_header('content-type', 'text/html')]::omni_http.http_header[])
-        into outcome;
+            coalesce(mime_types.name, 'application/octet-stream')
+        into mime_type
+        from
+                (select)                                            _
+                left join omni_mimetypes.file_extensions on path like '%%.' || file_extensions.extension
+                left join omni_mimetypes.mime_types_file_extensions mtfe
+                          on mtfe.file_extension_id = file_extensions.id
+                left join omni_mimetypes.mime_types on mtfe.mime_type_id = mime_types.id;
+
+        if if_none_match = etag then
+            -- Return 304 Not Modified
+            select
+                omni_httpd.http_response(
+                        status => 304,
+                        headers => array [
+                            omni_http.http_header('content-type', mime_type),
+                            omni_http.http_header('etag', etag),
+                            omni_http.http_header('cache-control', 'public, max-age=3600')
+                            ]
+                )
+            into outcome;
+        else
+            select
+                omni_httpd.http_response(
+                        file_content,
+                        headers => array [omni_http.http_header('content-type',
+                                                                mime_type),
+                            omni_http.http_header('etag', etag),
+                            omni_http.http_header('cache-control', 'public, max-age=3600')
+                            ])
+            into outcome;
+        end if;
     end if;
 
     if outcome is not null then
@@ -56,7 +79,8 @@ begin
        (omni_vfs.file_info(fs, fs_path || path || '/index.html')) is not distinct from null then
         select
             omni_httpd.http_response(
-                    (select string_agg('<a href="' || case when path = '/' then '/' else path || '/' end ||
+                    (select
+                         string_agg('<a href="' || case when path = '/' then '/' else path || '/' end ||
                                     name ||
                                     '">' || name || '</a>', '<br>')
                      from

--- a/extensions/omni_httpd/tests/static_file.yml
+++ b/extensions/omni_httpd/tests/static_file.yml
@@ -10,6 +10,7 @@ instance:
   - create extension omni_httpc cascade
   - create extension omni_vfs cascade
   - create extension omni_mimetypes
+  - create extension pgcrypto
   - select omni_httpd.instantiate_static_file_handler(schema => current_schema)
   - |
     create table static_file_router
@@ -37,16 +38,51 @@ tests:
            omni_httpc.http_request('http://127.0.0.1:' ||
                                    (select effective_port from omni_httpd.listeners) || '/test.json')))
     select
-      (select json_agg(json_build_object(h.name, h.value)) from unnest(response.headers) h where h.name = 'content-type') as headers,
+        (select
+             json_agg(json_build_object(h.name, h.value))
+         from
+             unnest(response.headers) h
+         where
+             h.name in ('content-type', 'etag'))   as headers,
       response.status,
-      convert_from(response.body, 'utf-8')::json as body
+        convert_from(response.body, 'utf-8')::json as body
       from response
   results:
   - status: 200
     headers:
       - content-type: application/json
+      - etag: "\"e051f32f7b2fdbabf1ac3ddf461d3554a283fe46febefd00c1f97b2ab2a85120\""
     body:
       test: passed
+
+- name: handle unmodified file
+  query: |
+    with
+        response as (select *
+                     from
+                         omni_httpc.http_execute(
+                                 omni_httpc.http_request('http://127.0.0.1:' ||
+                                                         (select effective_port from omni_httpd.listeners) ||
+                                                         '/test.json',
+                                                         headers => array [omni_http.http_header('if-none-match',
+                                                                                                 '"e051f32f7b2fdbabf1ac3ddf461d3554a283fe46febefd00c1f97b2ab2a85120"')])))
+    select
+        (select
+             json_agg(json_build_object(h.name, h.value))
+         from
+             unnest(response.headers) h
+         where
+             h.name in ('content-type', 'etag')) as headers,
+        response.status,
+        convert_from(response.body, 'utf-8')     as body
+    from
+        response
+  results:
+  - status: 304
+    headers:
+    - content-type: application/json
+    - etag: "\"e051f32f7b2fdbabf1ac3ddf461d3554a283fe46febefd00c1f97b2ab2a85120\""
+    body: ""
 
 - name: handle file path overriding
   query: |
@@ -85,7 +121,12 @@ tests:
            omni_httpc.http_request('http://127.0.0.1:' ||
                                    (select effective_port from omni_httpd.listeners) || '/')))
     select
-      (select json_agg(json_build_object(h.name, h.value)) from unnest(response.headers) h where h.name = 'content-type') as headers,
+        (select
+             json_agg(json_build_object(h.name, h.value))
+         from
+             unnest(response.headers) h
+         where
+             h.name in ('content-type', 'etag')) as headers,
       response.status,
       convert_from(response.body, 'utf-8') as body
       from response
@@ -93,6 +134,7 @@ tests:
   - status: 200
     headers:
     - content-type: text/html
+    - etag: "\"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08\""
     body: test
 
 - name: handle directory


### PR DESCRIPTION
Regardless of whether the client already has the file, the server will always resend it.

Solution: implement basic support for `ETag