### PR TITLE
Problem: limited HTTP routing capabilities

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -10,6 +10,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 * Support for `ETag` in static file handler [#888](https://github.com/omnigres/omnigres/pull/888)
+* Capability to route based on additional components such as hostname and
+  port [#890](https://github.com/omnigres/omnigres/pull/890)
 
 ## [0.4.8] - 2025-06-03
 

--- a/extensions/omni_httpd/http_worker.c
+++ b/extensions/omni_httpd/http_worker.c
@@ -1313,8 +1313,17 @@ static int handler(handler_message_t *msg) {
             continue;
           }
 
-          if (!match_urlpattern(&routes[i].match, req->path.base, req->path.len)) {
-            continue;
+          {
+            // Do the match against the URL
+            char *url =
+                psprintf("%.*s://%.*s%.*s", req->scheme->name.len, req->scheme->name.base,
+                         req->authority.len, req->authority.base, req->path.len, req->path.base);
+
+            if (!match_urlpattern(&routes[i].match, url, strlen(url))) {
+              pfree(url);
+              continue;
+            }
+            pfree(url);
           }
 
           fmgr_info(routes[i].proc->oid, &flinfo);

--- a/extensions/omni_httpd/tests/router.yml
+++ b/extensions/omni_httpd/tests/router.yml
@@ -7,6 +7,12 @@ instance:
   - create extension omni_httpd cascade
   - create extension omni_httpc cascade
   - call omni_httpd.wait_for_configuration_reloads(2)
+  - insert
+    into
+        omni_httpd.listeners (port)
+    values
+        (8081);
+  - call omni_httpd.wait_for_configuration_reloads(1)
   - |
      create table my_router (
          like omni_httpd.urlpattern_router
@@ -16,6 +22,24 @@ instance:
     as $$
     begin
       outcome := omni_httpd.http_response('ok');
+    end;
+    $$;
+  - |
+    create procedure another_port_handler(request omni_httpd.http_request, out outcome omni_httpd.http_outcome)
+        language plpgsql
+    as
+    $$
+    begin
+        outcome := omni_httpd.http_response('another port');
+    end;
+    $$;
+  - |
+    create procedure another_host_handler(request omni_httpd.http_request, out outcome omni_httpd.http_outcome)
+        language plpgsql
+    as
+    $$
+    begin
+        outcome := omni_httpd.http_response('another host');
     end;
     $$;
   - |
@@ -59,6 +83,10 @@ instance:
   - |
     insert into my_router (match, handler) values
       (omni_httpd.urlpattern('/'), 'root_handler'::regproc),
+      (omni_httpd.urlpattern('/another_port',
+                             port => (select effective_port from omni_httpd.listeners where port = 8081)),
+       'another_port_handler'::regproc),
+      (omni_httpd.urlpattern('/another_host', hostname => 'localhost'), 'another_host_handler'::regproc),
       (omni_httpd.urlpattern('/no_req'), 'no_req_handler'::regproc),
       (omni_httpd.urlpattern('/invalid_resp_arg'), 'invalid_resp_arg_handler'::regproc),
       (omni_httpd.urlpattern('/no_outcome'), 'no_outcome_handler'::regproc),
@@ -71,7 +99,7 @@ tests:
   query: |
     with response as (select * from omni_httpc.http_execute(
       omni_httpc.http_request('http://127.0.0.1:' ||
-      (select effective_port from omni_httpd.listeners) || '/')))
+                              (select effective_port from omni_httpd.listeners where port = 8080) || '/')))
     select
     response.status,
     convert_from(response.body, 'utf-8') as body
@@ -80,11 +108,83 @@ tests:
   - status: 200
     body: ok
 
+- name: route on a different port
+  query: |
+    with
+        response as (select *
+                     from
+                         omni_httpc.http_execute(
+                                 omni_httpc.http_request('http://127.0.0.1:' ||
+                                                         (select effective_port from omni_httpd.listeners where port = 8081) ||
+                                                         '/another_port')))
+    select
+        response.status,
+        convert_from(response.body, 'utf-8') as body
+    from
+        response
+  results:
+  - status: 200
+    body: another port
+
+- name: route on a different host
+  query: |
+    with
+        response as (select *
+                     from
+                         omni_httpc.http_execute(
+                                 omni_httpc.http_request('http://localhost:' ||
+                                                         (select effective_port from omni_httpd.listeners where port = 8080) ||
+                                                         '/another_host')))
+    select
+        response.status,
+        convert_from(response.body, 'utf-8') as body
+    from
+        response
+  results:
+  - status: 200
+    body: another host
+
+- name: fail to match route on a different port
+  query: |
+    with
+        response as (select *
+                     from
+                         omni_httpc.http_execute(
+                                 omni_httpc.http_request('http://127.0.0.1:' ||
+                                                         (select effective_port from omni_httpd.listeners where port = 8080) ||
+                                                         '/another_port')))
+    select
+        response.status,
+        convert_from(response.body, 'utf-8') as body
+    from
+        response
+    where
+        convert_from(response.body, 'utf-8') = 'another port'
+  results: [ ]
+
+- name: fail to match route on a different host
+  query: |
+    with
+        response as (select *
+                     from
+                         omni_httpc.http_execute(
+                                 omni_httpc.http_request('http://127.0.0.1:' ||
+                                                         (select effective_port from omni_httpd.listeners where port = 8080) ||
+                                                         '/another_host')))
+    select
+        response.status,
+        convert_from(response.body, 'utf-8') as body
+    from
+        response
+    where
+        convert_from(response.body, 'utf-8') = 'another host'
+  results: [ ]
+
 - name: no request in the handler
   query: |
     with response as (select * from omni_httpc.http_execute(
       omni_httpc.http_request('http://127.0.0.1:' ||
-      (select effective_port from omni_httpd.listeners) || '/no_req')))
+                              (select effective_port from omni_httpd.listeners where port = 8080) || '/no_req')))
     select
     response.status,
     convert_from(response.body, 'utf-8') as body
@@ -97,7 +197,7 @@ tests:
   query: |
     with response as (select * from omni_httpc.http_execute(
       omni_httpc.http_request('http://127.0.0.1:' ||
-      (select effective_port from omni_httpd.listeners) || '/no_outcome')))
+                              (select effective_port from omni_httpd.listeners where port = 8080) || '/no_outcome')))
     select
     response.status
     from response
@@ -111,7 +211,7 @@ tests:
                      from
                          omni_httpc.http_execute(
                                  omni_httpc.http_request('http://127.0.0.1:' ||
-                                                         (select effective_port from omni_httpd.listeners) ||
+                                                         (select effective_port from omni_httpd.listeners where port = 8080) ||
                                                          '/function')))
     select
         response.status,
@@ -129,7 +229,7 @@ tests:
                      from
                          omni_httpc.http_execute(
                                  omni_httpc.http_request('http://127.0.0.1:' ||
-                                                         (select effective_port from omni_httpd.listeners) ||
+                                                         (select effective_port from omni_httpd.listeners where port = 8080) ||
                                                          '/tuple')))
     select
         response.status,
@@ -147,7 +247,7 @@ tests:
                      from
                          omni_httpc.http_execute(
                                  omni_httpc.http_request('http://127.0.0.1:' ||
-                                                         (select effective_port from omni_httpd.listeners) ||
+                                                         (select effective_port from omni_httpd.listeners where port = 8080) ||
                                                          '/null')))
     select
         response.status,


### PR DESCRIPTION
Sometimes, we need to be able to route based on port or hostname.
    
Solution: implement matching against these components

Mostly copies the implementation from #841 by @diogob 