### PR TITLE
Problem: processing data in CSV (🚀 omni_csv 0.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Below is the current list of components being worked on, experimented with and d
 | [omni_cloudevents](extensions/omni_cloudevents/README.md)                                | :white_check_mark: First release candidate   | [CloudEvents](https://cloudevents.io/) support        |
 | [omni_json](extensions/omni_json/README.md)                                              | :white_check_mark: First release candidate   | JSON toolkit                                          |
 | [omni_yaml](extensions/omni_yaml/README.md)                                              | :white_check_mark: First release candidate   | YAML toolkit                                          |
+| [omni_csv](extensions/omni_csv/README.md)                                                | :white_check_mark: First release candidate   | CSV toolkit                                           |
 | [omni_xml](extensions/omni_xml/README.md)                                                | :white_check_mark: First release candidate   | XML toolkit                                           |
 | [omni_http](extensions/omni_http/README.md)                                              | :white_check_mark: First release candidate   | Common HTTP types library                             |
 | [omni_httpd](extensions/omni_httpd/README.md), [omni_web](extensions/omni_web/README.md) | :white_check_mark: First release candidate   | Serving HTTP in Postgres and building services in SQL |

--- a/extensions/omni_csv/CHANGELOG.md
+++ b/extensions/omni_csv/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-08-01
+
+Initial release
+
+[Unreleased]: https://github.com/omnigres/omnigres/commits/next/omni_csv
+
+[0.1.0]: [https://github.com/omnigres/omnigres/pull/893]

--- a/extensions/omni_csv/CMakeLists.txt
+++ b/extensions/omni_csv/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(omni_csv)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.1)
+        message(FATAL_ERROR "GCC version must be at least 13.1 Detected version: ${CMAKE_CXX_COMPILER_VERSION}")
+    endif ()
+endif ()
+
+include(CTest)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
+
+enable_testing()
+
+find_package(PostgreSQL REQUIRED)
+
+add_postgresql_extension(
+        omni_csv
+        COMMENT "CSV toolkit"
+        SOURCES omni_csv.cpp
+        SCHEMA omni_csv
+        RELOCATABLE false)
+
+
+target_compile_features(omni_csv PUBLIC cxx_std_20)
+
+target_include_directories(omni_csv PRIVATE
+${CMAKE_CURRENT_LIST_DIR}/deps
+${CMAKE_CURRENT_LIST_DIR}/../../deps/fmt/include)

--- a/extensions/omni_csv/README.md
+++ b/extensions/omni_csv/README.md
@@ -1,0 +1,3 @@
+# omni_csv
+
+CSV toolkit

--- a/extensions/omni_csv/deps/.clang-format
+++ b/extensions/omni_csv/deps/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never

--- a/extensions/omni_csv/deps/cppgres.hpp
+++ b/extensions/omni_csv/deps/cppgres.hpp
@@ -1,0 +1,12106 @@
+/**
+ * \file cppgres.hpp
+ *
+ * \mainpage Cppgres: Postgres extensions in C++
+ *
+ * \note __GitHub__ repository: [cppgres/cppgres](https://github.com/cppgres/cppgres)
+ *
+ * Cppgres allows you to build Postgres extensions using C++: a high-performance, feature-rich
+ * language already supported by the same compiler toolchains used to develop for Postgres,
+ * like GCC and Clang.
+ *
+ * \subsection Features
+ *
+ * - Header-only library
+ * - Compile and runtime safety checks
+ * - Automatic type mapping
+ * - Ergonomic executor API
+ * - Modern C+++20 interface & implementation
+ * - Direct integration with C
+ *
+ * \subsection qstart Quick start example
+ *
+ * ```
+ * #include <cppgres.hpp>
+ *
+ * extern "C" {
+ *  PG_MODULE_MAGIC;
+ * }
+ *
+ * postgres_function(demo_len, ([](std::string_view t) { return t.length(); }));
+ * ```
+ *
+ */
+
+#ifndef cppgres_hpp
+#define cppgres_hpp
+
+#if !defined(cppgres_prefer_fmt) && __has_include(<format>)
+#include <format>
+#if (defined(__clang__) && defined(_LIBCPP_HAS_NO_INCOMPLETE_FORMAT))
+#if __has_include(<fmt/core.h>)
+#define FMT_HEADER_ONLY
+#include <fmt/core.h>
+namespace cppgres::fmt {
+using ::fmt::format;
+}
+#else
+#error "Neither functional <format> nor <fmt/core.h> available"
+#endif
+#else
+namespace cppgres::fmt {
+using std::format;
+}
+#endif
+#elif __has_include(<fmt/core.h>)
+#define FMT_HEADER_ONLY
+#include <fmt/core.h>
+namespace cppgres::fmt {
+using ::fmt::format;
+}
+#else
+#error "Neither functional <format> nor <fmt/core.h> available"
+#endif
+
+
+/**
+ * \file
+ */
+
+/**
+ * \file
+ */
+
+/**
+* \file
+ */
+
+#include <optional>
+#include <string_view>
+#include <tuple>
+#include <utility>
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_HPP
+#define BOOST_PFR_HPP
+
+/// \file boost/pfr.hpp
+/// Includes all the Boost.PFR headers
+
+// Copyright (c) 2016-2023 Antony Polukhin
+// Copyright (c) 2022 Denis Mikhailov
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_CONFIG_HPP
+#define BOOST_PFR_CONFIG_HPP
+
+#if __cplusplus >= 201402L || (defined(_MSC_VER) && defined(_MSVC_LANG) && _MSC_VER > 1900)
+#include <type_traits> // to get non standard platform macro definitions (__GLIBCXX__ for example)
+#endif
+
+/// \file boost/pfr/config.hpp
+/// Contains all the macros that describe Boost.PFR configuration, like BOOST_PFR_ENABLED
+///
+/// \note This header file doesn't require C++14 Standard and supports all C++ compilers, even pre C++14 compilers (C++11, C++03...).
+
+// Reminder:
+//  * MSVC++ 14.2 _MSC_VER == 1927 <- Loophole is known to work (Visual Studio ????)
+//  * MSVC++ 14.1 _MSC_VER == 1916 <- Loophole is known to NOT work (Visual Studio 2017)
+//  * MSVC++ 14.0 _MSC_VER == 1900 (Visual Studio 2015)
+//  * MSVC++ 12.0 _MSC_VER == 1800 (Visual Studio 2013)
+
+#ifdef BOOST_PFR_NOT_SUPPORTED
+#   error Please, do not set BOOST_PFR_NOT_SUPPORTED value manually, use '-DBOOST_PFR_ENABLED=0' instead of it
+#endif
+
+#if defined(_MSC_VER)
+#   if !defined(_MSVC_LANG) || _MSC_VER <= 1900
+#       define BOOST_PFR_NOT_SUPPORTED 1
+#   endif
+#elif __cplusplus < 201402L
+#   define BOOST_PFR_NOT_SUPPORTED 1
+#endif
+
+#ifndef BOOST_PFR_USE_LOOPHOLE
+#   if defined(_MSC_VER)
+#       if _MSC_VER >= 1927
+#           define BOOST_PFR_USE_LOOPHOLE 1
+#       else
+#           define BOOST_PFR_USE_LOOPHOLE 0
+#       endif
+#   elif defined(__clang_major__) && __clang_major__ >= 8
+#       define BOOST_PFR_USE_LOOPHOLE 0
+#   else
+#       define BOOST_PFR_USE_LOOPHOLE 1
+#   endif
+#endif
+
+#ifndef BOOST_PFR_USE_CPP17
+#   ifdef __cpp_structured_bindings
+#       define BOOST_PFR_USE_CPP17 1
+#   elif defined(_MSVC_LANG)
+#       if _MSVC_LANG >= 201703L
+#           define BOOST_PFR_USE_CPP17 1
+#       else
+#           define BOOST_PFR_USE_CPP17 0
+#       endif
+#   else
+#       define BOOST_PFR_USE_CPP17 0
+#   endif
+#endif
+
+#if (!BOOST_PFR_USE_CPP17 && !BOOST_PFR_USE_LOOPHOLE)
+#   if (defined(_MSC_VER) && _MSC_VER < 1916) ///< in Visual Studio 2017 v15.9 PFR library with classic engine normally works
+#      define BOOST_PFR_NOT_SUPPORTED 1
+#   endif
+#endif
+
+#ifndef BOOST_PFR_USE_STD_MAKE_INTEGRAL_SEQUENCE
+// Assume that libstdc++ since GCC-7.3 does not have linear instantiation depth in std::make_integral_sequence
+#   if defined( __GLIBCXX__) && __GLIBCXX__ >= 20180101
+#       define BOOST_PFR_USE_STD_MAKE_INTEGRAL_SEQUENCE 1
+#   elif defined(_MSC_VER)
+#       define BOOST_PFR_USE_STD_MAKE_INTEGRAL_SEQUENCE 1
+//# elif other known working lib
+#   else
+#       define BOOST_PFR_USE_STD_MAKE_INTEGRAL_SEQUENCE 0
+#   endif
+#endif
+
+#ifndef BOOST_PFR_HAS_GUARANTEED_COPY_ELISION
+#   if  defined(__cpp_guaranteed_copy_elision) && (!defined(_MSC_VER) || _MSC_VER > 1928)
+#       define BOOST_PFR_HAS_GUARANTEED_COPY_ELISION 1
+#   else
+#       define BOOST_PFR_HAS_GUARANTEED_COPY_ELISION 0
+#   endif
+#endif
+
+#ifndef BOOST_PFR_ENABLE_IMPLICIT_REFLECTION
+#   if  defined(__cpp_lib_is_aggregate)
+#       define BOOST_PFR_ENABLE_IMPLICIT_REFLECTION 1
+#   else
+// There is no way to detect potential ability to be reflectable without std::is_aggregare
+#       define BOOST_PFR_ENABLE_IMPLICIT_REFLECTION 0
+#   endif
+#endif
+
+#ifndef BOOST_PFR_CORE_NAME_ENABLED
+#   if  (__cplusplus >= 202002L) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 202002L))
+#       if (defined(__cpp_nontype_template_args) && __cpp_nontype_template_args >= 201911) \
+         || (defined(__clang_major__) && __clang_major__ >= 12)
+#           define BOOST_PFR_CORE_NAME_ENABLED 1
+#       else
+#           define BOOST_PFR_CORE_NAME_ENABLED 0
+#       endif
+#   else
+#       define BOOST_PFR_CORE_NAME_ENABLED 0
+#   endif
+#endif
+
+
+#ifndef BOOST_PFR_CORE_NAME_PARSING
+#   if defined(_MSC_VER)
+#       define BOOST_PFR_CORE_NAME_PARSING (sizeof("auto __cdecl boost::pfr::detail::name_of_field_impl<") - 1, sizeof(">(void) noexcept") - 1, backward("->"))
+#   elif defined(__clang__)
+#       define BOOST_PFR_CORE_NAME_PARSING (sizeof("auto boost::pfr::detail::name_of_field_impl() [MsvcWorkaround = ") - 1, sizeof("}]") - 1, backward("."))
+#   elif defined(__GNUC__)
+#       define BOOST_PFR_CORE_NAME_PARSING (sizeof("consteval auto boost::pfr::detail::name_of_field_impl() [with MsvcWorkaround = ") - 1, sizeof(")]") - 1, backward("::"))
+#   else
+// Default parser for other platforms... Just skip nothing!
+#       define BOOST_PFR_CORE_NAME_PARSING (0, 0, "")
+#   endif
+#endif
+
+#if defined(__has_cpp_attribute)
+#   if __has_cpp_attribute(maybe_unused)
+#       define BOOST_PFR_MAYBE_UNUSED [[maybe_unused]]
+#   endif
+#endif
+
+#ifndef BOOST_PFR_MAYBE_UNUSED
+#   define BOOST_PFR_MAYBE_UNUSED
+#endif
+
+#ifndef BOOST_PFR_ENABLED
+#   ifdef BOOST_PFR_NOT_SUPPORTED
+#       define BOOST_PFR_ENABLED 0
+#   else
+#       define BOOST_PFR_ENABLED 1
+#   endif
+#endif
+
+#undef BOOST_PFR_NOT_SUPPORTED
+
+#endif // BOOST_PFR_CONFIG_HPP
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_CORE_HPP
+#define BOOST_PFR_CORE_HPP
+
+// Copyright (c) 2016-2023 Antony Polukhin
+// Copyright (c) 2022 Denis Mikhailov
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_CONFIG_HPP
+#define BOOST_PFR_DETAIL_CONFIG_HPP
+
+
+#if !BOOST_PFR_ENABLED
+
+#error Boost.PFR library is not supported in your environment.             \
+       Try one of the possible solutions:                                  \
+       1. try to take away an '-DBOOST_PFR_ENABLED=0', if it exists        \
+       2. enable C++14;                                                    \
+       3. enable C++17;                                                    \
+       4. update your compiler;                                            \
+       or disable this error by '-DBOOST_PFR_ENABLED=1' if you really know what are you doing.
+
+#endif // !BOOST_PFR_ENABLED
+
+#endif // BOOST_PFR_DETAIL_CONFIG_HPP
+
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_CORE_HPP
+#define BOOST_PFR_DETAIL_CORE_HPP
+
+
+// Each core provides `boost::pfr::detail::tie_as_tuple` and
+// `boost::pfr::detail::for_each_field_dispatcher` functions.
+//
+// The whole PFR library is build on top of those two functions.
+#if BOOST_PFR_USE_CPP17
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#ifndef BOOST_PFR_DETAIL_CORE17_HPP
+#define BOOST_PFR_DETAIL_CORE17_HPP
+
+// Copyright (c) 2016-2023 Antony Polukhin
+// Copyright (c) 2023 Denis Mikhailov
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////// THIS HEADER IS AUTO GENERATED BY misc/generate_cpp17.py                                    ////////////////
+//////////////// MODIFY AND RUN THE misc/generate_cpp17.py INSTEAD OF DIRECTLY MODIFYING THE GENERATED FILE ////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef BOOST_PFR_DETAIL_CORE17_GENERATED_HPP
+#define BOOST_PFR_DETAIL_CORE17_GENERATED_HPP
+
+#if !BOOST_PFR_USE_CPP17
+#   error C++17 is required for this header.
+#endif
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_SEQUENCE_TUPLE_HPP
+#define BOOST_PFR_DETAIL_SEQUENCE_TUPLE_HPP
+
+// Copyright (c) 2018 Sergei Fedorov
+// Copyright (c) 2019-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_MAKE_INTEGER_SEQUENCE_HPP
+#define BOOST_PFR_DETAIL_MAKE_INTEGER_SEQUENCE_HPP
+
+
+#include <type_traits>
+#include <utility>
+#include <cstddef>
+
+namespace boost { namespace pfr { namespace detail {
+
+#if BOOST_PFR_USE_STD_MAKE_INTEGRAL_SEQUENCE == 0
+
+#ifdef __has_builtin
+#   if __has_builtin(__make_integer_seq)
+#       define BOOST_PFR_USE_MAKE_INTEGER_SEQ_BUILTIN
+#   endif
+#endif
+
+#ifdef BOOST_PFR_USE_MAKE_INTEGER_SEQ_BUILTIN
+
+using std::integer_sequence;
+
+// Clang unable to use namespace qualified std::integer_sequence in __make_integer_seq.
+template <typename T, T N>
+using make_integer_sequence = __make_integer_seq<integer_sequence, T, N>;
+
+#undef BOOST_PFR_USE_MAKE_INTEGER_SEQ_BUILTIN
+
+#else
+
+template <typename T, typename U>
+struct join_sequences;
+
+template <typename T, T... A, T... B>
+struct join_sequences<std::integer_sequence<T, A...>, std::integer_sequence<T, B...>> {
+    using type = std::integer_sequence<T, A..., B...>;
+};
+
+template <typename T, T Min, T Max>
+struct build_sequence_impl {
+    static_assert(Min < Max, "Start of range must be less than its end");
+    static constexpr T size = Max - Min;
+    using type = typename join_sequences<
+            typename build_sequence_impl<T, Min, Min + size / 2>::type,
+            typename build_sequence_impl<T, Min + size / 2 + 1, Max>::type
+        >::type;
+};
+
+template <typename T, T V>
+struct build_sequence_impl<T, V, V> {
+    using type = std::integer_sequence<T, V>;
+};
+
+template <typename T, std::size_t N>
+struct make_integer_sequence_impl : build_sequence_impl<T, 0, N - 1> {};
+
+template <typename T>
+struct make_integer_sequence_impl<T, 0> {
+    using type = std::integer_sequence<T>;
+};
+
+template <typename T, T N>
+using make_integer_sequence = typename make_integer_sequence_impl<T, N>::type;
+
+#endif // !defined BOOST_PFR_USE_MAKE_INTEGER_SEQ_BUILTIN
+#else // BOOST_PFR_USE_STD_MAKE_INTEGRAL_SEQUENCE == 1
+
+template <typename T, T N>
+using make_integer_sequence = std::make_integer_sequence<T, N>;
+
+#endif // BOOST_PFR_USE_STD_MAKE_INTEGRAL_SEQUENCE == 1
+
+template <std::size_t N>
+using make_index_sequence = make_integer_sequence<std::size_t, N>;
+
+template <typename... T>
+using index_sequence_for = make_index_sequence<sizeof...(T)>;
+
+}}} // namespace boost::pfr::detail
+
+#endif
+
+
+#include <utility>      // metaprogramming stuff
+#include <cstddef>      // std::size_t
+
+///////////////////// Tuple that holds its values in the supplied order
+namespace boost { namespace pfr { namespace detail { namespace sequence_tuple {
+
+template <std::size_t N, class T>
+struct base_from_member {
+    T value;
+};
+
+template <class I, class ...Tail>
+struct tuple_base;
+
+
+
+template <std::size_t... I, class ...Tail>
+struct tuple_base< std::index_sequence<I...>, Tail... >
+    : base_from_member<I , Tail>...
+{
+    static constexpr std::size_t size_v = sizeof...(I);
+
+    // We do not use `noexcept` in the following functions, because if user forget to put one then clang will issue an error:
+    // "error: exception specification of explicitly defaulted default constructor does not match the calculated one".
+    constexpr tuple_base() = default;
+    constexpr tuple_base(tuple_base&&) = default;
+    constexpr tuple_base(const tuple_base&) = default;
+
+    constexpr tuple_base(Tail... v) noexcept
+        : base_from_member<I, Tail>{ v }...
+    {}
+};
+
+template <>
+struct tuple_base<std::index_sequence<> > {
+    static constexpr std::size_t size_v = 0;
+};
+
+template <std::size_t N, class T>
+constexpr T& get_impl(base_from_member<N, T>& t) noexcept {
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+    return t.value;
+}
+
+template <std::size_t N, class T>
+constexpr const T& get_impl(const base_from_member<N, T>& t) noexcept {
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+    return t.value;
+}
+
+template <std::size_t N, class T>
+constexpr volatile T& get_impl(volatile base_from_member<N, T>& t) noexcept {
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+    return t.value;
+}
+
+template <std::size_t N, class T>
+constexpr const volatile T& get_impl(const volatile base_from_member<N, T>& t) noexcept {
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+    return t.value;
+}
+
+template <std::size_t N, class T>
+constexpr T&& get_impl(base_from_member<N, T>&& t) noexcept {
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+    return std::forward<T>(t.value);
+}
+
+
+template <class T, std::size_t N>
+constexpr T& get_by_type_impl(base_from_member<N, T>& t) noexcept {
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+    return t.value;
+}
+
+template <class T, std::size_t N>
+constexpr const T& get_by_type_impl(const base_from_member<N, T>& t) noexcept {
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+    return t.value;
+}
+
+template <class T, std::size_t N>
+constexpr volatile T& get_by_type_impl(volatile base_from_member<N, T>& t) noexcept {
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+    return t.value;
+}
+
+template <class T, std::size_t N>
+constexpr const volatile T& get_by_type_impl(const volatile base_from_member<N, T>& t) noexcept {
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+    return t.value;
+}
+
+template <class T, std::size_t N>
+constexpr T&& get_by_type_impl(base_from_member<N, T>&& t) noexcept {
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+    return std::forward<T>(t.value);
+}
+
+template <class T, std::size_t N>
+constexpr const T&& get_by_type_impl(const base_from_member<N, T>&& t) noexcept {
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+    return std::forward<T>(t.value);
+}
+
+
+
+
+template <class ...Values>
+struct tuple: tuple_base<
+    detail::index_sequence_for<Values...>,
+    Values...>
+{
+    using tuple_base<
+        detail::index_sequence_for<Values...>,
+        Values...
+    >::tuple_base;
+
+    constexpr static std::size_t size() noexcept { return sizeof...(Values); }
+    constexpr static bool empty() noexcept { return size() == 0; }
+};
+
+
+template <std::size_t N, class ...T>
+constexpr decltype(auto) get(tuple<T...>& t) noexcept {
+    static_assert(N < tuple<T...>::size_v, "====================> Boost.PFR: Tuple index out of bounds");
+    return sequence_tuple::get_impl<N>(t);
+}
+
+template <std::size_t N, class ...T>
+constexpr decltype(auto) get(const tuple<T...>& t) noexcept {
+    static_assert(N < tuple<T...>::size_v, "====================> Boost.PFR: Tuple index out of bounds");
+    return sequence_tuple::get_impl<N>(t);
+}
+
+template <std::size_t N, class ...T>
+constexpr decltype(auto) get(const volatile tuple<T...>& t) noexcept {
+    static_assert(N < tuple<T...>::size_v, "====================> Boost.PFR: Tuple index out of bounds");
+    return sequence_tuple::get_impl<N>(t);
+}
+
+template <std::size_t N, class ...T>
+constexpr decltype(auto) get(volatile tuple<T...>& t) noexcept {
+    static_assert(N < tuple<T...>::size_v, "====================> Boost.PFR: Tuple index out of bounds");
+    return sequence_tuple::get_impl<N>(t);
+}
+
+template <std::size_t N, class ...T>
+constexpr decltype(auto) get(tuple<T...>&& t) noexcept {
+    static_assert(N < tuple<T...>::size_v, "====================> Boost.PFR: Tuple index out of bounds");
+    return sequence_tuple::get_impl<N>(std::move(t));
+}
+
+template <std::size_t I, class T>
+using tuple_element = std::remove_reference< decltype(
+        ::boost::pfr::detail::sequence_tuple::get<I>( std::declval<T>() )
+    ) >;
+
+template <class... Args>
+constexpr auto make_sequence_tuple(Args... args) noexcept {
+    return ::boost::pfr::detail::sequence_tuple::tuple<Args...>{ args... };
+}
+
+}}}} // namespace boost::pfr::detail::sequence_tuple
+
+#endif // BOOST_PFR_CORE_HPP
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_SIZE_T_HPP
+#define BOOST_PFR_DETAIL_SIZE_T_HPP
+
+namespace boost { namespace pfr { namespace detail {
+
+///////////////////// General utility stuff
+template <std::size_t Index>
+using size_t_ = std::integral_constant<std::size_t, Index >;
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_SIZE_T_HPP
+#include <type_traits> // for std::conditional_t, std::is_reference
+
+namespace boost { namespace pfr { namespace detail {
+
+template <class... Args>
+constexpr auto make_tuple_of_references(Args&&... args) noexcept {
+  return sequence_tuple::tuple<Args&...>{ args... };
+}
+
+template<typename T, typename Arg>
+constexpr decltype(auto) add_cv_like(Arg& arg) noexcept {
+    if constexpr (std::is_const<T>::value && std::is_volatile<T>::value) {
+        return const_cast<const volatile Arg&>(arg);
+    }
+    else if constexpr (std::is_const<T>::value) {
+        return const_cast<const Arg&>(arg);
+    }
+    else if constexpr (std::is_volatile<T>::value) {
+        return const_cast<volatile Arg&>(arg);
+    }
+    else {
+        return const_cast<Arg&>(arg);
+    }
+}
+
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78939
+template<typename T, typename Sb, typename Arg>
+constexpr decltype(auto) workaround_cast(Arg& arg) noexcept {
+    using output_arg_t = std::conditional_t<!std::is_reference<Sb>(), decltype(detail::add_cv_like<T>(arg)), Sb>;
+    return const_cast<output_arg_t>(arg);
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& /*val*/, size_t_<0>) noexcept {
+  return sequence_tuple::tuple<>{};
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<1>, std::enable_if_t<std::is_class< std::remove_cv_t<T> >::value>* = nullptr) noexcept {
+  auto& [a] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+  return ::boost::pfr::detail::make_tuple_of_references(detail::workaround_cast<T, decltype(a)>(a));
+}
+
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<1>, std::enable_if_t<!std::is_class< std::remove_cv_t<T> >::value>* = nullptr) noexcept {
+  return ::boost::pfr::detail::make_tuple_of_references( val );
+}
+
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<2>) noexcept {
+  auto& [a,b] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+  return ::boost::pfr::detail::make_tuple_of_references(detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b));
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<3>) noexcept {
+  auto& [a,b,c] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<4>) noexcept {
+  auto& [a,b,c,d] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<5>) noexcept {
+  auto& [a,b,c,d,e] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<6>) noexcept {
+  auto& [a,b,c,d,e,f] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<7>) noexcept {
+  auto& [a,b,c,d,e,f,g] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<8>) noexcept {
+  auto& [a,b,c,d,e,f,g,h] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<9>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<10>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<11>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<12>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<13>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<14>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<15>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<16>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<17>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<18>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<19>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<20>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<21>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<22>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<23>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<24>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<25>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<26>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<27>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<28>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<29>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<30>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<31>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<32>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<33>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<34>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<35>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<36>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<37>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<38>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<39>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<40>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<41>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<42>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<43>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<44>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<45>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<46>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<47>) noexcept {
+  auto& [a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<48>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<49>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<50>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<51>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<52>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<53>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<54>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<55>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<56>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<57>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<58>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<59>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<60>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<61>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<62>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<63>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<64>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<65>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<66>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<67>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<68>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<69>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<70>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<71>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<72>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<73>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<74>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<75>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<76>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<77>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<78>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<79>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<80>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<81>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<82>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<83>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<84>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<85>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<86>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<87>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<88>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<89>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS,aU
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS),detail::workaround_cast<T, decltype(aU)>(aU)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<90>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS,aU,aV
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS),detail::workaround_cast<T, decltype(aU)>(aU),detail::workaround_cast<T, decltype(aV)>(aV)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<91>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS,aU,aV,aW
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS),detail::workaround_cast<T, decltype(aU)>(aU),detail::workaround_cast<T, decltype(aV)>(aV),
+    detail::workaround_cast<T, decltype(aW)>(aW)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<92>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS,aU,aV,aW,aX
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS),detail::workaround_cast<T, decltype(aU)>(aU),detail::workaround_cast<T, decltype(aV)>(aV),
+    detail::workaround_cast<T, decltype(aW)>(aW),detail::workaround_cast<T, decltype(aX)>(aX)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<93>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS,aU,aV,aW,aX,aY
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS),detail::workaround_cast<T, decltype(aU)>(aU),detail::workaround_cast<T, decltype(aV)>(aV),
+    detail::workaround_cast<T, decltype(aW)>(aW),detail::workaround_cast<T, decltype(aX)>(aX),detail::workaround_cast<T, decltype(aY)>(aY)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<94>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS,aU,aV,aW,aX,aY,aZ
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS),detail::workaround_cast<T, decltype(aU)>(aU),detail::workaround_cast<T, decltype(aV)>(aV),
+    detail::workaround_cast<T, decltype(aW)>(aW),detail::workaround_cast<T, decltype(aX)>(aX),detail::workaround_cast<T, decltype(aY)>(aY),
+    detail::workaround_cast<T, decltype(aZ)>(aZ)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<95>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS,aU,aV,aW,aX,aY,aZ,
+    ba
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS),detail::workaround_cast<T, decltype(aU)>(aU),detail::workaround_cast<T, decltype(aV)>(aV),
+    detail::workaround_cast<T, decltype(aW)>(aW),detail::workaround_cast<T, decltype(aX)>(aX),detail::workaround_cast<T, decltype(aY)>(aY),
+    detail::workaround_cast<T, decltype(aZ)>(aZ),detail::workaround_cast<T, decltype(ba)>(ba)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<96>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS,aU,aV,aW,aX,aY,aZ,
+    ba,bb
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS),detail::workaround_cast<T, decltype(aU)>(aU),detail::workaround_cast<T, decltype(aV)>(aV),
+    detail::workaround_cast<T, decltype(aW)>(aW),detail::workaround_cast<T, decltype(aX)>(aX),detail::workaround_cast<T, decltype(aY)>(aY),
+    detail::workaround_cast<T, decltype(aZ)>(aZ),detail::workaround_cast<T, decltype(ba)>(ba),detail::workaround_cast<T, decltype(bb)>(bb)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<97>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS,aU,aV,aW,aX,aY,aZ,
+    ba,bb,bc
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS),detail::workaround_cast<T, decltype(aU)>(aU),detail::workaround_cast<T, decltype(aV)>(aV),
+    detail::workaround_cast<T, decltype(aW)>(aW),detail::workaround_cast<T, decltype(aX)>(aX),detail::workaround_cast<T, decltype(aY)>(aY),
+    detail::workaround_cast<T, decltype(aZ)>(aZ),detail::workaround_cast<T, decltype(ba)>(ba),detail::workaround_cast<T, decltype(bb)>(bb),
+    detail::workaround_cast<T, decltype(bc)>(bc)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<98>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS,aU,aV,aW,aX,aY,aZ,
+    ba,bb,bc,bd
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS),detail::workaround_cast<T, decltype(aU)>(aU),detail::workaround_cast<T, decltype(aV)>(aV),
+    detail::workaround_cast<T, decltype(aW)>(aW),detail::workaround_cast<T, decltype(aX)>(aX),detail::workaround_cast<T, decltype(aY)>(aY),
+    detail::workaround_cast<T, decltype(aZ)>(aZ),detail::workaround_cast<T, decltype(ba)>(ba),detail::workaround_cast<T, decltype(bb)>(bb),
+    detail::workaround_cast<T, decltype(bc)>(bc),detail::workaround_cast<T, decltype(bd)>(bd)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<99>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS,aU,aV,aW,aX,aY,aZ,
+    ba,bb,bc,bd,be
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS),detail::workaround_cast<T, decltype(aU)>(aU),detail::workaround_cast<T, decltype(aV)>(aV),
+    detail::workaround_cast<T, decltype(aW)>(aW),detail::workaround_cast<T, decltype(aX)>(aX),detail::workaround_cast<T, decltype(aY)>(aY),
+    detail::workaround_cast<T, decltype(aZ)>(aZ),detail::workaround_cast<T, decltype(ba)>(ba),detail::workaround_cast<T, decltype(bb)>(bb),
+    detail::workaround_cast<T, decltype(bc)>(bc),detail::workaround_cast<T, decltype(bd)>(bd),detail::workaround_cast<T, decltype(be)>(be)
+  );
+}
+
+template <class T>
+constexpr auto tie_as_tuple(T& val, size_t_<100>) noexcept {
+  auto& [
+    a,b,c,d,e,f,g,h,j,k,l,m,n,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,H,J,K,L,M,N,P,Q,R,S,U,V,W,X,Y,Z,
+    aa,ab,ac,ad,ae,af,ag,ah,aj,ak,al,am,an,ap,aq,ar,as,at,au,av,aw,ax,ay,az,aA,aB,aC,aD,aE,aF,aG,aH,aJ,aK,aL,aM,aN,aP,aQ,aR,aS,aU,aV,aW,aX,aY,aZ,
+    ba,bb,bc,bd,be,bf
+  ] = const_cast<std::remove_cv_t<T>&>(val); // ====================> Boost.PFR: User-provided type is not a SimpleAggregate.
+
+  return ::boost::pfr::detail::make_tuple_of_references(
+    detail::workaround_cast<T, decltype(a)>(a),detail::workaround_cast<T, decltype(b)>(b),detail::workaround_cast<T, decltype(c)>(c),
+    detail::workaround_cast<T, decltype(d)>(d),detail::workaround_cast<T, decltype(e)>(e),detail::workaround_cast<T, decltype(f)>(f),
+    detail::workaround_cast<T, decltype(g)>(g),detail::workaround_cast<T, decltype(h)>(h),detail::workaround_cast<T, decltype(j)>(j),
+    detail::workaround_cast<T, decltype(k)>(k),detail::workaround_cast<T, decltype(l)>(l),detail::workaround_cast<T, decltype(m)>(m),
+    detail::workaround_cast<T, decltype(n)>(n),detail::workaround_cast<T, decltype(p)>(p),detail::workaround_cast<T, decltype(q)>(q),
+    detail::workaround_cast<T, decltype(r)>(r),detail::workaround_cast<T, decltype(s)>(s),detail::workaround_cast<T, decltype(t)>(t),
+    detail::workaround_cast<T, decltype(u)>(u),detail::workaround_cast<T, decltype(v)>(v),detail::workaround_cast<T, decltype(w)>(w),
+    detail::workaround_cast<T, decltype(x)>(x),detail::workaround_cast<T, decltype(y)>(y),detail::workaround_cast<T, decltype(z)>(z),
+    detail::workaround_cast<T, decltype(A)>(A),detail::workaround_cast<T, decltype(B)>(B),detail::workaround_cast<T, decltype(C)>(C),
+    detail::workaround_cast<T, decltype(D)>(D),detail::workaround_cast<T, decltype(E)>(E),detail::workaround_cast<T, decltype(F)>(F),
+    detail::workaround_cast<T, decltype(G)>(G),detail::workaround_cast<T, decltype(H)>(H),detail::workaround_cast<T, decltype(J)>(J),
+    detail::workaround_cast<T, decltype(K)>(K),detail::workaround_cast<T, decltype(L)>(L),detail::workaround_cast<T, decltype(M)>(M),
+    detail::workaround_cast<T, decltype(N)>(N),detail::workaround_cast<T, decltype(P)>(P),detail::workaround_cast<T, decltype(Q)>(Q),
+    detail::workaround_cast<T, decltype(R)>(R),detail::workaround_cast<T, decltype(S)>(S),detail::workaround_cast<T, decltype(U)>(U),
+    detail::workaround_cast<T, decltype(V)>(V),detail::workaround_cast<T, decltype(W)>(W),detail::workaround_cast<T, decltype(X)>(X),
+    detail::workaround_cast<T, decltype(Y)>(Y),detail::workaround_cast<T, decltype(Z)>(Z),detail::workaround_cast<T, decltype(aa)>(aa),
+    detail::workaround_cast<T, decltype(ab)>(ab),detail::workaround_cast<T, decltype(ac)>(ac),detail::workaround_cast<T, decltype(ad)>(ad),
+    detail::workaround_cast<T, decltype(ae)>(ae),detail::workaround_cast<T, decltype(af)>(af),detail::workaround_cast<T, decltype(ag)>(ag),
+    detail::workaround_cast<T, decltype(ah)>(ah),detail::workaround_cast<T, decltype(aj)>(aj),detail::workaround_cast<T, decltype(ak)>(ak),
+    detail::workaround_cast<T, decltype(al)>(al),detail::workaround_cast<T, decltype(am)>(am),detail::workaround_cast<T, decltype(an)>(an),
+    detail::workaround_cast<T, decltype(ap)>(ap),detail::workaround_cast<T, decltype(aq)>(aq),detail::workaround_cast<T, decltype(ar)>(ar),
+    detail::workaround_cast<T, decltype(as)>(as),detail::workaround_cast<T, decltype(at)>(at),detail::workaround_cast<T, decltype(au)>(au),
+    detail::workaround_cast<T, decltype(av)>(av),detail::workaround_cast<T, decltype(aw)>(aw),detail::workaround_cast<T, decltype(ax)>(ax),
+    detail::workaround_cast<T, decltype(ay)>(ay),detail::workaround_cast<T, decltype(az)>(az),detail::workaround_cast<T, decltype(aA)>(aA),
+    detail::workaround_cast<T, decltype(aB)>(aB),detail::workaround_cast<T, decltype(aC)>(aC),detail::workaround_cast<T, decltype(aD)>(aD),
+    detail::workaround_cast<T, decltype(aE)>(aE),detail::workaround_cast<T, decltype(aF)>(aF),detail::workaround_cast<T, decltype(aG)>(aG),
+    detail::workaround_cast<T, decltype(aH)>(aH),detail::workaround_cast<T, decltype(aJ)>(aJ),detail::workaround_cast<T, decltype(aK)>(aK),
+    detail::workaround_cast<T, decltype(aL)>(aL),detail::workaround_cast<T, decltype(aM)>(aM),detail::workaround_cast<T, decltype(aN)>(aN),
+    detail::workaround_cast<T, decltype(aP)>(aP),detail::workaround_cast<T, decltype(aQ)>(aQ),detail::workaround_cast<T, decltype(aR)>(aR),
+    detail::workaround_cast<T, decltype(aS)>(aS),detail::workaround_cast<T, decltype(aU)>(aU),detail::workaround_cast<T, decltype(aV)>(aV),
+    detail::workaround_cast<T, decltype(aW)>(aW),detail::workaround_cast<T, decltype(aX)>(aX),detail::workaround_cast<T, decltype(aY)>(aY),
+    detail::workaround_cast<T, decltype(aZ)>(aZ),detail::workaround_cast<T, decltype(ba)>(ba),detail::workaround_cast<T, decltype(bb)>(bb),
+    detail::workaround_cast<T, decltype(bc)>(bc),detail::workaround_cast<T, decltype(bd)>(bd),detail::workaround_cast<T, decltype(be)>(be),
+    detail::workaround_cast<T, decltype(bf)>(bf)
+  );
+}
+
+
+template <class T, std::size_t I>
+constexpr void tie_as_tuple(T& /*val*/, size_t_<I>) noexcept {
+  static_assert(sizeof(T) && false,
+                "====================> Boost.PFR: Too many fields in a structure T. Regenerate include/boost/pfr/detail/core17_generated.hpp file for appropriate count of fields. For example: `python ./misc/generate_cpp17.py 300 > include/boost/pfr/detail/core17_generated.hpp`");
+}
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_CORE17_GENERATED_HPP
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_FIELDS_COUNT_HPP
+#define BOOST_PFR_DETAIL_FIELDS_COUNT_HPP
+
+// Copyright (c) 2019-2023 Antony Polukhin.
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_UNSAFE_DECLVAL_HPP
+#define BOOST_PFR_DETAIL_UNSAFE_DECLVAL_HPP
+
+
+#include <type_traits>
+
+namespace boost { namespace pfr { namespace detail {
+
+// This function serves as a link-time assert. If linker requires it, then
+// `unsafe_declval()` is used at runtime.
+void report_if_you_see_link_error_with_this_function() noexcept;
+
+// For returning non default constructible types. Do NOT use at runtime!
+//
+// GCCs std::declval may not be used in potentionally evaluated contexts,
+// so we reinvent it.
+template <class T>
+constexpr T unsafe_declval() noexcept {
+    report_if_you_see_link_error_with_this_function();
+
+    typename std::remove_reference<T>::type* ptr = nullptr;
+    ptr += 42; // suppresses 'null pointer dereference' warnings
+    return static_cast<T>(*ptr);
+}
+
+}}} // namespace boost::pfr::detail
+
+
+#endif // BOOST_PFR_DETAIL_UNSAFE_DECLVAL_HPP
+
+
+#include <climits>      // CHAR_BIT
+#include <type_traits>
+#include <utility>      // metaprogramming stuff
+
+#ifdef __clang__
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wmissing-braces"
+#   pragma clang diagnostic ignored "-Wundefined-inline"
+#   pragma clang diagnostic ignored "-Wundefined-internal"
+#   pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
+namespace boost { namespace pfr { namespace detail {
+
+///////////////////// Structure that can be converted to reference to anything
+struct ubiq_lref_constructor {
+    std::size_t ignore;
+    template <class Type> constexpr operator Type&() const && noexcept {  // tweak for template_unconstrained.cpp like cases
+        return detail::unsafe_declval<Type&>();
+    }
+
+    template <class Type> constexpr operator Type&() const & noexcept {  // tweak for optional_chrono.cpp like cases
+        return detail::unsafe_declval<Type&>();
+    }
+};
+
+///////////////////// Structure that can be converted to rvalue reference to anything
+struct ubiq_rref_constructor {
+    std::size_t ignore;
+    template <class Type> /*constexpr*/ operator Type() const && noexcept {  // Allows initialization of rvalue reference fields and move-only types
+        return detail::unsafe_declval<Type>();
+    }
+};
+
+
+#ifndef __cpp_lib_is_aggregate
+///////////////////// Hand-made is_aggregate_initializable_n<T> trait
+
+// Structure that can be converted to reference to anything except reference to T
+template <class T, bool IsCopyConstructible>
+struct ubiq_constructor_except {
+    std::size_t ignore;
+    template <class Type> constexpr operator std::enable_if_t<!std::is_same<T, Type>::value, Type&> () const noexcept; // Undefined
+};
+
+template <class T>
+struct ubiq_constructor_except<T, false> {
+    std::size_t ignore;
+    template <class Type> constexpr operator std::enable_if_t<!std::is_same<T, Type>::value, Type&&> () const noexcept; // Undefined
+};
+
+
+// `std::is_constructible<T, ubiq_constructor_except<T>>` consumes a lot of time, so we made a separate lazy trait for it.
+template <std::size_t N, class T> struct is_single_field_and_aggregate_initializable: std::false_type {};
+template <class T> struct is_single_field_and_aggregate_initializable<1, T>: std::integral_constant<
+    bool, !std::is_constructible<T, ubiq_constructor_except<T, std::is_copy_constructible<T>::value>>::value
+> {};
+
+// Hand-made is_aggregate<T> trait:
+// Before C++20 aggregates could be constructed from `decltype(ubiq_?ref_constructor{I})...` but type traits report that
+// there's no constructor from `decltype(ubiq_?ref_constructor{I})...`
+// Special case for N == 1: `std::is_constructible<T, ubiq_?ref_constructor>` returns true if N == 1 and T is copy/move constructible.
+template <class T, std::size_t N>
+struct is_aggregate_initializable_n {
+    template <std::size_t ...I>
+    static constexpr bool is_not_constructible_n(std::index_sequence<I...>) noexcept {
+        return (!std::is_constructible<T, decltype(ubiq_lref_constructor{I})...>::value && !std::is_constructible<T, decltype(ubiq_rref_constructor{I})...>::value)
+            || is_single_field_and_aggregate_initializable<N, T>::value
+        ;
+    }
+
+    static constexpr bool value =
+           std::is_empty<T>::value
+        || std::is_array<T>::value
+        || std::is_fundamental<T>::value
+        || is_not_constructible_n(detail::make_index_sequence<N>{})
+    ;
+};
+
+#endif // #ifndef __cpp_lib_is_aggregate
+
+///////////////////// Detect aggregates with inheritance
+template <class Derived, class U>
+constexpr bool static_assert_non_inherited() noexcept {
+    static_assert(
+            !std::is_base_of<U, Derived>::value,
+            "====================> Boost.PFR: Boost.PFR: Inherited types are not supported."
+    );
+    return true;
+}
+
+template <class Derived>
+struct ubiq_lref_base_asserting {
+    template <class Type> constexpr operator Type&() const &&  // tweak for template_unconstrained.cpp like cases
+        noexcept(detail::static_assert_non_inherited<Derived, Type>())  // force the computation of assert function
+    {
+        return detail::unsafe_declval<Type&>();
+    }
+
+    template <class Type> constexpr operator Type&() const &  // tweak for optional_chrono.cpp like cases
+        noexcept(detail::static_assert_non_inherited<Derived, Type>())  // force the computation of assert function
+    {
+        return detail::unsafe_declval<Type&>();
+    }
+};
+
+template <class Derived>
+struct ubiq_rref_base_asserting {
+    template <class Type> /*constexpr*/ operator Type() const &&  // Allows initialization of rvalue reference fields and move-only types
+        noexcept(detail::static_assert_non_inherited<Derived, Type>())  // force the computation of assert function
+    {
+        return detail::unsafe_declval<Type>();
+    }
+};
+
+template <class T, std::size_t I0, std::size_t... I, class /*Enable*/ = typename std::enable_if<std::is_copy_constructible<T>::value>::type>
+constexpr auto assert_first_not_base(std::index_sequence<I0, I...>) noexcept
+    -> typename std::add_pointer<decltype(T{ ubiq_lref_base_asserting<T>{}, ubiq_lref_constructor{I}... })>::type
+{
+    return nullptr;
+}
+
+template <class T, std::size_t I0, std::size_t... I, class /*Enable*/ = typename std::enable_if<!std::is_copy_constructible<T>::value>::type>
+constexpr auto assert_first_not_base(std::index_sequence<I0, I...>) noexcept
+    -> typename std::add_pointer<decltype(T{ ubiq_rref_base_asserting<T>{}, ubiq_rref_constructor{I}... })>::type
+{
+    return nullptr;
+}
+
+template <class T>
+constexpr void* assert_first_not_base(std::index_sequence<>) noexcept
+{
+    return nullptr;
+}
+
+///////////////////// Helper for SFINAE on fields count
+template <class T, std::size_t... I, class /*Enable*/ = typename std::enable_if<std::is_copy_constructible<T>::value>::type>
+constexpr auto enable_if_constructible_helper(std::index_sequence<I...>) noexcept
+    -> typename std::add_pointer<decltype(T{ ubiq_lref_constructor{I}... })>::type;
+
+template <class T, std::size_t... I, class /*Enable*/ = typename std::enable_if<!std::is_copy_constructible<T>::value>::type>
+constexpr auto enable_if_constructible_helper(std::index_sequence<I...>) noexcept
+    -> typename std::add_pointer<decltype(T{ ubiq_rref_constructor{I}... })>::type;
+
+template <class T, std::size_t N, class /*Enable*/ = decltype( enable_if_constructible_helper<T>(detail::make_index_sequence<N>()) ) >
+using enable_if_constructible_helper_t = std::size_t;
+
+///////////////////// Helpers for range size detection
+template <std::size_t Begin, std::size_t Last>
+using is_one_element_range = std::integral_constant<bool, Begin == Last>;
+
+using multi_element_range = std::false_type;
+using one_element_range = std::true_type;
+
+///////////////////// Non greedy fields count search. Templates instantiation depth is log(sizeof(T)), templates instantiation count is log(sizeof(T)).
+template <class T, std::size_t Begin, std::size_t Middle>
+constexpr std::size_t detect_fields_count(detail::one_element_range, long) noexcept {
+    static_assert(
+        Begin == Middle,
+        "====================> Boost.PFR: Internal logic error."
+    );
+    return Begin;
+}
+
+template <class T, std::size_t Begin, std::size_t Middle>
+constexpr std::size_t detect_fields_count(detail::multi_element_range, int) noexcept;
+
+template <class T, std::size_t Begin, std::size_t Middle>
+constexpr auto detect_fields_count(detail::multi_element_range, long) noexcept
+    -> detail::enable_if_constructible_helper_t<T, Middle>
+{
+    constexpr std::size_t next_v = Middle + (Middle - Begin + 1) / 2;
+    return detail::detect_fields_count<T, Middle, next_v>(detail::is_one_element_range<Middle, next_v>{}, 1L);
+}
+
+template <class T, std::size_t Begin, std::size_t Middle>
+constexpr std::size_t detect_fields_count(detail::multi_element_range, int) noexcept {
+    constexpr std::size_t next_v = Begin + (Middle - Begin) / 2;
+    return detail::detect_fields_count<T, Begin, next_v>(detail::is_one_element_range<Begin, next_v>{}, 1L);
+}
+
+///////////////////// Greedy search. Templates instantiation depth is log(sizeof(T)), templates instantiation count is log(sizeof(T))*T in worst case.
+template <class T, std::size_t N>
+constexpr auto detect_fields_count_greedy_remember(long) noexcept
+    -> detail::enable_if_constructible_helper_t<T, N>
+{
+    return N;
+}
+
+template <class T, std::size_t N>
+constexpr std::size_t detect_fields_count_greedy_remember(int) noexcept {
+    return 0;
+}
+
+template <class T, std::size_t Begin, std::size_t Last>
+constexpr std::size_t detect_fields_count_greedy(detail::one_element_range) noexcept {
+    static_assert(
+        Begin == Last,
+        "====================> Boost.PFR: Internal logic error."
+    );
+    return detail::detect_fields_count_greedy_remember<T, Begin>(1L);
+}
+
+template <class T, std::size_t Begin, std::size_t Last>
+constexpr std::size_t detect_fields_count_greedy(detail::multi_element_range) noexcept {
+    constexpr std::size_t middle = Begin + (Last - Begin) / 2;
+    constexpr std::size_t fields_count_big_range = detail::detect_fields_count_greedy<T, middle + 1, Last>(
+        detail::is_one_element_range<middle + 1, Last>{}
+    );
+
+    constexpr std::size_t small_range_begin = (fields_count_big_range ? 0 : Begin);
+    constexpr std::size_t small_range_last = (fields_count_big_range ? 0 : middle);
+    constexpr std::size_t fields_count_small_range = detail::detect_fields_count_greedy<T, small_range_begin, small_range_last>(
+        detail::is_one_element_range<small_range_begin, small_range_last>{}
+    );
+    return fields_count_big_range ? fields_count_big_range : fields_count_small_range;
+}
+
+///////////////////// Choosing between array size, greedy and non greedy search.
+template <class T, std::size_t N>
+constexpr auto detect_fields_count_dispatch(size_t_<N>, long, long) noexcept
+    -> typename std::enable_if<std::is_array<T>::value, std::size_t>::type
+{
+    return sizeof(T) / sizeof(typename std::remove_all_extents<T>::type);
+}
+
+template <class T, std::size_t N>
+constexpr auto detect_fields_count_dispatch(size_t_<N>, long, int) noexcept
+    -> decltype(sizeof(T{}))
+{
+    constexpr std::size_t middle = N / 2 + 1;
+    return detail::detect_fields_count<T, 0, middle>(detail::multi_element_range{}, 1L);
+}
+
+template <class T, std::size_t N>
+constexpr std::size_t detect_fields_count_dispatch(size_t_<N>, int, int) noexcept {
+    // T is not default aggregate initialzable. It means that at least one of the members is not default constructible,
+    // so we have to check all the aggregate initializations for T up to N parameters and return the bigest succeeded
+    // (we can not use binary search for detecting fields count).
+    return detail::detect_fields_count_greedy<T, 0, N>(detail::multi_element_range{});
+}
+
+///////////////////// Returns fields count
+template <class T>
+constexpr std::size_t fields_count() noexcept {
+    using type = std::remove_cv_t<T>;
+
+    static_assert(
+        !std::is_reference<type>::value,
+        "====================> Boost.PFR: Attempt to get fields count on a reference. This is not allowed because that could hide an issue and different library users expect different behavior in that case."
+    );
+
+#if !BOOST_PFR_HAS_GUARANTEED_COPY_ELISION
+    static_assert(
+        std::is_copy_constructible<std::remove_all_extents_t<type>>::value || (
+            std::is_move_constructible<std::remove_all_extents_t<type>>::value
+            && std::is_move_assignable<std::remove_all_extents_t<type>>::value
+        ),
+        "====================> Boost.PFR: Type and each field in the type must be copy constructible (or move constructible and move assignable)."
+    );
+#endif  // #if !BOOST_PFR_HAS_GUARANTEED_COPY_ELISION
+
+    static_assert(
+        !std::is_polymorphic<type>::value,
+        "====================> Boost.PFR: Type must have no virtual function, because otherwise it is not aggregate initializable."
+    );
+
+#ifdef __cpp_lib_is_aggregate
+    static_assert(
+        std::is_aggregate<type>::value             // Does not return `true` for built-in types.
+        || std::is_scalar<type>::value,
+        "====================> Boost.PFR: Type must be aggregate initializable."
+    );
+#endif
+
+// Can't use the following. See the non_std_layout.cpp test.
+//#if !BOOST_PFR_USE_CPP17
+//    static_assert(
+//        std::is_standard_layout<type>::value,   // Does not return `true` for structs that have non standard layout members.
+//        "Type must be aggregate initializable."
+//    );
+//#endif
+
+#if defined(_MSC_VER) && (_MSC_VER <= 1920)
+    // Workaround for msvc compilers. Versions <= 1920 have a limit of max 1024 elements in template parameter pack
+    constexpr std::size_t max_fields_count = (sizeof(type) * CHAR_BIT >= 1024 ? 1024 : sizeof(type) * CHAR_BIT);
+#else
+    constexpr std::size_t max_fields_count = (sizeof(type) * CHAR_BIT); // We multiply by CHAR_BIT because the type may have bitfields in T
+#endif
+
+    constexpr std::size_t result = detail::detect_fields_count_dispatch<type>(size_t_<max_fields_count>{}, 1L, 1L);
+
+    detail::assert_first_not_base<type>(detail::make_index_sequence<result>{});
+
+#ifndef __cpp_lib_is_aggregate
+    static_assert(
+        is_aggregate_initializable_n<type, result>::value,
+        "====================> Boost.PFR: Types with user specified constructors (non-aggregate initializable types) are not supported."
+    );
+#endif
+
+    static_assert(
+        result != 0 || std::is_empty<type>::value || std::is_fundamental<type>::value || std::is_reference<type>::value,
+        "====================> Boost.PFR: If there's no other failed static asserts then something went wrong. Please report this issue to the github along with the structure you're reflecting."
+    );
+
+    return result;
+}
+
+}}} // namespace boost::pfr::detail
+
+#ifdef __clang__
+#   pragma clang diagnostic pop
+#endif
+
+#endif // BOOST_PFR_DETAIL_FIELDS_COUNT_HPP
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_FOR_EACH_FIELD_IMPL_HPP
+#define BOOST_PFR_DETAIL_FOR_EACH_FIELD_IMPL_HPP
+
+
+#include <utility>      // metaprogramming stuff
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_RVALUE_T_HPP
+#define BOOST_PFR_DETAIL_RVALUE_T_HPP
+
+#include <type_traits>
+#include <utility>      // std::enable_if_t
+
+// This header provides aliases rvalue_t and lvalue_t.
+//
+// Usage: template <class T> void foo(rvalue<T> rvalue);
+//
+// Those are useful for
+//  * better type safety - you can validate at compile time that only rvalue reference is passed into the function
+//  * documentation and readability - rvalue_t<T> is much better than T&&+SFINAE
+
+namespace boost { namespace pfr { namespace detail {
+
+/// Binds to rvalues only, no copying allowed.
+template <class T
+#ifdef BOOST_PFR_DETAIL_STRICT_RVALUE_TESTING
+    , class = std::enable_if_t<std::is_rvalue_reference<T&&>::value>
+#endif
+>
+using rvalue_t = T&&;
+
+/// Binds to mutable lvalues only
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_RVALUE_T_HPP
+
+namespace boost { namespace pfr { namespace detail {
+
+template <std::size_t Index>
+using size_t_ = std::integral_constant<std::size_t, Index >;
+
+template <class T, class F, class I, class = decltype(std::declval<F>()(std::declval<T>(), I{}))>
+constexpr void for_each_field_impl_apply(T&& v, F&& f, I i, long) {
+    std::forward<F>(f)(std::forward<T>(v), i);
+}
+
+template <class T, class F, class I>
+constexpr void for_each_field_impl_apply(T&& v, F&& f, I /*i*/, int) {
+    std::forward<F>(f)(std::forward<T>(v));
+}
+
+#if !defined(__cpp_fold_expressions) || __cpp_fold_expressions < 201603
+template <class T, class F, std::size_t... I>
+constexpr void for_each_field_impl(T& t, F&& f, std::index_sequence<I...>, std::false_type /*move_values*/) {
+     const int v[] = {0, (
+         detail::for_each_field_impl_apply(sequence_tuple::get<I>(t), std::forward<F>(f), size_t_<I>{}, 1L),
+         0
+     )...};
+     (void)v;
+}
+
+
+template <class T, class F, std::size_t... I>
+constexpr void for_each_field_impl(T& t, F&& f, std::index_sequence<I...>, std::true_type /*move_values*/) {
+     const int v[] = {0, (
+         detail::for_each_field_impl_apply(sequence_tuple::get<I>(std::move(t)), std::forward<F>(f), size_t_<I>{}, 1L),
+         0
+     )...};
+     (void)v;
+}
+#else
+template <class T, class F, std::size_t... I>
+constexpr void for_each_field_impl(T& t, F&& f, std::index_sequence<I...>, std::false_type /*move_values*/) {
+     (detail::for_each_field_impl_apply(sequence_tuple::get<I>(t), std::forward<F>(f), size_t_<I>{}, 1L), ...);
+}
+
+template <class T, class F, std::size_t... I>
+constexpr void for_each_field_impl(T& t, F&& f, std::index_sequence<I...>, std::true_type /*move_values*/) {
+     (detail::for_each_field_impl_apply(sequence_tuple::get<I>(std::move(t)), std::forward<F>(f), size_t_<I>{}, 1L), ...);
+}
+#endif
+
+}}} // namespace boost::pfr::detail
+
+
+#endif // BOOST_PFR_DETAIL_FOR_EACH_FIELD_IMPL_HPP
+
+namespace boost { namespace pfr { namespace detail {
+
+#ifndef _MSC_VER // MSVC fails to compile the following code, but compiles the structured bindings in core17_generated.hpp
+struct do_not_define_std_tuple_size_for_me {
+    bool test1 = true;
+};
+
+template <class T>
+constexpr bool do_structured_bindings_work() noexcept { // ******************************************* IN CASE OF ERROR READ THE FOLLOWING LINES IN boost/pfr/detail/core17.hpp FILE:
+    T val{};
+    auto& [a] = val; // ******************************************* IN CASE OF ERROR READ THE FOLLOWING LINES IN boost/pfr/detail/core17.hpp FILE:
+
+    /****************************************************************************
+    *
+    * It looks like your compiler or Standard Library can not handle C++17
+    * structured bindings.
+    *
+    * Workaround: Define BOOST_PFR_USE_CPP17 to 0
+    * It will disable the C++17 features for Boost.PFR library.
+    *
+    * Sorry for the inconvenience caused.
+    *
+    ****************************************************************************/
+
+    return a;
+}
+
+static_assert(
+    do_structured_bindings_work<do_not_define_std_tuple_size_for_me>(),
+    "====================> Boost.PFR: Your compiler can not handle C++17 structured bindings. Read the above comments for workarounds."
+);
+#endif // #ifndef _MSC_VER
+
+template <class T>
+constexpr auto tie_as_tuple(T& val) noexcept {
+  static_assert(
+    !std::is_union<T>::value,
+    "====================> Boost.PFR: For safety reasons it is forbidden to reflect unions. See `Reflection of unions` section in the docs for more info."
+  );
+  typedef size_t_<boost::pfr::detail::fields_count<T>()> fields_count_tag;
+  return boost::pfr::detail::tie_as_tuple(val, fields_count_tag{});
+}
+
+template <class T, class F, std::size_t... I>
+constexpr void for_each_field_dispatcher(T& t, F&& f, std::index_sequence<I...>) {
+    static_assert(
+        !std::is_union<T>::value,
+        "====================> Boost.PFR: For safety reasons it is forbidden to reflect unions. See `Reflection of unions` section in the docs for more info."
+    );
+    std::forward<F>(f)(
+        detail::tie_as_tuple(t)
+    );
+}
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_CORE17_HPP
+#elif BOOST_PFR_USE_LOOPHOLE
+// Copyright (c) 2017-2018 Alexandr Poltavsky, Antony Polukhin.
+// Copyright (c) 2019-2023 Antony Polukhin.
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+// The Great Type Loophole (C++14)
+// Initial implementation by Alexandr Poltavsky, http://alexpolt.github.io
+//
+// Description:
+//  The Great Type Loophole is a technique that allows to exchange type information with template
+//  instantiations. Basically you can assign and read type information during compile time.
+//  Here it is used to detect data members of a data type. I described it for the first time in
+//  this blog post http://alexpolt.github.io/type-loophole.html .
+//
+// This technique exploits the http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#2118
+// CWG 2118. Stateful metaprogramming via friend injection
+// Note: CWG agreed that such techniques should be ill-formed, although the mechanism for prohibiting them is as yet undetermined.
+
+#ifndef BOOST_PFR_DETAIL_CORE14_LOOPHOLE_HPP
+#define BOOST_PFR_DETAIL_CORE14_LOOPHOLE_HPP
+
+
+#include <type_traits>
+#include <utility>
+
+#include <boost/pfr/detail/cast_to_layout_compatible.hpp> // still needed for enums
+// Copyright (c) 2017-2018 Chris Beck
+// Copyright (c) 2019-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_OFFSET_BASED_GETTER_HPP
+#define BOOST_PFR_DETAIL_OFFSET_BASED_GETTER_HPP
+
+
+#include <type_traits>
+#include <utility>
+#include <memory>  // std::addressof
+
+
+namespace boost { namespace pfr { namespace detail {
+
+// Our own implementation of std::aligned_storage. On godbolt with MSVC, I have compilation errors
+// using the standard version, it seems the compiler cannot generate default ctor.
+
+template<std::size_t s, std::size_t a>
+struct internal_aligned_storage {
+   alignas(a) char storage_[s];
+};
+
+// Metafunction that replaces tuple<T1, T2, T3, ...> with
+// tuple<std::aligned_storage_t<sizeof(T1), alignof(T1)>, std::aligned_storage<sizeof(T2), alignof(T2)>, ...>
+//
+// The point is, the new tuple is "layout compatible" in the sense that members have the same offsets,
+// but this tuple is constexpr constructible.
+
+template <typename T>
+struct tuple_of_aligned_storage;
+
+template <typename... Ts>
+struct tuple_of_aligned_storage<sequence_tuple::tuple<Ts...>> {
+  using type = sequence_tuple::tuple<internal_aligned_storage<sizeof(Ts),
+#if defined(__GNUC__) && __GNUC__ < 8 && !defined(__x86_64__) && !defined(__CYGWIN__)
+      // Before GCC-8 the `alignof` was returning the optimal alignment rather than the minimal one.
+      // We have to adjust the alignment because otherwise we get the wrong offset.
+      (alignof(Ts) > 4 ? 4 : alignof(Ts))
+#else
+      alignof(Ts)
+#endif
+  >...>;
+};
+
+// Note: If pfr has a typelist also, could also have an overload for that here
+
+template <typename T>
+using tuple_of_aligned_storage_t = typename tuple_of_aligned_storage<T>::type;
+
+/***
+ * Given a structure type and its sequence of members, we want to build a function
+ * object "getter" that implements a version of `std::get` using offset arithmetic
+ * and reinterpret_cast.
+ *
+ * typename U should be a user-defined struct
+ * typename S should be a sequence_tuple which is layout compatible with U
+ */
+
+template <typename U, typename S>
+class offset_based_getter {
+  using this_t = offset_based_getter<U, S>;
+
+  static_assert(sizeof(U) == sizeof(S), "====================> Boost.PFR: Member sequence does not indicate correct size for struct type! Maybe the user-provided type is not a SimpleAggregate?");
+  static_assert(alignof(U) == alignof(S), "====================> Boost.PFR: Member sequence does not indicate correct alignment for struct type!");
+
+  static_assert(!std::is_const<U>::value, "====================> Boost.PFR: const should be stripped from user-defined type when using offset_based_getter or overload resolution will be ambiguous later, this indicates an error within pfr");
+  static_assert(!std::is_reference<U>::value, "====================> Boost.PFR: reference should be stripped from user-defined type when using offset_based_getter or overload resolution will be ambiguous later, this indicates an error within pfr");
+  static_assert(!std::is_volatile<U>::value, "====================> Boost.PFR: volatile should be stripped from user-defined type when using offset_based_getter or overload resolution will be ambiguous later. this indicates an error within pfr");
+
+  // Get type of idx'th member
+  template <std::size_t idx>
+  using index_t = typename sequence_tuple::tuple_element<idx, S>::type;
+
+  // Get offset of idx'th member
+  // Idea: Layout object has the same offsets as instance of S, so if S and U are layout compatible, then these offset
+  // calculations are correct.
+  template <std::size_t idx>
+  static constexpr std::ptrdiff_t offset() noexcept {
+    constexpr tuple_of_aligned_storage_t<S> layout{};
+    return &sequence_tuple::get<idx>(layout).storage_[0] - &sequence_tuple::get<0>(layout).storage_[0];
+  }
+
+  // Encapsulates offset arithmetic and reinterpret_cast
+  template <std::size_t idx>
+  static index_t<idx> * get_pointer(U * u) noexcept {
+    return reinterpret_cast<index_t<idx> *>(reinterpret_cast<char *>(u) + this_t::offset<idx>());
+  }
+
+  template <std::size_t idx>
+  static const index_t<idx> * get_pointer(const U * u) noexcept {
+    return reinterpret_cast<const index_t<idx> *>(reinterpret_cast<const char *>(u) + this_t::offset<idx>());
+  }
+
+  template <std::size_t idx>
+  static volatile index_t<idx> * get_pointer(volatile U * u) noexcept {
+    return reinterpret_cast<volatile index_t<idx> *>(reinterpret_cast<volatile char *>(u) + this_t::offset<idx>());
+  }
+
+  template <std::size_t idx>
+  static const volatile index_t<idx> * get_pointer(const volatile U * u) noexcept {
+    return reinterpret_cast<const volatile index_t<idx> *>(reinterpret_cast<const volatile char *>(u) + this_t::offset<idx>());
+  }
+
+public:
+  template <std::size_t idx>
+  index_t<idx> & get(U & u, size_t_<idx>) const noexcept {
+    return *this_t::get_pointer<idx>(std::addressof(u));
+  }
+
+  template <std::size_t idx>
+  index_t<idx> const & get(U const & u, size_t_<idx>) const noexcept {
+    return *this_t::get_pointer<idx>(std::addressof(u));
+  }
+
+  template <std::size_t idx>
+  index_t<idx> volatile & get(U volatile & u, size_t_<idx>) const noexcept {
+    return *this_t::get_pointer<idx>(std::addressof(u));
+  }
+
+  template <std::size_t idx>
+  index_t<idx> const volatile & get(U const volatile & u, size_t_<idx>) const noexcept {
+    return *this_t::get_pointer<idx>(std::addressof(u));
+  }
+
+  // rvalues must not be used here, to avoid template instantiation bloats.
+  template <std::size_t idx>
+  index_t<idx> && get(rvalue_t<U> u, size_t_<idx>) const = delete;
+};
+
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_OFFSET_LIST_HPP
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_MAKE_FLAT_TUPLE_OF_REFERENCES_HPP
+#define BOOST_PFR_DETAIL_MAKE_FLAT_TUPLE_OF_REFERENCES_HPP
+
+
+#include <utility>      // metaprogramming stuff
+
+
+namespace boost { namespace pfr { namespace detail {
+
+template <std::size_t Index>
+using size_t_ = std::integral_constant<std::size_t, Index >;
+
+// Helper: Make a "getter" object corresponding to built-in tuple::get
+// For user-defined structures, the getter should be "offset_based_getter"
+struct sequence_tuple_getter {
+  template <std::size_t idx, typename TupleOfReferences>
+  decltype(auto) get(TupleOfReferences&& t, size_t_<idx>) const noexcept {
+    return sequence_tuple::get<idx>(std::forward<TupleOfReferences>(t));
+  }
+};
+
+
+template <class TupleOrUserType, class Getter, std::size_t Begin, std::size_t Size>
+constexpr auto make_flat_tuple_of_references(TupleOrUserType&, const Getter&, size_t_<Begin>, size_t_<Size>) noexcept;
+
+template <class TupleOrUserType, class Getter, std::size_t Begin>
+constexpr sequence_tuple::tuple<> make_flat_tuple_of_references(TupleOrUserType&, const Getter&, size_t_<Begin>, size_t_<0>) noexcept;
+
+template <class TupleOrUserType, class Getter, std::size_t Begin>
+constexpr auto make_flat_tuple_of_references(TupleOrUserType&, const Getter&, size_t_<Begin>, size_t_<1>) noexcept;
+
+template <class... T>
+constexpr auto tie_as_tuple_with_references(T&... args) noexcept {
+    return sequence_tuple::tuple<T&...>{ args... };
+}
+
+template <class... T>
+constexpr decltype(auto) tie_as_tuple_with_references(detail::sequence_tuple::tuple<T...>& t) noexcept {
+    return detail::make_flat_tuple_of_references(t, sequence_tuple_getter{}, size_t_<0>{}, size_t_<sequence_tuple::tuple<T...>::size_v>{});
+}
+
+template <class... T>
+constexpr decltype(auto) tie_as_tuple_with_references(const detail::sequence_tuple::tuple<T...>& t) noexcept {
+    return detail::make_flat_tuple_of_references(t, sequence_tuple_getter{}, size_t_<0>{}, size_t_<sequence_tuple::tuple<T...>::size_v>{});
+}
+
+template <class Tuple1, std::size_t... I1, class Tuple2, std::size_t... I2>
+constexpr auto my_tuple_cat_impl(const Tuple1& t1, std::index_sequence<I1...>, const Tuple2& t2, std::index_sequence<I2...>) noexcept {
+    return detail::tie_as_tuple_with_references(
+        sequence_tuple::get<I1>(t1)...,
+        sequence_tuple::get<I2>(t2)...
+    );
+}
+
+template <class Tuple1, class Tuple2>
+constexpr auto my_tuple_cat(const Tuple1& t1, const Tuple2& t2) noexcept {
+    return detail::my_tuple_cat_impl(
+        t1, detail::make_index_sequence< Tuple1::size_v >{},
+        t2, detail::make_index_sequence< Tuple2::size_v >{}
+    );
+}
+
+template <class TupleOrUserType, class Getter, std::size_t Begin, std::size_t Size>
+constexpr auto make_flat_tuple_of_references(TupleOrUserType& t, const Getter& g, size_t_<Begin>, size_t_<Size>) noexcept {
+    constexpr std::size_t next_size = Size / 2;
+    return detail::my_tuple_cat(
+        detail::make_flat_tuple_of_references(t, g, size_t_<Begin>{}, size_t_<next_size>{}),
+        detail::make_flat_tuple_of_references(t, g, size_t_<Begin + Size / 2>{}, size_t_<Size - next_size>{})
+    );
+}
+
+template <class TupleOrUserType, class Getter, std::size_t Begin>
+constexpr sequence_tuple::tuple<> make_flat_tuple_of_references(TupleOrUserType&, const Getter&, size_t_<Begin>, size_t_<0>) noexcept {
+    return {};
+}
+
+template <class TupleOrUserType, class Getter, std::size_t Begin>
+constexpr auto make_flat_tuple_of_references(TupleOrUserType& t, const Getter& g, size_t_<Begin>, size_t_<1>) noexcept {
+    return detail::tie_as_tuple_with_references(
+        g.get(t, size_t_<Begin>{})
+    );
+}
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_MAKE_FLAT_TUPLE_OF_REFERENCES_HPP
+
+
+#ifdef __clang__
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wmissing-braces"
+#   pragma clang diagnostic ignored "-Wundefined-inline"
+#   pragma clang diagnostic ignored "-Wundefined-internal"
+#   pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#elif defined(__GNUC__)
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wnon-template-friend"
+#endif
+
+
+namespace boost { namespace pfr { namespace detail {
+
+// tag<T,N> generates friend declarations and helps with overload resolution.
+// There are two types: one with the auto return type, which is the way we read types later.
+// The second one is used in the detection of instantiations without which we'd get multiple
+// definitions.
+
+template <class T, std::size_t N>
+struct tag {
+    friend auto loophole(tag<T,N>);
+};
+
+// The definitions of friend functions.
+template <class T, class U, std::size_t N, bool B>
+struct fn_def_lref {
+    friend auto loophole(tag<T,N>) {
+        // Standard Library containers do not SFINAE on invalid copy constructor. Because of that std::vector<std::unique_ptr<int>> reports that it is copyable,
+        // which leads to an instantiation error at this place.
+        //
+        // To workaround the issue, we check that the type U is movable, and move it in that case.
+        using no_extents_t = std::remove_all_extents_t<U>;
+        return static_cast< std::conditional_t<std::is_move_constructible<no_extents_t>::value, no_extents_t&&, no_extents_t&> >(
+            boost::pfr::detail::unsafe_declval<no_extents_t&>()
+        );
+    }
+};
+template <class T, class U, std::size_t N, bool B>
+struct fn_def_rref {
+    friend auto loophole(tag<T,N>) { return std::move(boost::pfr::detail::unsafe_declval< std::remove_all_extents_t<U>& >()); }
+};
+
+
+// Those specializations are to avoid multiple definition errors.
+template <class T, class U, std::size_t N>
+struct fn_def_lref<T, U, N, true> {};
+
+template <class T, class U, std::size_t N>
+struct fn_def_rref<T, U, N, true> {};
+
+
+// This has a templated conversion operator which in turn triggers instantiations.
+// Important point, using sizeof seems to be more reliable. Also default template
+// arguments are "cached" (I think). To fix that I provide a U template parameter to
+// the ins functions which do the detection using constexpr friend functions and SFINAE.
+template <class T, std::size_t N>
+struct loophole_ubiq_lref {
+    template<class U, std::size_t M> static std::size_t ins(...);
+    template<class U, std::size_t M, std::size_t = sizeof(loophole(tag<T,M>{})) > static char ins(int);
+
+    template<class U, std::size_t = sizeof(fn_def_lref<T, U, N, sizeof(ins<U, N>(0)) == sizeof(char)>)>
+    constexpr operator U&() const&& noexcept; // `const&&` here helps to avoid ambiguity in loophole instantiations. optional_like test validate that behavior.
+};
+
+template <class T, std::size_t N>
+struct loophole_ubiq_rref {
+    template<class U, std::size_t M> static std::size_t ins(...);
+    template<class U, std::size_t M, std::size_t = sizeof(loophole(tag<T,M>{})) > static char ins(int);
+
+    template<class U, std::size_t = sizeof(fn_def_rref<T, U, N, sizeof(ins<U, N>(0)) == sizeof(char)>)>
+    constexpr operator U&&() const&& noexcept; // `const&&` here helps to avoid ambiguity in loophole instantiations. optional_like test validate that behavior.
+};
+
+
+// This is a helper to turn a data structure into a tuple.
+template <class T, class U>
+struct loophole_type_list_lref;
+
+template <typename T, std::size_t... I>
+struct loophole_type_list_lref< T, std::index_sequence<I...> >
+     // Instantiating loopholes:
+    : sequence_tuple::tuple< decltype(T{ loophole_ubiq_lref<T, I>{}... }, 0) >
+{
+    using type = sequence_tuple::tuple< decltype(loophole(tag<T, I>{}))... >;
+};
+
+
+template <class T, class U>
+struct loophole_type_list_rref;
+
+template <typename T, std::size_t... I>
+struct loophole_type_list_rref< T, std::index_sequence<I...> >
+     // Instantiating loopholes:
+    : sequence_tuple::tuple< decltype(T{ loophole_ubiq_rref<T, I>{}... }, 0) >
+{
+    using type = sequence_tuple::tuple< decltype(loophole(tag<T, I>{}))... >;
+};
+
+
+// Lazily returns loophole_type_list_{lr}ref.
+template <bool IsCopyConstructible /*= true*/, class T, class U>
+struct loophole_type_list_selector {
+    using type = loophole_type_list_lref<T, U>;
+};
+
+template <class T, class U>
+struct loophole_type_list_selector<false /*IsCopyConstructible*/, T, U> {
+    using type = loophole_type_list_rref<T, U>;
+};
+
+template <class T>
+auto tie_as_tuple_loophole_impl(T& lvalue) noexcept {
+    using type = std::remove_cv_t<std::remove_reference_t<T>>;
+    using indexes = detail::make_index_sequence<fields_count<type>()>;
+    using loophole_type_list = typename detail::loophole_type_list_selector<
+        std::is_copy_constructible<std::remove_all_extents_t<type>>::value, type, indexes
+    >::type;
+    using tuple_type = typename loophole_type_list::type;
+
+    return boost::pfr::detail::make_flat_tuple_of_references(
+        lvalue,
+        offset_based_getter<type, tuple_type>{},
+        size_t_<0>{},
+        size_t_<tuple_type::size_v>{}
+    );
+}
+
+template <class T>
+auto tie_as_tuple(T& val) noexcept {
+    static_assert(
+        !std::is_union<T>::value,
+        "====================> Boost.PFR: For safety reasons it is forbidden to reflect unions. See `Reflection of unions` section in the docs for more info."
+    );
+    return boost::pfr::detail::tie_as_tuple_loophole_impl(
+        val
+    );
+}
+
+template <class T, class F, std::size_t... I>
+void for_each_field_dispatcher(T& t, F&& f, std::index_sequence<I...>) {
+    static_assert(
+        !std::is_union<T>::value,
+        "====================> Boost.PFR: For safety reasons it is forbidden to reflect unions. See `Reflection of unions` section in the docs for more info."
+    );
+    std::forward<F>(f)(
+        boost::pfr::detail::tie_as_tuple_loophole_impl(t)
+    );
+}
+
+}}} // namespace boost::pfr::detail
+
+
+#ifdef __clang__
+#   pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#   pragma GCC diagnostic pop
+#endif
+
+
+#endif // BOOST_PFR_DETAIL_CORE14_LOOPHOLE_HPP
+
+#else
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_CORE14_CLASSIC_HPP
+#define BOOST_PFR_DETAIL_CORE14_CLASSIC_HPP
+
+
+#include <type_traits>
+#include <utility>      // metaprogramming stuff
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_SIZE_ARRAY_HPP
+#define BOOST_PFR_DETAIL_SIZE_ARRAY_HPP
+
+
+#include <cstddef>      // metaprogramming stuff
+
+namespace boost { namespace pfr { namespace detail {
+
+///////////////////// Array that has the constexpr
+template <std::size_t N>
+struct size_array {                         // libc++ misses constexpr on operator[]
+    typedef std::size_t type;
+    std::size_t data[N];
+
+    static constexpr std::size_t size() noexcept { return N; }
+
+    constexpr std::size_t count_nonzeros() const noexcept {
+        std::size_t count = 0;
+        for (std::size_t i = 0; i < size(); ++i) {
+            if (data[i]) {
+                ++ count;
+            }
+        }
+        return count;
+    }
+
+    constexpr std::size_t count_from_opening_till_matching_parenthis_seq(std::size_t from, std::size_t opening_parenthis, std::size_t closing_parenthis) const noexcept {
+        if (data[from] != opening_parenthis) {
+            return 0;
+        }
+        std::size_t unclosed_parnthesis = 0;
+        std::size_t count = 0;
+        for (; ; ++from) {
+            if (data[from] == opening_parenthis) {
+                ++ unclosed_parnthesis;
+            } else if (data[from] == closing_parenthis) {
+                -- unclosed_parnthesis;
+            }
+            ++ count;
+
+            if (unclosed_parnthesis == 0) {
+                return count;
+            }
+        }
+
+        return count;
+    }
+};
+
+template <>
+struct size_array<0> {                         // libc++ misses constexpr on operator[]
+    typedef std::size_t type;
+    std::size_t data[1];
+
+    static constexpr std::size_t size() noexcept { return 0; }
+
+    constexpr std::size_t count_nonzeros() const noexcept {
+        return 0;
+    }
+};
+
+template <std::size_t I, std::size_t N>
+constexpr std::size_t get(const size_array<N>& a) noexcept {
+    static_assert(I < N, "====================> Boost.PFR: Array index out of bounds");
+    return a.data[I];
+}
+
+
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_SIZE_ARRAY_HPP
+
+#ifdef __clang__
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wmissing-braces"
+#   pragma clang diagnostic ignored "-Wundefined-inline"
+#   pragma clang diagnostic ignored "-Wundefined-internal"
+#   pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
+namespace boost { namespace pfr { namespace detail {
+
+///////////////////// General utility stuff
+
+template <class T> struct identity {
+    typedef T type;
+};
+
+template <class T>
+constexpr T construct_helper() noexcept { // adding const here allows to deal with copyable only types
+    return {};
+}
+
+template <class T> constexpr size_array<sizeof(T) * 3> fields_count_and_type_ids_with_zeros() noexcept;
+template <class T> constexpr auto flat_array_of_type_ids() noexcept;
+
+///////////////////// All the stuff for representing Type as integer and converting integer back to type
+namespace typeid_conversions {
+
+///////////////////// Helper constants and typedefs
+
+#ifdef _MSC_VER
+#   pragma warning( push )
+    // '<<': check operator precedence for possible error; use parentheses to clarify precedence
+#   pragma warning( disable : 4554 )
+#endif
+
+constexpr std::size_t native_types_mask = 31;
+constexpr std::size_t bits_per_extension = 3;
+constexpr std::size_t extension_mask = (
+    static_cast<std::size_t>((1 << bits_per_extension) - 1)
+        << static_cast<std::size_t>(sizeof(std::size_t) * 8 - bits_per_extension)
+);
+constexpr std::size_t native_ptr_type = (
+    static_cast<std::size_t>(1)
+        << static_cast<std::size_t>(sizeof(std::size_t) * 8 - bits_per_extension)
+);
+constexpr std::size_t native_const_ptr_type = (
+    static_cast<std::size_t>(2)
+        << static_cast<std::size_t>(sizeof(std::size_t) * 8 - bits_per_extension)
+);
+
+constexpr std::size_t native_const_volatile_ptr_type = (
+    static_cast<std::size_t>(3)
+        << static_cast<std::size_t>(sizeof(std::size_t) * 8 - bits_per_extension)
+);
+
+constexpr std::size_t native_volatile_ptr_type = (
+    static_cast<std::size_t>(4)
+        << static_cast<std::size_t>(sizeof(std::size_t) * 8 - bits_per_extension)
+);
+
+constexpr std::size_t native_ref_type = (
+    static_cast<std::size_t>(5)
+        << static_cast<std::size_t>(sizeof(std::size_t) * 8 - bits_per_extension)
+);
+
+template <std::size_t Index, std::size_t Extension>
+using if_extension = std::enable_if_t< (Index & extension_mask) == Extension >*;
+
+///////////////////// Helper functions
+template <std::size_t Unptr>
+constexpr std::size_t type_to_id_extension_apply(std::size_t ext) noexcept {
+    constexpr std::size_t native_id = (Unptr & native_types_mask);
+    constexpr std::size_t extensions = (Unptr & ~native_types_mask);
+    static_assert(
+        !((extensions >> bits_per_extension) & native_types_mask),
+        "====================> Boost.PFR: Too many extensions for a single field (something close to `int************************** p;` is in the POD type)."
+    );
+
+    return (extensions >> bits_per_extension) | native_id | ext;
+}
+
+template <std::size_t Index>
+using remove_1_ext = size_t_<
+    ((Index & ~native_types_mask) << bits_per_extension) | (Index & native_types_mask)
+>;
+
+#ifdef _MSC_VER
+#   pragma warning( pop )
+#endif
+
+///////////////////// Forward declarations
+
+template <class Type> constexpr std::size_t type_to_id(identity<Type*>) noexcept;
+template <class Type> constexpr std::size_t type_to_id(identity<const Type*>) noexcept;
+template <class Type> constexpr std::size_t type_to_id(identity<const volatile Type*>) noexcept;
+template <class Type> constexpr std::size_t type_to_id(identity<volatile Type*>) noexcept;
+template <class Type> constexpr std::size_t type_to_id(identity<Type&>) noexcept;
+template <class Type> constexpr std::size_t type_to_id(identity<Type>, std::enable_if_t<std::is_enum<Type>::value>* = nullptr) noexcept;
+template <class Type> constexpr std::size_t type_to_id(identity<Type>, std::enable_if_t<std::is_empty<Type>::value>* = nullptr) noexcept;
+template <class Type> constexpr std::size_t type_to_id(identity<Type>, std::enable_if_t<std::is_union<Type>::value>* = nullptr) noexcept;
+template <class Type> constexpr size_array<sizeof(Type) * 3> type_to_id(identity<Type>, std::enable_if_t<!std::is_enum<Type>::value && !std::is_empty<Type>::value && !std::is_union<Type>::value>* = 0) noexcept;
+
+template <std::size_t Index> constexpr auto id_to_type(size_t_<Index >, if_extension<Index, native_const_ptr_type> = nullptr) noexcept;
+template <std::size_t Index> constexpr auto id_to_type(size_t_<Index >, if_extension<Index, native_ptr_type> = nullptr) noexcept;
+template <std::size_t Index> constexpr auto id_to_type(size_t_<Index >, if_extension<Index, native_const_volatile_ptr_type> = nullptr) noexcept;
+template <std::size_t Index> constexpr auto id_to_type(size_t_<Index >, if_extension<Index, native_volatile_ptr_type> = nullptr) noexcept;
+template <std::size_t Index> constexpr auto id_to_type(size_t_<Index >, if_extension<Index, native_ref_type> = nullptr) noexcept;
+
+
+///////////////////// Definitions of type_to_id and id_to_type for fundamental types
+/// @cond
+#define BOOST_MAGIC_GET_REGISTER_TYPE(Type, Index)              \
+    constexpr std::size_t type_to_id(identity<Type>) noexcept { \
+        return Index;                                           \
+    }                                                           \
+    constexpr Type id_to_type( size_t_<Index > ) noexcept {     \
+        return detail::construct_helper<Type>();                \
+    }                                                           \
+    /**/
+/// @endcond
+
+
+// Register all base types here
+BOOST_MAGIC_GET_REGISTER_TYPE(unsigned char         , 1)
+BOOST_MAGIC_GET_REGISTER_TYPE(unsigned short        , 2)
+BOOST_MAGIC_GET_REGISTER_TYPE(unsigned int          , 3)
+BOOST_MAGIC_GET_REGISTER_TYPE(unsigned long         , 4)
+BOOST_MAGIC_GET_REGISTER_TYPE(unsigned long long    , 5)
+BOOST_MAGIC_GET_REGISTER_TYPE(signed char           , 6)
+BOOST_MAGIC_GET_REGISTER_TYPE(short                 , 7)
+BOOST_MAGIC_GET_REGISTER_TYPE(int                   , 8)
+BOOST_MAGIC_GET_REGISTER_TYPE(long                  , 9)
+BOOST_MAGIC_GET_REGISTER_TYPE(long long             , 10)
+BOOST_MAGIC_GET_REGISTER_TYPE(char                  , 11)
+BOOST_MAGIC_GET_REGISTER_TYPE(wchar_t               , 12)
+BOOST_MAGIC_GET_REGISTER_TYPE(char16_t              , 13)
+BOOST_MAGIC_GET_REGISTER_TYPE(char32_t              , 14)
+BOOST_MAGIC_GET_REGISTER_TYPE(float                 , 15)
+BOOST_MAGIC_GET_REGISTER_TYPE(double                , 16)
+BOOST_MAGIC_GET_REGISTER_TYPE(long double           , 17)
+BOOST_MAGIC_GET_REGISTER_TYPE(bool                  , 18)
+BOOST_MAGIC_GET_REGISTER_TYPE(void*                 , 19)
+BOOST_MAGIC_GET_REGISTER_TYPE(const void*           , 20)
+BOOST_MAGIC_GET_REGISTER_TYPE(volatile void*        , 21)
+BOOST_MAGIC_GET_REGISTER_TYPE(const volatile void*  , 22)
+BOOST_MAGIC_GET_REGISTER_TYPE(std::nullptr_t        , 23)
+constexpr std::size_t tuple_begin_tag               = 24;
+constexpr std::size_t tuple_end_tag                 = 25;
+
+#undef BOOST_MAGIC_GET_REGISTER_TYPE
+
+///////////////////// Definitions of type_to_id and id_to_type for types with extensions and nested types
+template <class Type>
+constexpr std::size_t type_to_id(identity<Type*>) noexcept {
+    constexpr auto unptr = typeid_conversions::type_to_id(identity<Type>{});
+    static_assert(
+        std::is_same<const std::size_t, decltype(unptr)>::value,
+        "====================> Boost.PFR: Pointers to user defined types are not supported."
+    );
+    return typeid_conversions::type_to_id_extension_apply<unptr>(native_ptr_type);
+}
+
+template <class Type>
+constexpr std::size_t type_to_id(identity<const Type*>) noexcept {
+    constexpr auto unptr = typeid_conversions::type_to_id(identity<Type>{});
+    static_assert(
+        std::is_same<const std::size_t, decltype(unptr)>::value,
+        "====================> Boost.PFR: Const pointers to user defined types are not supported."
+    );
+    return typeid_conversions::type_to_id_extension_apply<unptr>(native_const_ptr_type);
+}
+
+template <class Type>
+constexpr std::size_t type_to_id(identity<const volatile Type*>) noexcept {
+    constexpr auto unptr = typeid_conversions::type_to_id(identity<Type>{});
+    static_assert(
+        std::is_same<const std::size_t, decltype(unptr)>::value,
+        "====================> Boost.PFR: Const volatile pointers to user defined types are not supported."
+    );
+    return typeid_conversions::type_to_id_extension_apply<unptr>(native_const_volatile_ptr_type);
+}
+
+template <class Type>
+constexpr std::size_t type_to_id(identity<volatile Type*>) noexcept {
+    constexpr auto unptr = typeid_conversions::type_to_id(identity<Type>{});
+    static_assert(
+        std::is_same<const std::size_t, decltype(unptr)>::value,
+        "====================> Boost.PFR: Volatile pointers to user defined types are not supported."
+    );
+    return typeid_conversions::type_to_id_extension_apply<unptr>(native_volatile_ptr_type);
+}
+
+template <class Type>
+constexpr std::size_t type_to_id(identity<Type&>) noexcept {
+    constexpr auto unptr = typeid_conversions::type_to_id(identity<Type>{});
+    static_assert(
+        std::is_same<const std::size_t, decltype(unptr)>::value,
+        "====================> Boost.PFR: References to user defined types are not supported."
+    );
+    return typeid_conversions::type_to_id_extension_apply<unptr>(native_ref_type);
+}
+
+template <class Type>
+constexpr std::size_t type_to_id(identity<Type>, std::enable_if_t<std::is_enum<Type>::value>*) noexcept {
+    return typeid_conversions::type_to_id(identity<typename std::underlying_type<Type>::type >{});
+}
+
+template <class Type>
+constexpr std::size_t type_to_id(identity<Type>, std::enable_if_t<std::is_empty<Type>::value>*) noexcept {
+    static_assert(!std::is_empty<Type>::value, "====================> Boost.PFR: Empty classes/structures as members are not supported.");
+    return 0;
+}
+
+template <class Type>
+constexpr std::size_t type_to_id(identity<Type>, std::enable_if_t<std::is_union<Type>::value>*) noexcept {
+    static_assert(
+        !std::is_union<Type>::value,
+        "====================> Boost.PFR: For safety reasons it is forbidden to reflect unions. See `Reflection of unions` section in the docs for more info."
+    );
+    return 0;
+}
+
+template <class Type>
+constexpr size_array<sizeof(Type) * 3> type_to_id(identity<Type>, std::enable_if_t<!std::is_enum<Type>::value && !std::is_empty<Type>::value && !std::is_union<Type>::value>*) noexcept {
+    constexpr auto t = detail::flat_array_of_type_ids<Type>();
+    size_array<sizeof(Type) * 3> result {{tuple_begin_tag}};
+    constexpr bool requires_tuplening = (
+        (t.count_nonzeros() != 1)  || (t.count_nonzeros() == t.count_from_opening_till_matching_parenthis_seq(0, tuple_begin_tag, tuple_end_tag))
+    );
+
+    if (requires_tuplening) {
+        for (std::size_t i = 0; i < t.size(); ++i)
+            result.data[i + 1] = t.data[i];
+        result.data[result.size() - 1] = tuple_end_tag;
+    } else {
+        for (std::size_t i = 0; i < t.size(); ++i)
+            result.data[i] = t.data[i];
+    }
+    return result;
+}
+
+
+
+template <std::size_t Index>
+constexpr auto id_to_type(size_t_<Index >, if_extension<Index, native_ptr_type>) noexcept {
+    typedef decltype( typeid_conversions::id_to_type(remove_1_ext<Index>()) )* res_t;
+    return detail::construct_helper<res_t>();
+}
+
+template <std::size_t Index>
+constexpr auto id_to_type(size_t_<Index >, if_extension<Index, native_const_ptr_type>) noexcept {
+    typedef const decltype( typeid_conversions::id_to_type(remove_1_ext<Index>()) )* res_t;
+    return detail::construct_helper<res_t>();
+}
+
+template <std::size_t Index>
+constexpr auto id_to_type(size_t_<Index >, if_extension<Index, native_const_volatile_ptr_type>) noexcept {
+    typedef const volatile decltype( typeid_conversions::id_to_type(remove_1_ext<Index>()) )* res_t;
+    return detail::construct_helper<res_t>();
+}
+
+
+template <std::size_t Index>
+constexpr auto id_to_type(size_t_<Index >, if_extension<Index, native_volatile_ptr_type>) noexcept {
+    typedef volatile decltype( typeid_conversions::id_to_type(remove_1_ext<Index>()) )* res_t;
+    return detail::construct_helper<res_t>();
+}
+
+
+template <std::size_t Index>
+constexpr auto id_to_type(size_t_<Index >, if_extension<Index, native_ref_type>) noexcept {
+    static_assert(!Index, "====================> Boost.PFR: References are not supported");
+    return nullptr;
+}
+
+} // namespace typeid_conversions
+
+///////////////////// Structure that remembers types as integers on a `constexpr operator Type()` call
+struct ubiq_val {
+    std::size_t* ref_;
+
+    template <class T>
+    constexpr void assign(const T& typeids) const noexcept {
+        for (std::size_t i = 0; i < T::size(); ++i)
+            ref_[i] = typeids.data[i];
+    }
+
+    constexpr void assign(std::size_t val) const noexcept {
+        ref_[0] = val;
+    }
+
+    template <class Type>
+    constexpr operator Type() const noexcept {
+        constexpr auto typeids = typeid_conversions::type_to_id(identity<Type>{});
+        assign(typeids);
+        return detail::construct_helper<Type>();
+    }
+};
+
+///////////////////// Structure that remembers size of the type on a `constexpr operator Type()` call
+struct ubiq_sizes {
+    std::size_t& ref_;
+
+    template <class Type>
+    constexpr operator Type() const noexcept {
+        ref_ = sizeof(Type);
+        return detail::construct_helper<Type>();
+    }
+};
+
+///////////////////// Returns array of (offsets without accounting alignments). Required for keeping places for nested type ids
+template <class T, std::size_t N, std::size_t... I>
+constexpr size_array<N> get_type_offsets() noexcept {
+    typedef size_array<N> array_t;
+    array_t sizes{};
+    T tmp{ ubiq_sizes{sizes.data[I]}... };
+    (void)tmp;
+
+    array_t offsets{{0}};
+    for (std::size_t i = 1; i < N; ++i)
+        offsets.data[i] = offsets.data[i - 1] + sizes.data[i - 1];
+
+    return offsets;
+}
+
+///////////////////// Returns array of typeids and zeros if constructor of a type accepts sizeof...(I) parameters
+template <class T, std::size_t N, std::size_t... I>
+constexpr void* flat_type_to_array_of_type_ids(std::size_t* types, std::index_sequence<I...>) noexcept
+{
+    static_assert(
+        N <= sizeof(T),
+        "====================> Boost.PFR: Bit fields are not supported."
+    );
+
+    constexpr auto offsets = detail::get_type_offsets<T, N, I...>();
+    T tmp{ ubiq_val{types + get<I>(offsets) * 3}... };
+    (void)types;
+    (void)tmp;
+    (void)offsets; // If type is empty offsets are not used
+    return nullptr;
+}
+
+///////////////////// Returns array of typeids and zeros
+template <class T>
+constexpr size_array<sizeof(T) * 3> fields_count_and_type_ids_with_zeros() noexcept {
+    size_array<sizeof(T) * 3> types{};
+    constexpr std::size_t N = detail::fields_count<T>();
+    detail::flat_type_to_array_of_type_ids<T, N>(types.data, detail::make_index_sequence<N>());
+    return types;
+}
+
+///////////////////// Returns array of typeids without zeros
+template <class T>
+constexpr auto flat_array_of_type_ids() noexcept {
+    constexpr auto types = detail::fields_count_and_type_ids_with_zeros<T>();
+    constexpr std::size_t count = types.count_nonzeros();
+    size_array<count> res{};
+    std::size_t j = 0;
+    for (std::size_t i = 0; i < decltype(types)::size(); ++i) {
+        if (types.data[i]) {
+            res.data[j] = types.data[i];
+            ++ j;
+        }
+    }
+
+    return res;
+}
+
+///////////////////// Convert array of typeids into sequence_tuple::tuple
+
+template <class T, std::size_t First, std::size_t... I>
+constexpr auto as_flat_tuple_impl(std::index_sequence<First, I...>) noexcept;
+
+template <class T>
+constexpr sequence_tuple::tuple<> as_flat_tuple_impl(std::index_sequence<>) noexcept {
+    return sequence_tuple::tuple<>{};
+}
+
+template <std::size_t Increment, std::size_t... I>
+constexpr auto increment_index_sequence(std::index_sequence<I...>) noexcept {
+    return std::index_sequence<I + Increment...>{};
+}
+
+template <class T, std::size_t V, std::size_t I, std::size_t SubtupleLength>
+constexpr auto prepare_subtuples(size_t_<V>, size_t_<I>, size_t_<SubtupleLength>) noexcept {
+    static_assert(SubtupleLength == 0, "====================> Boost.PFR: Internal error while representing nested field as tuple");
+    return typeid_conversions::id_to_type(size_t_<V>{});
+}
+
+template <class T, std::size_t I, std::size_t SubtupleLength>
+constexpr auto prepare_subtuples(size_t_<typeid_conversions::tuple_end_tag>, size_t_<I>, size_t_<SubtupleLength>) noexcept {
+    static_assert(sizeof(T) == 0, "====================> Boost.PFR: Internal error while representing nested field as tuple");
+    return int{};
+}
+
+template <class T, std::size_t I, std::size_t SubtupleLength>
+constexpr auto prepare_subtuples(size_t_<typeid_conversions::tuple_begin_tag>, size_t_<I>, size_t_<SubtupleLength>) noexcept {
+    static_assert(SubtupleLength > 2, "====================> Boost.PFR: Internal error while representing nested field as tuple");
+    constexpr auto seq = detail::make_index_sequence<SubtupleLength - 2>{};
+    return detail::as_flat_tuple_impl<T>( detail::increment_index_sequence<I + 1>(seq) );
+}
+
+
+template <class Array>
+constexpr Array remove_subtuples(Array indexes_plus_1, const Array& subtuple_lengths) noexcept {
+    for (std::size_t i = 0; i < subtuple_lengths.size(); ++i) {
+        if (subtuple_lengths.data[i]) {
+            const std::size_t skips_count = subtuple_lengths.data[i];
+            for (std::size_t j = i + 1; j < skips_count + i; ++j) {
+                indexes_plus_1.data[j] = 0;
+            }
+            i += skips_count - 1;
+        }
+    }
+    return indexes_plus_1;
+}
+
+template <std::size_t N, class Array>
+constexpr size_array<N> resize_dropping_zeros_and_decrementing(size_t_<N>, const Array& a) noexcept {
+    size_array<N> result{};
+    std::size_t result_indx = 0;
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        if (a.data[i]) {
+            result.data[result_indx] = static_cast<std::size_t>(a.data[i] - 1);
+            ++ result_indx;
+        }
+    }
+
+    return result;
+}
+
+template <class T, std::size_t First, std::size_t... I, std::size_t... INew>
+constexpr auto as_flat_tuple_impl_drop_helpers(std::index_sequence<First, I...>, std::index_sequence<INew...>) noexcept {
+    constexpr auto a = detail::flat_array_of_type_ids<T>();
+
+    constexpr size_array<sizeof...(I) + 1> subtuples_length {{
+        a.count_from_opening_till_matching_parenthis_seq(First, typeid_conversions::tuple_begin_tag, typeid_conversions::tuple_end_tag),
+        a.count_from_opening_till_matching_parenthis_seq(I, typeid_conversions::tuple_begin_tag, typeid_conversions::tuple_end_tag)...
+    }};
+
+    constexpr size_array<sizeof...(I) + 1> type_indexes_with_subtuple_internals {{ 1, 1 + I - First...}};
+    constexpr auto type_indexes_plus_1_and_zeros_as_skips = detail::remove_subtuples(type_indexes_with_subtuple_internals, subtuples_length);
+    constexpr auto new_size = size_t_<type_indexes_plus_1_and_zeros_as_skips.count_nonzeros()>{};
+    constexpr auto type_indexes = detail::resize_dropping_zeros_and_decrementing(new_size, type_indexes_plus_1_and_zeros_as_skips);
+
+    typedef sequence_tuple::tuple<
+        decltype(detail::prepare_subtuples<T>(
+            size_t_< a.data[ First + type_indexes.data[INew] ]          >{},    // id of type
+            size_t_< First + type_indexes.data[INew]                    >{},    // index of current id in `a`
+            size_t_< subtuples_length.data[ type_indexes.data[INew] ]   >{}     // if id of type is tuple, then length of that tuple
+        ))...
+    > subtuples_uncleanuped_t;
+
+    return subtuples_uncleanuped_t{};
+}
+
+template <class Array>
+constexpr std::size_t count_skips_in_array(std::size_t begin_index, std::size_t end_index, const Array& a) noexcept {
+    std::size_t skips = 0;
+    for (std::size_t i = begin_index; i < end_index; ++i) {
+        if (a.data[i] == typeid_conversions::tuple_begin_tag) {
+            const std::size_t this_tuple_size = a.count_from_opening_till_matching_parenthis_seq(i, typeid_conversions::tuple_begin_tag, typeid_conversions::tuple_end_tag) - 1;
+            skips += this_tuple_size;
+            i += this_tuple_size - 1;
+        }
+    }
+
+    return skips;
+}
+
+template <class T, std::size_t First, std::size_t... I>
+constexpr auto as_flat_tuple_impl(std::index_sequence<First, I...>) noexcept {
+    constexpr auto a = detail::flat_array_of_type_ids<T>();
+    constexpr std::size_t count_of_I = sizeof...(I);
+
+    return detail::as_flat_tuple_impl_drop_helpers<T>(
+        std::index_sequence<First, I...>{},
+        detail::make_index_sequence< 1 + count_of_I - count_skips_in_array(First, First + count_of_I, a) >{}
+    );
+}
+
+template <class T>
+constexpr auto internal_tuple_with_same_alignment() noexcept {
+    typedef typename std::remove_cv<T>::type type;
+
+    static_assert(
+        std::is_trivial<type>::value && std::is_standard_layout<type>::value,
+        "====================> Boost.PFR: Type can not be reflected without Loophole or C++17, because it's not POD"
+    );
+    static_assert(!std::is_reference<type>::value, "====================> Boost.PFR: Not applyable");
+    constexpr auto res = detail::as_flat_tuple_impl<type>(
+        detail::make_index_sequence< decltype(detail::flat_array_of_type_ids<type>())::size() >()
+    );
+
+    return res;
+}
+
+template <class T>
+using internal_tuple_with_same_alignment_t = decltype( detail::internal_tuple_with_same_alignment<T>() );
+
+
+///////////////////// Flattening
+struct ubiq_is_flat_refelectable {
+    bool& is_flat_refelectable;
+
+    template <class Type>
+    constexpr operator Type() const noexcept {
+        is_flat_refelectable = std::is_fundamental<std::remove_pointer_t<Type>>::value;
+        return {};
+    }
+};
+
+template <class T, std::size_t... I>
+constexpr bool is_flat_refelectable(std::index_sequence<I...>) noexcept {
+    constexpr std::size_t fields = sizeof...(I);
+    bool result[fields] = {static_cast<bool>(I)...};
+    const T v{ ubiq_is_flat_refelectable{result[I]}... };
+    (void)v;
+
+    for (std::size_t i = 0; i < fields; ++i) {
+        if (!result[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+template<class T>
+constexpr bool is_flat_refelectable(std::index_sequence<>) noexcept {
+    return true; ///< all empty structs always flat refelectable
+}
+
+template <class T>
+auto tie_as_flat_tuple(T& lvalue) noexcept {
+    static_assert(
+        !std::is_union<T>::value,
+        "====================> Boost.PFR: For safety reasons it is forbidden to reflect unions. See `Reflection of unions` section in the docs for more info."
+    );
+    using type = std::remove_cv_t<T>;
+    using tuple_type = internal_tuple_with_same_alignment_t<type>;
+
+    offset_based_getter<type, tuple_type> getter;
+    return boost::pfr::detail::make_flat_tuple_of_references(lvalue, getter, size_t_<0>{}, size_t_<tuple_type::size_v>{});
+}
+
+template <class T>
+auto tie_as_tuple(T& val) noexcept {
+    static_assert(
+        !std::is_union<T>::value,
+        "====================> Boost.PFR: For safety reasons it is forbidden to reflect unions. See `Reflection of unions` section in the docs for more info."
+    );
+    static_assert(
+        boost::pfr::detail::is_flat_refelectable<T>( detail::make_index_sequence<boost::pfr::detail::fields_count<T>()>{} ),
+        "====================> Boost.PFR: Not possible in C++14 to represent that type without loosing information. Change type definition or enable C++17"
+    );
+    return boost::pfr::detail::tie_as_flat_tuple(val);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+///////////////////// Structure that can be converted to copy of anything
+struct ubiq_constructor_constexpr_copy {
+    std::size_t ignore;
+
+    template <class Type>
+    constexpr operator Type() const noexcept {
+        static_assert(
+            std::is_trivially_destructible<Type>::value,
+            "====================> Boost.PFR: One of the fields in the type passed to `for_each_field` has non trivial destructor."
+        );
+        return {};
+    }
+};
+
+/////////////////////
+
+template <class T, std::size_t... I>
+struct is_constexpr_aggregate_initializable {
+    template<class T2, std::size_t... I2>
+    static constexpr void* constexpr_aggregate_initializer() noexcept {
+        T2 tmp{ ubiq_constructor_constexpr_copy{I2}... };
+        (void)tmp;
+        return nullptr;
+    }
+
+    template <void* = constexpr_aggregate_initializer<T, I...>() >
+    static std::true_type test(long) noexcept;
+
+    static std::false_type test(...) noexcept;
+
+    static constexpr bool value = decltype(test(0)){};
+};
+
+
+template <class T, class F, std::size_t I0, std::size_t... I, class... Fields>
+void for_each_field_in_depth(T& t, F&& f, std::index_sequence<I0, I...>, identity<Fields>...);
+
+template <class T, class F, class... Fields>
+void for_each_field_in_depth(T& t, F&& f, std::index_sequence<>, identity<Fields>...);
+
+template <class T, class F, class IndexSeq, class... Fields>
+struct next_step {
+    T& t;
+    F& f;
+
+    template <class Field>
+    operator Field() const {
+         boost::pfr::detail::for_each_field_in_depth(
+             t,
+             std::forward<F>(f),
+             IndexSeq{},
+             identity<Fields>{}...,
+             identity<Field>{}
+         );
+
+         return {};
+    }
+};
+
+template <class T, class F, std::size_t I0, std::size_t... I, class... Fields>
+void for_each_field_in_depth(T& t, F&& f, std::index_sequence<I0, I...>, identity<Fields>...) {
+    (void)std::add_const_t<std::remove_reference_t<T>>{
+        Fields{}...,
+        next_step<T, F, std::index_sequence<I...>, Fields...>{t, f},
+        ubiq_constructor_constexpr_copy{I}...
+    };
+}
+
+template <class T, class F, class... Fields>
+void for_each_field_in_depth(T& lvalue, F&& f, std::index_sequence<>, identity<Fields>...) {
+    using tuple_type = sequence_tuple::tuple<Fields...>;
+
+    offset_based_getter<std::remove_cv_t<std::remove_reference_t<T>>, tuple_type> getter;
+    std::forward<F>(f)(
+        boost::pfr::detail::make_flat_tuple_of_references(lvalue, getter, size_t_<0>{}, size_t_<sizeof...(Fields)>{})
+    );
+}
+
+template <class T, class F, std::size_t... I>
+void for_each_field_dispatcher_1(T& t, F&& f, std::index_sequence<I...>, std::true_type /*is_flat_refelectable*/) {
+    std::forward<F>(f)(
+        boost::pfr::detail::tie_as_flat_tuple(t)
+    );
+}
+
+
+template <class T, class F, std::size_t... I>
+void for_each_field_dispatcher_1(T& t, F&& f, std::index_sequence<I...>, std::false_type /*is_flat_refelectable*/) {
+    boost::pfr::detail::for_each_field_in_depth(
+        t,
+        std::forward<F>(f),
+        std::index_sequence<I...>{}
+    );
+}
+
+template <class T, class F, std::size_t... I>
+void for_each_field_dispatcher(T& t, F&& f, std::index_sequence<I...>) {
+    static_assert(
+        !std::is_union<T>::value,
+        "====================> Boost.PFR: For safety reasons it is forbidden to reflect unions. See `Reflection of unions` section in the docs for more info."
+    );
+    static_assert(is_constexpr_aggregate_initializable<T, I...>::value, "====================> Boost.PFR: T must be a constexpr initializable type");
+
+    constexpr bool is_flat_refelectable_val = detail::is_flat_refelectable<T>( std::index_sequence<I...>{} );
+    detail::for_each_field_dispatcher_1(
+        t,
+        std::forward<F>(f),
+        std::index_sequence<I...>{},
+        std::integral_constant<bool, is_flat_refelectable_val>{}
+    );
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifdef __clang__
+#   pragma clang diagnostic pop
+#endif
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_CORE14_CLASSIC_HPP
+#endif
+
+#endif // BOOST_PFR_DETAIL_CORE_HPP
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_STDTUPLE_HPP
+#define BOOST_PFR_DETAIL_STDTUPLE_HPP
+
+
+#include <utility>      // metaprogramming stuff
+#include <tuple>
+
+
+namespace boost { namespace pfr { namespace detail {
+
+template <class T, std::size_t... I>
+constexpr auto make_stdtuple_from_tietuple(const T& t, std::index_sequence<I...>) noexcept {
+    return std::make_tuple(
+        boost::pfr::detail::sequence_tuple::get<I>(t)...
+    );
+}
+
+template <class T, std::size_t... I>
+constexpr auto make_stdtiedtuple_from_tietuple(const T& t, std::index_sequence<I...>) noexcept {
+    return std::tie(
+        boost::pfr::detail::sequence_tuple::get<I>(t)...
+    );
+}
+
+template <class T, std::size_t... I>
+constexpr auto make_conststdtiedtuple_from_tietuple(const T& t, std::index_sequence<I...>) noexcept {
+    return std::tuple<
+        std::add_lvalue_reference_t<std::add_const_t<
+            std::remove_reference_t<decltype(boost::pfr::detail::sequence_tuple::get<I>(t))>
+        >>...
+    >(
+        boost::pfr::detail::sequence_tuple::get<I>(t)...
+    );
+}
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_STDTUPLE_HPP
+// Copyright (c) 2018 Adam Butcher, Antony Polukhin
+// Copyright (c) 2019-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_TIE_FROM_STRUCTURE_TUPLE_HPP
+#define BOOST_PFR_DETAIL_TIE_FROM_STRUCTURE_TUPLE_HPP
+
+
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#ifndef BOOST_PFR_TUPLE_SIZE_HPP
+#define BOOST_PFR_TUPLE_SIZE_HPP
+
+
+#include <type_traits>
+#include <utility>      // metaprogramming stuff
+
+
+/// \file boost/pfr/tuple_size.hpp
+/// Contains tuple-like interfaces to get fields count \forcedlink{tuple_size}, \forcedlink{tuple_size_v}.
+///
+/// \b Synopsis:
+namespace boost { namespace pfr {
+
+/// Has a static const member variable `value` that contains fields count in a T.
+/// Works for any T that satisfies \aggregate.
+///
+/// \b Example:
+/// \code
+///     std::array<int, boost::pfr::tuple_size<my_structure>::value > a;
+/// \endcode
+template <class T>
+using tuple_size = detail::size_t_< boost::pfr::detail::fields_count<T>() >;
+
+
+/// `tuple_size_v` is a template variable that contains fields count in a T and
+/// works for any T that satisfies \aggregate.
+///
+/// \b Example:
+/// \code
+///     std::array<int, boost::pfr::tuple_size_v<my_structure> > a;
+/// \endcode
+template <class T>
+constexpr std::size_t tuple_size_v = tuple_size<T>::value;
+
+}} // namespace boost::pfr
+
+#endif // BOOST_PFR_TUPLE_SIZE_HPP
+
+#include <tuple>
+
+namespace boost { namespace pfr { namespace detail {
+
+/// \brief A `std::tuple` capable of de-structuring assignment used to support
+/// a tie of multiple lvalue references to fields of an aggregate T.
+///
+/// \sa boost::pfr::tie_from_structure
+template <typename... Elements>
+struct tie_from_structure_tuple : std::tuple<Elements&...> {
+    using base = std::tuple<Elements&...>;
+    using base::base;
+
+    template <typename T>
+    constexpr tie_from_structure_tuple& operator= (T const& t) {
+        base::operator=(
+            detail::make_stdtiedtuple_from_tietuple(
+                detail::tie_as_tuple(t),
+                detail::make_index_sequence<tuple_size_v<T>>()));
+        return *this;
+    }
+};
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_TIE_FROM_STRUCTURE_TUPLE_HPP
+
+#include <type_traits>
+#include <utility>      // metaprogramming stuff
+
+
+/// \file boost/pfr/core.hpp
+/// Contains all the basic tuple-like interfaces \forcedlink{get}, \forcedlink{tuple_size}, \forcedlink{tuple_element_t}, and others.
+///
+/// \b Synopsis:
+
+namespace boost { namespace pfr {
+
+/// \brief Returns reference or const reference to a field with index `I` in \aggregate `val`.
+/// Overload taking the type `U` returns reference or const reference to a field
+/// with provided type `U` in \aggregate `val` if there's only one field of such type in `val`.
+///
+/// \b Example:
+/// \code
+///     struct my_struct { int i, short s; };
+///     my_struct s {10, 11};
+///
+///     assert(boost::pfr::get<0>(s) == 10);
+///     boost::pfr::get<1>(s) = 0;
+///
+///     assert(boost::pfr::get<int>(s) == 10);
+///     boost::pfr::get<short>(s) = 11;
+/// \endcode
+template <std::size_t I, class T>
+constexpr decltype(auto) get(const T& val) noexcept {
+    return detail::sequence_tuple::get<I>( detail::tie_as_tuple(val) );
+}
+
+/// \overload get
+template <std::size_t I, class T>
+constexpr decltype(auto) get(T& val
+#if !BOOST_PFR_USE_CPP17
+    , std::enable_if_t<std::is_assignable<T, T>::value>* = nullptr
+#endif
+) noexcept {
+    return detail::sequence_tuple::get<I>( detail::tie_as_tuple(val) );
+}
+
+#if !BOOST_PFR_USE_CPP17
+/// \overload get
+template <std::size_t I, class T>
+constexpr auto get(T&, std::enable_if_t<!std::is_assignable<T, T>::value>* = nullptr) noexcept {
+    static_assert(sizeof(T) && false, "====================> Boost.PFR: Calling boost::pfr::get on non const non assignable type is allowed only in C++17");
+    return 0;
+}
+#endif
+
+
+/// \overload get
+template <std::size_t I, class T>
+constexpr auto get(T&& val, std::enable_if_t< std::is_rvalue_reference<T&&>::value>* = nullptr) noexcept {
+    return std::move(detail::sequence_tuple::get<I>( detail::tie_as_tuple(val) ));
+}
+
+
+/// \overload get
+template <class U, class T>
+constexpr const U& get(const T& val) noexcept {
+    return detail::sequence_tuple::get_by_type_impl<const U&>( detail::tie_as_tuple(val) );
+}
+
+
+/// \overload get
+template <class U, class T>
+constexpr U& get(T& val
+#if !BOOST_PFR_USE_CPP17
+    , std::enable_if_t<std::is_assignable<T, T>::value>* = nullptr
+#endif
+) noexcept {
+    return detail::sequence_tuple::get_by_type_impl<U&>( detail::tie_as_tuple(val) );
+}
+
+#if !BOOST_PFR_USE_CPP17
+/// \overload get
+template <class U, class T>
+constexpr U& get(T&, std::enable_if_t<!std::is_assignable<T, T>::value>* = nullptr) noexcept {
+    static_assert(sizeof(T) && false, "====================> Boost.PFR: Calling boost::pfr::get on non const non assignable type is allowed only in C++17");
+    return 0;
+}
+#endif
+
+
+/// \overload get
+template <class U, class T>
+constexpr U&& get(T&& val, std::enable_if_t< std::is_rvalue_reference<T&&>::value>* = nullptr) noexcept {
+    return std::move(detail::sequence_tuple::get_by_type_impl<U&>( detail::tie_as_tuple(val) ));
+}
+
+
+/// \brief `tuple_element` has a member typedef `type` that returns the type of a field with index I in \aggregate T.
+///
+/// \b Example:
+/// \code
+///     std::vector< boost::pfr::tuple_element<0, my_structure>::type > v;
+/// \endcode
+template <std::size_t I, class T>
+using tuple_element = detail::sequence_tuple::tuple_element<I, decltype( ::boost::pfr::detail::tie_as_tuple(std::declval<T&>()) ) >;
+
+
+/// \brief Type of a field with index `I` in \aggregate `T`.
+///
+/// \b Example:
+/// \code
+///     std::vector< boost::pfr::tuple_element_t<0, my_structure> > v;
+/// \endcode
+template <std::size_t I, class T>
+using tuple_element_t = typename tuple_element<I, T>::type;
+
+
+/// \brief Creates a `std::tuple` from fields of an \aggregate `val`.
+///
+/// \b Example:
+/// \code
+///     struct my_struct { int i, short s; };
+///     my_struct s {10, 11};
+///     std::tuple<int, short> t = boost::pfr::structure_to_tuple(s);
+///     assert(get<0>(t) == 10);
+/// \endcode
+template <class T>
+constexpr auto structure_to_tuple(const T& val) noexcept {
+    return detail::make_stdtuple_from_tietuple(
+        detail::tie_as_tuple(val),
+        detail::make_index_sequence< tuple_size_v<T> >()
+    );
+}
+
+
+/// \brief std::tie` like function that ties fields of a structure.
+///
+/// \returns a `std::tuple` with lvalue and const lvalue references to fields of an \aggregate `val`.
+///
+/// \b Example:
+/// \code
+///     void foo(const int&, const short&);
+///     struct my_struct { int i, short s; };
+///
+///     const my_struct const_s{1, 2};
+///     std::apply(foo, boost::pfr::structure_tie(const_s));
+///
+///     my_struct s;
+///     boost::pfr::structure_tie(s) = std::tuple<int, short>{10, 11};
+///     assert(s.s == 11);
+/// \endcode
+template <class T>
+constexpr auto structure_tie(const T& val) noexcept {
+    return detail::make_conststdtiedtuple_from_tietuple(
+        detail::tie_as_tuple(const_cast<T&>(val)),
+        detail::make_index_sequence< tuple_size_v<T> >()
+    );
+}
+
+
+/// \overload structure_tie
+template <class T>
+constexpr auto structure_tie(T& val
+#if !BOOST_PFR_USE_CPP17
+    , std::enable_if_t<std::is_assignable<T, T>::value>* = nullptr
+#endif
+) noexcept {
+    return detail::make_stdtiedtuple_from_tietuple(
+        detail::tie_as_tuple(val),
+        detail::make_index_sequence< tuple_size_v<T> >()
+    );
+}
+
+#if !BOOST_PFR_USE_CPP17
+/// \overload structure_tie
+template <class T>
+constexpr auto structure_tie(T&, std::enable_if_t<!std::is_assignable<T, T>::value>* = nullptr) noexcept {
+    static_assert(sizeof(T) && false, "====================> Boost.PFR: Calling boost::pfr::structure_tie on non const non assignable type is allowed only in C++17");
+    return 0;
+}
+#endif
+
+
+/// \overload structure_tie
+template <class T>
+constexpr auto structure_tie(T&&, std::enable_if_t< std::is_rvalue_reference<T&&>::value>* = nullptr) noexcept {
+    static_assert(sizeof(T) && false, "====================> Boost.PFR: Calling boost::pfr::structure_tie on rvalue references is forbidden");
+    return 0;
+}
+
+/// Calls `func` for each field of a `value`.
+///
+/// \param func must have one of the following signatures:
+///     * any_return_type func(U&& field)                // field of value is perfect forwarded to function
+///     * any_return_type func(U&& field, std::size_t i)
+///     * any_return_type func(U&& value, I i)           // Here I is an `std::integral_constant<size_t, field_index>`
+///
+/// \param value To each field of this variable will be the `func` applied.
+///
+/// \b Example:
+/// \code
+///     struct my_struct { int i, short s; };
+///     int sum = 0;
+///     boost::pfr::for_each_field(my_struct{20, 22}, [&sum](const auto& field) { sum += field; });
+///     assert(sum == 42);
+/// \endcode
+template <class T, class F>
+constexpr void for_each_field(T&& value, F&& func) {
+    constexpr std::size_t fields_count_val = boost::pfr::detail::fields_count<std::remove_reference_t<T>>();
+
+    ::boost::pfr::detail::for_each_field_dispatcher(
+        value,
+        [f = std::forward<F>(func)](auto&& t) mutable {
+            // MSVC related workaround. Its lambdas do not capture constexprs.
+            constexpr std::size_t fields_count_val_in_lambda
+                = boost::pfr::detail::fields_count<std::remove_reference_t<T>>();
+
+            ::boost::pfr::detail::for_each_field_impl(
+                t,
+                std::forward<F>(f),
+                detail::make_index_sequence<fields_count_val_in_lambda>{},
+                std::is_rvalue_reference<T&&>{}
+            );
+        },
+        detail::make_index_sequence<fields_count_val>{}
+    );
+}
+
+/// \brief std::tie-like function that allows assigning to tied values from aggregates.
+///
+/// \returns an object with lvalue references to `args...`; on assignment of an \aggregate value to that
+/// object each field of an aggregate is assigned to the corresponding `args...` reference.
+///
+/// \b Example:
+/// \code
+///     auto f() {
+///       struct { struct { int x, y } p; short s; } res { { 4, 5 }, 6 };
+///       return res;
+///     }
+///     auto [p, s] = f();
+///     boost::pfr::tie_from_structure(p, s) = f();
+/// \endcode
+template <typename... Elements>
+constexpr detail::tie_from_structure_tuple<Elements...> tie_from_structure(Elements&... args) noexcept {
+    return detail::tie_from_structure_tuple<Elements...>(args...);
+}
+
+}} // namespace boost::pfr
+
+#endif // BOOST_PFR_CORE_HPP
+// Copyright (c) 2023 Bela Schaum, X-Ryl669, Denis Mikhailov.
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+// Initial implementation by Bela Schaum, https://github.com/schaumb
+// The way to make it union and UB free by X-Ryl669, https://github.com/X-Ryl669
+//
+
+#ifndef BOOST_PFR_CORE_NAME_HPP
+#define BOOST_PFR_CORE_NAME_HPP
+
+
+// Copyright (c) 2023 Bela Schaum, X-Ryl669, Denis Mikhailov.
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+// Initial implementation by Bela Schaum, https://github.com/schaumb
+// The way to make it union and UB free by X-Ryl669, https://github.com/X-Ryl669
+//
+
+#ifndef BOOST_PFR_DETAIL_CORE_NAME_HPP
+#define BOOST_PFR_DETAIL_CORE_NAME_HPP
+
+
+// Each core_name provides `boost::pfr::detail::get_name` and
+// `boost::pfr::detail::tie_as_names_tuple` functions.
+//
+// The whole functional of extracting field's names is build on top of those
+// two functions.
+#if BOOST_PFR_CORE_NAME_ENABLED
+// Copyright (c) 2023 Bela Schaum, X-Ryl669, Denis Mikhailov.
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+// Initial implementation by Bela Schaum, https://github.com/schaumb
+// The way to make it union and UB free by X-Ryl669, https://github.com/X-Ryl669
+//
+
+#ifndef BOOST_PFR_DETAIL_CORE_NAME20_STATIC_HPP
+#define BOOST_PFR_DETAIL_CORE_NAME20_STATIC_HPP
+
+// Copyright (c) 2023 Denis Mikhailov
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_STDARRAY_HPP
+#define BOOST_PFR_DETAIL_STDARRAY_HPP
+
+
+#include <utility> // metaprogramming stuff
+#include <array>
+#include <type_traits> // for std::common_type_t
+#include <cstddef>
+
+
+namespace boost { namespace pfr { namespace detail {
+
+template <class... Types>
+constexpr auto make_stdarray(const Types&... t) noexcept {
+    return std::array<std::common_type_t<Types...>, sizeof...(Types)>{t...};
+}
+
+template <class T, std::size_t... I>
+constexpr auto make_stdarray_from_tietuple(const T& t, std::index_sequence<I...>, int) noexcept {
+    return detail::make_stdarray(
+        boost::pfr::detail::sequence_tuple::get<I>(t)...
+    );
+}
+
+template <class T>
+constexpr auto make_stdarray_from_tietuple(const T&, std::index_sequence<>, long) noexcept {
+    return std::array<std::nullptr_t, 0>{};
+}
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_STDARRAY_HPP
+
+// Copyright (c) 2023 Bela Schaum, X-Ryl669, Denis Mikhailov.
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+// Initial implementation by Bela Schaum, https://github.com/schaumb
+// The way to make it union and UB free by X-Ryl669, https://github.com/X-Ryl669
+//
+
+#ifndef BOOST_PFR_DETAIL_FAKE_OBJECT_HPP
+#define BOOST_PFR_DETAIL_FAKE_OBJECT_HPP
+
+
+namespace boost { namespace pfr { namespace detail {
+
+template <class T>
+extern const T fake_object;
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_FAKE_OBJECT_HPP
+
+#include <type_traits>
+#include <string_view>
+#include <array>
+#include <memory> // for std::addressof
+
+namespace boost { namespace pfr { namespace detail {
+
+struct core_name_skip {
+    std::size_t size_at_begin;
+    std::size_t size_at_end;
+    bool is_backward;
+    std::string_view until_runtime;
+
+    consteval std::string_view apply(std::string_view sv) const noexcept {
+        // We use std::min here to make the compiler diagnostic shorter and
+        // cleaner in case of misconfigured BOOST_PFR_CORE_NAME_PARSING
+        sv.remove_prefix((std::min)(size_at_begin, sv.size()));
+        sv.remove_suffix((std::min)(size_at_end, sv.size()));
+        if (until_runtime.empty()) {
+            return sv;
+        }
+
+        const auto found = is_backward ? sv.rfind(until_runtime)
+                                       : sv.find(until_runtime);
+
+        const auto cut_until = found + until_runtime.size();
+        const auto safe_cut_until = (std::min)(cut_until, sv.size());
+        return sv.substr(safe_cut_until);
+    }
+};
+
+struct backward {
+    explicit consteval backward(std::string_view value) noexcept
+        : value(value)
+    {}
+
+    std::string_view value;
+};
+
+consteval core_name_skip make_core_name_skip(std::size_t size_at_begin,
+                                             std::size_t size_at_end,
+                                             std::string_view until_runtime) noexcept
+{
+    return core_name_skip{size_at_begin, size_at_end, false, until_runtime};
+}
+
+consteval core_name_skip make_core_name_skip(std::size_t size_at_begin,
+                                             std::size_t size_at_end,
+                                             backward until_runtime) noexcept
+{
+    return core_name_skip{size_at_begin, size_at_end, true, until_runtime.value};
+}
+
+// it might be compilation failed without this workaround sometimes
+// See https://github.com/llvm/llvm-project/issues/41751 for details
+template <class>
+consteval std::string_view clang_workaround(std::string_view value) noexcept
+{
+    return value;
+}
+
+template <class MsvcWorkaround, auto ptr>
+consteval auto name_of_field_impl() noexcept {
+    // Some of the following compiler specific macro may be defined only
+    // inside the function body:
+
+#ifndef BOOST_PFR_FUNCTION_SIGNATURE
+#   if defined(__FUNCSIG__)
+#       define BOOST_PFR_FUNCTION_SIGNATURE __FUNCSIG__
+#   elif defined(__PRETTY_FUNCTION__) || defined(__GNUC__) || defined(__clang__)
+#       define BOOST_PFR_FUNCTION_SIGNATURE __PRETTY_FUNCTION__
+#   else
+#       define BOOST_PFR_FUNCTION_SIGNATURE ""
+#   endif
+#endif
+
+    constexpr std::string_view sv = detail::clang_workaround<MsvcWorkaround>(BOOST_PFR_FUNCTION_SIGNATURE);
+    static_assert(!sv.empty(),
+        "====================> Boost.PFR: Field reflection parser configured in a wrong way. "
+        "Please define the BOOST_PFR_FUNCTION_SIGNATURE to a compiler specific macro, "
+        "that outputs the whole function signature including non-type template parameters."  
+    );
+
+    constexpr auto skip = detail::make_core_name_skip BOOST_PFR_CORE_NAME_PARSING;
+    static_assert(skip.size_at_begin + skip.size_at_end + skip.until_runtime.size() < sv.size(),
+        "====================> Boost.PFR: Field reflection parser configured in a wrong way. "
+        "It attempts to skip more chars than available. "
+        "Please define BOOST_PFR_CORE_NAME_PARSING to correct values. See documentation section "
+        "'Limitations and Configuration' for more information."
+    );
+    constexpr auto fn = skip.apply(sv);
+    static_assert(
+        !fn.empty(),
+        "====================> Boost.PFR: Extraction of field name is misconfigured for your compiler. "
+        "It skipped all the input, leaving the field name empty. "
+        "Please define BOOST_PFR_CORE_NAME_PARSING to correct values. See documentation section "
+        "'Limitations and Configuration' for more information."
+    );
+    auto res = std::array<char, fn.size()+1>{};
+
+    auto* out = res.data();
+    for (auto x: fn) {
+        *out = x;
+        ++out;
+    }
+
+    return res;
+}
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundefined-var-template"
+
+// clang 16 and earlier don't support address of non-static member as template parameter
+// but fortunately it's possible to use C++20 non-type template parameters in another way
+// even in clang 16 and more older clangs
+// all we need is to wrap pointer into 'clang_wrapper_t' and then pass it into template
+template <class T>
+struct clang_wrapper_t {
+    T v;
+};
+template <class T>
+clang_wrapper_t(T) -> clang_wrapper_t<T>;
+
+template <class T>
+constexpr auto make_clang_wrapper(const T& arg) noexcept {
+    return clang_wrapper_t{arg};
+}
+
+#else
+
+template <class T>
+constexpr const T& make_clang_wrapper(const T& arg) noexcept {
+    // It's everything OK with address of non-static member as template parameter support on this compiler
+    // so we don't need a wrapper here, just pass the pointer into template
+    return arg;
+}
+
+#endif
+
+template <class MsvcWorkaround, auto ptr>
+consteval auto name_of_field() noexcept {
+    // Sanity check: known field name must match the deduced one
+    static_assert(
+        sizeof(MsvcWorkaround)  // do not trigger if `name_of_field()` is not used
+        && std::string_view{
+            detail::name_of_field_impl<
+                core_name_skip, detail::make_clang_wrapper(std::addressof(
+                    fake_object<core_name_skip>.size_at_begin
+                ))
+            >().data()
+        } == "size_at_begin",
+        "====================> Boost.PFR: Extraction of field name is misconfigured for your compiler. "
+        "It does not return the proper field name. "
+        "Please define BOOST_PFR_CORE_NAME_PARSING to correct values. See documentation section "
+        "'Limitations and Configuration' for more information."
+    );
+
+    return detail::name_of_field_impl<MsvcWorkaround, ptr>();
+}
+
+// Storing part of a string literal into an array minimizes the binary size.
+//
+// Without passing 'T' into 'name_of_field' different fields from different structures might have the same name!
+// See https://developercommunity.visualstudio.com/t/__FUNCSIG__-outputs-wrong-value-with-C/10458554 for details
+template <class T, std::size_t I>
+inline constexpr auto stored_name_of_field = detail::name_of_field<T,
+    detail::make_clang_wrapper(std::addressof(detail::sequence_tuple::get<I>(
+        detail::tie_as_tuple(detail::fake_object<T>)
+    )))
+>();
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+template <class T, std::size_t... I>
+constexpr auto tie_as_names_tuple_impl(std::index_sequence<I...>) noexcept {
+    return detail::sequence_tuple::make_sequence_tuple(std::string_view{stored_name_of_field<T, I>.data()}...);
+}
+
+template <class T, std::size_t I>
+constexpr std::string_view get_name() noexcept {
+    static_assert(
+        !std::is_union<T>::value,
+        "====================> Boost.PFR: For safety reasons it is forbidden to reflect unions. See `Reflection of unions` section in the docs for more info."
+    );
+    static_assert(
+        !std::is_array<T>::value,
+        "====================> Boost.PFR: It is impossible to extract name from old C array since it doesn't have named members"
+    );
+    static_assert(
+        sizeof(T) && BOOST_PFR_USE_CPP17,
+        "====================> Boost.PFR: Extraction of field's names is allowed only when the BOOST_PFR_USE_CPP17 macro enabled."
+   );
+
+   return stored_name_of_field<T, I>.data();
+}
+
+template <class T>
+constexpr auto tie_as_names_tuple() noexcept {
+    static_assert(
+        !std::is_union<T>::value,
+        "====================> Boost.PFR: For safety reasons it is forbidden to reflect unions. See `Reflection of unions` section in the docs for more info."
+    );
+    static_assert(
+        !std::is_array<T>::value,
+        "====================> Boost.PFR: It is impossible to extract name from old C array since it doesn't have named members"
+    );
+    static_assert(
+        sizeof(T) && BOOST_PFR_USE_CPP17,
+        "====================> Boost.PFR: Extraction of field's names is allowed only when the BOOST_PFR_USE_CPP17 macro enabled."
+    );
+
+    return detail::tie_as_names_tuple_impl<T>(detail::make_index_sequence<detail::fields_count<T>()>{});
+}
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_CORE_NAME20_STATIC_HPP
+
+#else
+// Copyright (c) 2023 Bela Schaum, X-Ryl669, Denis Mikhailov.
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+// Initial implementation by Bela Schaum, https://github.com/schaumb
+// The way to make it union and UB free by X-Ryl669, https://github.com/X-Ryl669
+//
+
+#ifndef BOOST_PFR_DETAIL_CORE_NAME14_DISABLED_HPP
+#define BOOST_PFR_DETAIL_CORE_NAME14_DISABLED_HPP
+
+
+namespace boost { namespace pfr { namespace detail {
+
+template <class T, std::size_t I>
+constexpr auto get_name() noexcept {
+    static_assert(
+        sizeof(T) && false,
+        "====================> Boost.PFR: Field's names extracting functionality requires C++20."
+    );
+
+    return nullptr;
+}
+
+template <class T>
+constexpr auto tie_as_names_tuple() noexcept {
+    static_assert(
+        sizeof(T) && false,
+        "====================> Boost.PFR: Field's names extracting functionality requires C++20."
+    );
+
+    return detail::sequence_tuple::make_sequence_tuple();
+}
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_CORE_NAME14_DISABLED_HPP
+
+#endif
+
+#endif // BOOST_PFR_DETAIL_CORE_NAME_HPP
+
+
+
+#include <cstddef> // for std::size_t
+
+
+/// \file boost/pfr/core_name.hpp
+/// Contains functions \forcedlink{get_name} and \forcedlink{names_as_array} to know which names each field of any \aggregate has.
+///
+/// \fnrefl for details.
+///
+/// \b Synopsis:
+
+namespace boost { namespace pfr {
+
+/// \brief Returns name of a field with index `I` in \aggregate `T`.
+///
+/// \b Example:
+/// \code
+///     struct my_struct { int i, short s; };
+///
+///     assert(boost::pfr::get_name<0, my_struct>() == "i");
+///     assert(boost::pfr::get_name<1, my_struct>() == "s");
+/// \endcode
+template <std::size_t I, class T>
+constexpr
+#ifdef BOOST_PFR_DOXYGEN_INVOKED
+std::string_view
+#else
+auto
+#endif
+get_name() noexcept {
+    return detail::get_name<T, I>();
+}
+
+// FIXME: implement this
+// template<class U, class T>
+// constexpr auto get_name() noexcept {
+//     return detail::sequence_tuple::get_by_type_impl<U>( detail::tie_as_names_tuple<T>() );
+// }
+
+/// \brief Creates a `std::array` from names of fields of an \aggregate `T`.
+///
+/// \b Example:
+/// \code
+///     struct my_struct { int i, short s; };
+///     std::array<std::string_view, 2> a = boost::pfr::names_as_array<my_struct>();
+///     assert(a[0] == "i");
+/// \endcode
+template <class T>
+constexpr
+#ifdef BOOST_PFR_DOXYGEN_INVOKED
+std::array<std::string_view, boost::pfr::tuple_size_v<T>>
+#else
+auto
+#endif
+names_as_array() noexcept {
+    return detail::make_stdarray_from_tietuple(
+        detail::tie_as_names_tuple<T>(),
+        detail::make_index_sequence< tuple_size_v<T> >(),
+        1L
+    );
+}
+
+}} // namespace boost::pfr
+
+#endif // BOOST_PFR_CORE_NAME_HPP
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_FUNCTIONS_FOR_HPP
+#define BOOST_PFR_FUNCTIONS_FOR_HPP
+
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_OPS_FIELDS_HPP
+#define BOOST_PFR_OPS_FIELDS_HPP
+
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_FUNCTIONAL_HPP
+#define BOOST_PFR_DETAIL_FUNCTIONAL_HPP
+
+
+#include <functional>
+#include <cstdint>
+
+
+namespace boost { namespace pfr { namespace detail {
+    template <std::size_t I, std::size_t N>
+    struct equal_impl {
+        template <class T, class U>
+        constexpr static bool cmp(const T& v1, const U& v2) noexcept {
+            return ::boost::pfr::detail::sequence_tuple::get<I>(v1) == ::boost::pfr::detail::sequence_tuple::get<I>(v2)
+                && equal_impl<I + 1, N>::cmp(v1, v2);
+        }
+    };
+
+    template <std::size_t N>
+    struct equal_impl<N, N> {
+        template <class T, class U>
+        constexpr static bool cmp(const T&, const U&) noexcept {
+            return T::size_v == U::size_v;
+        }
+    };
+
+    template <std::size_t I, std::size_t N>
+    struct not_equal_impl {
+        template <class T, class U>
+        constexpr static bool cmp(const T& v1, const U& v2) noexcept {
+            return ::boost::pfr::detail::sequence_tuple::get<I>(v1) != ::boost::pfr::detail::sequence_tuple::get<I>(v2)
+                || not_equal_impl<I + 1, N>::cmp(v1, v2);
+        }
+    };
+
+    template <std::size_t N>
+    struct not_equal_impl<N, N> {
+        template <class T, class U>
+        constexpr static bool cmp(const T&, const U&) noexcept {
+            return T::size_v != U::size_v;
+        }
+    };
+
+    template <std::size_t I, std::size_t N>
+    struct less_impl {
+        template <class T, class U>
+        constexpr static bool cmp(const T& v1, const U& v2) noexcept {
+            return sequence_tuple::get<I>(v1) < sequence_tuple::get<I>(v2)
+                || (sequence_tuple::get<I>(v1) == sequence_tuple::get<I>(v2) && less_impl<I + 1, N>::cmp(v1, v2));
+        }
+    };
+
+    template <std::size_t N>
+    struct less_impl<N, N> {
+        template <class T, class U>
+        constexpr static bool cmp(const T&, const U&) noexcept {
+            return T::size_v < U::size_v;
+        }
+    };
+
+    template <std::size_t I, std::size_t N>
+    struct less_equal_impl {
+        template <class T, class U>
+        constexpr static bool cmp(const T& v1, const U& v2) noexcept {
+            return sequence_tuple::get<I>(v1) < sequence_tuple::get<I>(v2)
+                || (sequence_tuple::get<I>(v1) == sequence_tuple::get<I>(v2) && less_equal_impl<I + 1, N>::cmp(v1, v2));
+        }
+    };
+
+    template <std::size_t N>
+    struct less_equal_impl<N, N> {
+        template <class T, class U>
+        constexpr static bool cmp(const T&, const U&) noexcept {
+            return T::size_v <= U::size_v;
+        }
+    };
+
+    template <std::size_t I, std::size_t N>
+    struct greater_impl {
+        template <class T, class U>
+        constexpr static bool cmp(const T& v1, const U& v2) noexcept {
+            return sequence_tuple::get<I>(v1) > sequence_tuple::get<I>(v2)
+                || (sequence_tuple::get<I>(v1) == sequence_tuple::get<I>(v2) && greater_impl<I + 1, N>::cmp(v1, v2));
+        }
+    };
+
+    template <std::size_t N>
+    struct greater_impl<N, N> {
+        template <class T, class U>
+        constexpr static bool cmp(const T&, const U&) noexcept {
+            return T::size_v > U::size_v;
+        }
+    };
+
+    template <std::size_t I, std::size_t N>
+    struct greater_equal_impl {
+        template <class T, class U>
+        constexpr static bool cmp(const T& v1, const U& v2) noexcept {
+            return sequence_tuple::get<I>(v1) > sequence_tuple::get<I>(v2)
+                || (sequence_tuple::get<I>(v1) == sequence_tuple::get<I>(v2) && greater_equal_impl<I + 1, N>::cmp(v1, v2));
+        }
+    };
+
+    template <std::size_t N>
+    struct greater_equal_impl<N, N> {
+        template <class T, class U>
+        constexpr static bool cmp(const T&, const U&) noexcept {
+            return T::size_v >= U::size_v;
+        }
+    };
+
+    // Hash combine functions copied from Boost.ContainerHash
+    // https://github.com/boostorg/container_hash/blob/171c012d4723c5e93cc7cffe42919afdf8b27dfa/include/boost/container_hash/hash.hpp#L311
+    // that is based on Peter Dimov's proposal
+    // http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2005/n1756.pdf
+    // issue 6.18.
+    //
+    // This also contains public domain code from MurmurHash. From the
+    // MurmurHash header:
+    //
+    // MurmurHash3 was written by Austin Appleby, and is placed in the public
+    // domain. The author hereby disclaims copyright to this source code.
+    template <typename SizeT>
+    constexpr void hash_combine(SizeT& seed, SizeT value) noexcept {
+        seed ^= value + 0x9e3779b9 + (seed<<6) + (seed>>2);
+    }
+
+    constexpr auto rotl(std::uint32_t x, std::uint32_t r) noexcept {
+        return (x << r) | (x >> (32 - r));
+    }
+
+    constexpr void hash_combine(std::uint32_t& h1, std::uint32_t k1) noexcept {
+          const std::uint32_t c1 = 0xcc9e2d51;
+          const std::uint32_t c2 = 0x1b873593;
+
+          k1 *= c1;
+          k1 = detail::rotl(k1,15);
+          k1 *= c2;
+
+          h1 ^= k1;
+          h1 = detail::rotl(h1,13);
+          h1 = h1*5+0xe6546b64;
+    }
+
+#if defined(INT64_MIN) && defined(UINT64_MAX)
+    constexpr void hash_combine(std::uint64_t& h, std::uint64_t k) noexcept {
+        const std::uint64_t m = 0xc6a4a7935bd1e995ULL;
+        const int r = 47;
+
+        k *= m;
+        k ^= k >> r;
+        k *= m;
+
+        h ^= k;
+        h *= m;
+
+        // Completely arbitrary number, to prevent 0's
+        // from hashing to 0.
+        h += 0xe6546b64;
+    }
+#endif
+
+    template <typename T>
+    auto compute_hash(const T& value, long /*priority*/)
+        -> decltype(std::hash<T>()(value))
+    {
+        return std::hash<T>()(value);
+    }
+
+    template <typename T>
+    std::size_t compute_hash(const T& /*value*/, int /*priority*/) {
+        static_assert(sizeof(T) && false, "====================> Boost.PFR: std::hash not specialized for type T");
+        return 0;
+    }
+
+    template <std::size_t I, std::size_t N>
+    struct hash_impl {
+        template <class T>
+        constexpr static std::size_t compute(const T& val) noexcept {
+            std::size_t h = detail::compute_hash( ::boost::pfr::detail::sequence_tuple::get<I>(val), 1L );
+            detail::hash_combine(h, hash_impl<I + 1, N>::compute(val) );
+            return h;
+        }
+    };
+
+    template <std::size_t N>
+    struct hash_impl<N, N> {
+        template <class T>
+        constexpr static std::size_t compute(const T&) noexcept {
+            return 0;
+        }
+    };
+
+///////////////////// Define min_element and to avoid inclusion of <algorithm>
+    constexpr std::size_t min_size(std::size_t x, std::size_t y) noexcept {
+        return x < y ? x : y;
+    }
+
+    template <template <std::size_t, std::size_t> class Visitor, class T, class U>
+    constexpr bool binary_visit(const T& x, const U& y) {
+        constexpr std::size_t fields_count_lhs = detail::fields_count<std::remove_reference_t<T>>();
+        constexpr std::size_t fields_count_rhs = detail::fields_count<std::remove_reference_t<U>>();
+        constexpr std::size_t fields_count_min = detail::min_size(fields_count_lhs, fields_count_rhs);
+        typedef Visitor<0, fields_count_min> visitor_t;
+
+#if BOOST_PFR_USE_CPP17 || BOOST_PFR_USE_LOOPHOLE
+        return visitor_t::cmp(detail::tie_as_tuple(x), detail::tie_as_tuple(y));
+#else
+        bool result = true;
+        ::boost::pfr::detail::for_each_field_dispatcher(
+            x,
+            [&result, &y](const auto& lhs) {
+                constexpr std::size_t fields_count_rhs_ = detail::fields_count<std::remove_reference_t<U>>();
+                ::boost::pfr::detail::for_each_field_dispatcher(
+                    y,
+                    [&result, &lhs](const auto& rhs) {
+                        result = visitor_t::cmp(lhs, rhs);
+                    },
+                    detail::make_index_sequence<fields_count_rhs_>{}
+                );
+            },
+            detail::make_index_sequence<fields_count_lhs>{}
+        );
+
+        return result;
+#endif
+    }
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_FUNCTIONAL_HPP
+
+/// \file boost/pfr/ops_fields.hpp
+/// Contains field-by-fields comparison and hash functions.
+///
+/// \b Example:
+/// \code
+///     #include <boost/pfr/ops_fields.hpp>
+///     struct comparable_struct {      // No operators defined for that structure
+///         int i; short s;
+///     };
+///     // ...
+///
+///     comparable_struct s1 {0, 1};
+///     comparable_struct s2 {0, 2};
+///     assert(boost::pfr::lt_fields(s1, s2));
+/// \endcode
+///
+/// \podops for other ways to define operators and more details.
+///
+/// \b Synopsis:
+namespace boost { namespace pfr {
+
+    /// Does a field-by-field equality comparison.
+    ///
+    /// \returns `L == R && tuple_size_v<T> == tuple_size_v<U>`, where `L` and
+    /// `R` are the results of calling `std::tie` on first `N` fields of `lhs` and
+    // `rhs` respectively; `N` is `std::min(tuple_size_v<T>, tuple_size_v<U>)`.
+    template <class T, class U>
+    constexpr bool eq_fields(const T& lhs, const U& rhs) noexcept {
+        return detail::binary_visit<detail::equal_impl>(lhs, rhs);
+    }
+
+
+    /// Does a field-by-field inequality comparison.
+    ///
+    /// \returns `L != R || tuple_size_v<T> != tuple_size_v<U>`, where `L` and
+    /// `R` are the results of calling `std::tie` on first `N` fields of `lhs` and
+    // `rhs` respectively; `N` is `std::min(tuple_size_v<T>, tuple_size_v<U>)`.
+    template <class T, class U>
+    constexpr bool ne_fields(const T& lhs, const U& rhs) noexcept {
+        return detail::binary_visit<detail::not_equal_impl>(lhs, rhs);
+    }
+
+    /// Does a field-by-field greter comparison.
+    ///
+    /// \returns `L > R || (L == R && tuple_size_v<T> > tuple_size_v<U>)`, where `L` and
+    /// `R` are the results of calling `std::tie` on first `N` fields of `lhs` and
+    // `rhs` respectively; `N` is `std::min(tuple_size_v<T>, tuple_size_v<U>)`.
+    template <class T, class U>
+    constexpr bool gt_fields(const T& lhs, const U& rhs) noexcept {
+        return detail::binary_visit<detail::greater_impl>(lhs, rhs);
+    }
+
+
+    /// Does a field-by-field less comparison.
+    ///
+    /// \returns `L < R || (L == R && tuple_size_v<T> < tuple_size_v<U>)`, where `L` and
+    /// `R` are the results of calling `std::tie` on first `N` fields of `lhs` and
+    // `rhs` respectively; `N` is `std::min(tuple_size_v<T>, tuple_size_v<U>)`.
+    template <class T, class U>
+    constexpr bool lt_fields(const T& lhs, const U& rhs) noexcept {
+        return detail::binary_visit<detail::less_impl>(lhs, rhs);
+    }
+
+
+    /// Does a field-by-field greater equal comparison.
+    ///
+    /// \returns `L > R || (L == R && tuple_size_v<T> >= tuple_size_v<U>)`, where `L` and
+    /// `R` are the results of calling `std::tie` on first `N` fields of `lhs` and
+    // `rhs` respectively; `N` is `std::min(tuple_size_v<T>, tuple_size_v<U>)`.
+    template <class T, class U>
+    constexpr bool ge_fields(const T& lhs, const U& rhs) noexcept {
+        return detail::binary_visit<detail::greater_equal_impl>(lhs, rhs);
+    }
+
+
+    /// Does a field-by-field less equal comparison.
+    ///
+    /// \returns `L < R || (L == R && tuple_size_v<T> <= tuple_size_v<U>)`, where `L` and
+    /// `R` are the results of calling `std::tie` on first `N` fields of `lhs` and
+    // `rhs` respectively; `N` is `std::min(tuple_size_v<T>, tuple_size_v<U>)`.
+    template <class T, class U>
+    constexpr bool le_fields(const T& lhs, const U& rhs) noexcept {
+        return detail::binary_visit<detail::less_equal_impl>(lhs, rhs);
+    }
+
+
+    /// Does a field-by-field hashing.
+    ///
+    /// \returns combined hash of all the fields
+    template <class T>
+    std::size_t hash_fields(const T& x) {
+        constexpr std::size_t fields_count_val = boost::pfr::detail::fields_count<std::remove_reference_t<T>>();
+#if BOOST_PFR_USE_CPP17 || BOOST_PFR_USE_LOOPHOLE
+        return detail::hash_impl<0, fields_count_val>::compute(detail::tie_as_tuple(x));
+#else
+        std::size_t result = 0;
+        ::boost::pfr::detail::for_each_field_dispatcher(
+            x,
+            [&result](const auto& lhs) {
+                // We can not reuse `fields_count_val` in lambda because compilers had issues with
+                // passing constexpr variables into lambdas. Computing is again is the most portable solution.
+                constexpr std::size_t fields_count_val_lambda = boost::pfr::detail::fields_count<std::remove_reference_t<T>>();
+                result = detail::hash_impl<0, fields_count_val_lambda>::compute(lhs);
+            },
+            detail::make_index_sequence<fields_count_val>{}
+        );
+
+        return result;
+#endif
+    }
+}} // namespace boost::pfr
+
+#endif // BOOST_PFR_OPS_HPP
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#ifndef BOOST_PFR_IO_FIELDS_HPP
+#define BOOST_PFR_IO_FIELDS_HPP
+
+
+
+#include <type_traits>
+#include <utility>      // metaprogramming stuff
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_IO_HPP
+#define BOOST_PFR_DETAIL_IO_HPP
+
+
+#include <iosfwd>       // stream operators
+#include <iomanip>
+
+#if defined(__has_include)
+#   if __has_include(<string_view>) && BOOST_PFR_USE_CPP17
+#       include <string_view>
+#   endif
+#endif
+
+namespace boost { namespace pfr { namespace detail {
+
+inline auto quoted_helper(const std::string& s) noexcept {
+    return std::quoted(s);
+}
+
+#if defined(__has_include)
+#   if __has_include(<string_view>) && BOOST_PFR_USE_CPP17
+template <class CharT, class Traits>
+inline auto quoted_helper(std::basic_string_view<CharT, Traits> s) noexcept {
+    return std::quoted(s);
+}
+#   endif
+#endif
+
+inline auto quoted_helper(std::string& s) noexcept {
+    return std::quoted(s);
+}
+
+template <class T>
+inline decltype(auto) quoted_helper(T&& v) noexcept {
+    return std::forward<T>(v);
+}
+
+template <std::size_t I, std::size_t N>
+struct print_impl {
+    template <class Stream, class T>
+    static void print (Stream& out, const T& value) {
+        if (!!I) out << ", ";
+        out << detail::quoted_helper(boost::pfr::detail::sequence_tuple::get<I>(value));
+        print_impl<I + 1, N>::print(out, value);
+    }
+};
+
+template <std::size_t I>
+struct print_impl<I, I> {
+    template <class Stream, class T> static void print (Stream&, const T&) noexcept {}
+};
+
+
+template <std::size_t I, std::size_t N>
+struct read_impl {
+    template <class Stream, class T>
+    static void read (Stream& in, const T& value) {
+        char ignore = {};
+        if (!!I) {
+            in >> ignore;
+            if (ignore != ',') in.setstate(Stream::failbit);
+            in >> ignore;
+            if (ignore != ' ')  in.setstate(Stream::failbit);
+        }
+        in >> detail::quoted_helper( boost::pfr::detail::sequence_tuple::get<I>(value) );
+        read_impl<I + 1, N>::read(in, value);
+    }
+};
+
+template <std::size_t I>
+struct read_impl<I, I> {
+    template <class Stream, class T> static void read (Stream&, const T&) {}
+};
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_IO_HPP
+
+/// \file boost/pfr/io_fields.hpp
+/// Contains IO manipulator \forcedlink{io_fields} to read/write any \aggregate field-by-field.
+///
+/// \b Example:
+/// \code
+///     struct my_struct {
+///         int i;
+///         short s;
+///     };
+///
+///     std::ostream& operator<<(std::ostream& os, const my_struct& x) {
+///         return os << boost::pfr::io_fields(x);  // Equivalent to: os << "{ " << x.i << " ," <<  x.s << " }"
+///     }
+///
+///     std::istream& operator>>(std::istream& is, my_struct& x) {
+///         return is >> boost::pfr::io_fields(x);  // Equivalent to: is >> "{ " >> x.i >> " ," >>  x.s >> " }"
+///     }
+/// \endcode
+///
+/// \podops for other ways to define operators and more details.
+///
+/// \b Synopsis:
+
+namespace boost { namespace pfr {
+
+namespace detail {
+
+template <class T>
+struct io_fields_impl {
+    T value;
+};
+
+
+template <class Char, class Traits, class T>
+std::basic_ostream<Char, Traits>& operator<<(std::basic_ostream<Char, Traits>& out, io_fields_impl<const T&>&& x) {
+    const T& value = x.value;
+    constexpr std::size_t fields_count_val = boost::pfr::detail::fields_count<T>();
+    out << '{';
+#if BOOST_PFR_USE_CPP17 || BOOST_PFR_USE_LOOPHOLE
+    detail::print_impl<0, fields_count_val>::print(out, detail::tie_as_tuple(value));
+#else
+    ::boost::pfr::detail::for_each_field_dispatcher(
+        value,
+        [&out](const auto& val) {
+            // We can not reuse `fields_count_val` in lambda because compilers had issues with
+            // passing constexpr variables into lambdas. Computing is again is the most portable solution.
+            constexpr std::size_t fields_count_val_lambda = boost::pfr::detail::fields_count<T>();
+            detail::print_impl<0, fields_count_val_lambda>::print(out, val);
+        },
+        detail::make_index_sequence<fields_count_val>{}
+    );
+#endif
+    return out << '}';
+}
+
+
+template <class Char, class Traits, class T>
+std::basic_ostream<Char, Traits>& operator<<(std::basic_ostream<Char, Traits>& out, io_fields_impl<T>&& x) {
+    return out << io_fields_impl<const std::remove_reference_t<T>&>{x.value};
+}
+
+template <class Char, class Traits, class T>
+std::basic_istream<Char, Traits>& operator>>(std::basic_istream<Char, Traits>& in, io_fields_impl<T&>&& x) {
+    T& value = x.value;
+    constexpr std::size_t fields_count_val = boost::pfr::detail::fields_count<T>();
+
+    const auto prev_exceptions = in.exceptions();
+    in.exceptions( typename std::basic_istream<Char, Traits>::iostate(0) );
+    const auto prev_flags = in.flags( typename std::basic_istream<Char, Traits>::fmtflags(0) );
+
+    char parenthis = {};
+    in >> parenthis;
+    if (parenthis != '{') in.setstate(std::basic_istream<Char, Traits>::failbit);
+
+#if BOOST_PFR_USE_CPP17 || BOOST_PFR_USE_LOOPHOLE
+    detail::read_impl<0, fields_count_val>::read(in, detail::tie_as_tuple(value));
+#else
+    ::boost::pfr::detail::for_each_field_dispatcher(
+        value,
+        [&in](const auto& val) {
+            // We can not reuse `fields_count_val` in lambda because compilers had issues with
+            // passing constexpr variables into lambdas. Computing is again is the most portable solution.
+            constexpr std::size_t fields_count_val_lambda = boost::pfr::detail::fields_count<T>();
+            detail::read_impl<0, fields_count_val_lambda>::read(in, val);
+        },
+        detail::make_index_sequence<fields_count_val>{}
+    );
+#endif
+
+    in >> parenthis;
+    if (parenthis != '}') in.setstate(std::basic_istream<Char, Traits>::failbit);
+
+    in.flags(prev_flags);
+    in.exceptions(prev_exceptions);
+
+    return in;
+}
+
+template <class Char, class Traits, class T>
+std::basic_istream<Char, Traits>& operator>>(std::basic_istream<Char, Traits>& in, io_fields_impl<const T&>&& ) {
+    static_assert(sizeof(T) && false, "====================> Boost.PFR: Attempt to use istream operator on a boost::pfr::io_fields wrapped type T with const qualifier.");
+    return in;
+}
+
+template <class Char, class Traits, class T>
+std::basic_istream<Char, Traits>& operator>>(std::basic_istream<Char, Traits>& in, io_fields_impl<T>&& ) {
+    static_assert(sizeof(T) && false, "====================> Boost.PFR: Attempt to use istream operator on a boost::pfr::io_fields wrapped temporary of type T.");
+    return in;
+}
+
+} // namespace detail
+
+/// IO manipulator to read/write \aggregate `value` field-by-field.
+///
+/// \b Example:
+/// \code
+///     struct my_struct {
+///         int i;
+///         short s;
+///     };
+///
+///     std::ostream& operator<<(std::ostream& os, const my_struct& x) {
+///         return os << boost::pfr::io_fields(x);  // Equivalent to: os << "{ " << x.i << " ," <<  x.s << " }"
+///     }
+///
+///     std::istream& operator>>(std::istream& is, my_struct& x) {
+///         return is >> boost::pfr::io_fields(x);  // Equivalent to: is >> "{ " >> x.i >> " ," >>  x.s >> " }"
+///     }
+/// \endcode
+///
+/// Input and output streaming operators for `boost::pfr::io_fields` are symmetric, meaning that you get the original value by streaming it and
+/// reading back if each fields streaming operator is symmetric.
+///
+/// \customio
+template <class T>
+auto io_fields(T&& value) noexcept {
+    return detail::io_fields_impl<T>{std::forward<T>(value)};
+}
+
+}} // namespace boost::pfr
+
+#endif // BOOST_PFR_IO_FIELDS_HPP
+
+/// \file boost/pfr/functions_for.hpp
+/// Contains BOOST_PFR_FUNCTIONS_FOR macro that defined comparison and stream operators for T along with hash_value function.
+/// \b Example:
+/// \code
+///     #include <boost/pfr/functions_for.hpp>
+///
+///     namespace my_namespace {
+///         struct my_struct {      // No operators defined for that structure
+///             int i; short s; char data[7]; bool bl; int a,b,c,d,e,f;
+///         };
+///         BOOST_PFR_FUNCTIONS_FOR(my_struct)
+///     }
+/// \endcode
+///
+/// \podops for other ways to define operators and more details.
+///
+/// \b Synopsis:
+
+/// \def BOOST_PFR_FUNCTIONS_FOR(T)
+/// Defines comparison and stream operators for T along with hash_value function.
+///
+/// \b Example:
+/// \code
+///     #include <boost/pfr/functions_for.hpp>
+///     struct comparable_struct {      // No operators defined for that structure
+///         int i; short s; char data[7]; bool bl; int a,b,c,d,e,f;
+///     };
+///     BOOST_PFR_FUNCTIONS_FOR(comparable_struct)
+///     // ...
+///
+///     comparable_struct s1 {0, 1, "Hello", false, 6,7,8,9,10,11};
+///     comparable_struct s2 {0, 1, "Hello", false, 6,7,8,9,10,11111};
+///     assert(s1 < s2);
+///     std::cout << s1 << std::endl; // Outputs: {0, 1, H, e, l, l, o, , , 0, 6, 7, 8, 9, 10, 11}
+/// \endcode
+///
+/// \podops for other ways to define operators and more details.
+///
+/// \b Defines \b following \b for \b T:
+/// \code
+/// bool operator==(const T& lhs, const T& rhs);
+/// bool operator!=(const T& lhs, const T& rhs);
+/// bool operator< (const T& lhs, const T& rhs);
+/// bool operator> (const T& lhs, const T& rhs);
+/// bool operator<=(const T& lhs, const T& rhs);
+/// bool operator>=(const T& lhs, const T& rhs);
+///
+/// template <class Char, class Traits>
+/// std::basic_ostream<Char, Traits>& operator<<(std::basic_ostream<Char, Traits>& out, const T& value);
+///
+/// template <class Char, class Traits>
+/// std::basic_istream<Char, Traits>& operator>>(std::basic_istream<Char, Traits>& in, T& value);
+///
+/// // helper function for Boost unordered containers and boost::hash<>.
+/// std::size_t hash_value(const T& value);
+/// \endcode
+
+#define BOOST_PFR_FUNCTIONS_FOR(T)                                                                                                          \
+    BOOST_PFR_MAYBE_UNUSED inline bool operator==(const T& lhs, const T& rhs) { return ::boost::pfr::eq_fields(lhs, rhs); }                 \
+    BOOST_PFR_MAYBE_UNUSED inline bool operator!=(const T& lhs, const T& rhs) { return ::boost::pfr::ne_fields(lhs, rhs); }                 \
+    BOOST_PFR_MAYBE_UNUSED inline bool operator< (const T& lhs, const T& rhs) { return ::boost::pfr::lt_fields(lhs, rhs); }                 \
+    BOOST_PFR_MAYBE_UNUSED inline bool operator> (const T& lhs, const T& rhs) { return ::boost::pfr::gt_fields(lhs, rhs); }                 \
+    BOOST_PFR_MAYBE_UNUSED inline bool operator<=(const T& lhs, const T& rhs) { return ::boost::pfr::le_fields(lhs, rhs); }                 \
+    BOOST_PFR_MAYBE_UNUSED inline bool operator>=(const T& lhs, const T& rhs) { return ::boost::pfr::ge_fields(lhs, rhs); }                 \
+    template <class Char, class Traits>                                                                                                     \
+    BOOST_PFR_MAYBE_UNUSED inline ::std::basic_ostream<Char, Traits>& operator<<(::std::basic_ostream<Char, Traits>& out, const T& value) { \
+        return out << ::boost::pfr::io_fields(value);                                                                                       \
+    }                                                                                                                                       \
+    template <class Char, class Traits>                                                                                                     \
+    BOOST_PFR_MAYBE_UNUSED inline ::std::basic_istream<Char, Traits>& operator>>(::std::basic_istream<Char, Traits>& in, T& value) {        \
+        return in >> ::boost::pfr::io_fields(value);                                                                                        \
+    }                                                                                                                                       \
+    BOOST_PFR_MAYBE_UNUSED inline std::size_t hash_value(const T& v) {                                                                      \
+        return ::boost::pfr::hash_fields(v);                                                                                                \
+    }                                                                                                                                       \
+/**/
+
+#endif // BOOST_PFR_FUNCTIONS_FOR_HPP
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_FUNCTORS_HPP
+#define BOOST_PFR_FUNCTORS_HPP
+
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_OPS_HPP
+#define BOOST_PFR_OPS_HPP
+
+
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_DETECTORS_HPP
+#define BOOST_PFR_DETAIL_DETECTORS_HPP
+
+
+#include <functional>
+#include <type_traits>
+
+namespace boost { namespace pfr { namespace detail {
+///////////////////// `value` is true if Detector<Tleft, Tright> does not compile (SFINAE)
+    struct can_not_apply{};
+
+    template <template <class, class> class Detector, class Tleft, class Tright>
+    struct not_appliable {
+        static constexpr bool value = std::is_same<
+            Detector<Tleft, Tright>,
+            can_not_apply
+        >::value;
+    };
+
+///////////////////// Detectors for different operators
+    template <class S, class T> auto comp_eq_detector_msvc_helper(long) -> decltype(std::declval<S>() == std::declval<T>());
+    template <class S, class T> can_not_apply comp_eq_detector_msvc_helper(int);
+    template <class T1, class T2> using comp_eq_detector = decltype(comp_eq_detector_msvc_helper<T1,T2>(1L));
+
+    template <class S, class T> auto comp_ne_detector_msvc_helper(long) -> decltype(std::declval<S>() != std::declval<T>());
+    template <class S, class T> can_not_apply comp_ne_detector_msvc_helper(int);
+    template <class T1, class T2> using comp_ne_detector = decltype(comp_ne_detector_msvc_helper<T1,T2>(1L));
+
+    template <class S, class T> auto comp_lt_detector_msvc_helper(long) -> decltype(std::declval<S>() < std::declval<T>());
+    template <class S, class T> can_not_apply comp_lt_detector_msvc_helper(int);
+    template <class T1, class T2> using comp_lt_detector = decltype(comp_lt_detector_msvc_helper<T1,T2>(1L));
+
+    template <class S, class T> auto comp_le_detector_msvc_helper(long) -> decltype(std::declval<S>() <= std::declval<T>());
+    template <class S, class T> can_not_apply comp_le_detector_msvc_helper(int);
+    template <class T1, class T2> using comp_le_detector = decltype(comp_le_detector_msvc_helper<T1,T2>(1L));
+
+    template <class S, class T> auto comp_gt_detector_msvc_helper(long) -> decltype(std::declval<S>() > std::declval<T>());
+    template <class S, class T> can_not_apply comp_gt_detector_msvc_helper(int);
+    template <class T1, class T2> using comp_gt_detector = decltype(comp_gt_detector_msvc_helper<T1,T2>(1L));
+
+    template <class S, class T> auto comp_ge_detector_msvc_helper(long) -> decltype(std::declval<S>() >= std::declval<T>());
+    template <class S, class T> can_not_apply comp_ge_detector_msvc_helper(int);
+    template <class T1, class T2> using comp_ge_detector = decltype(comp_ge_detector_msvc_helper<T1,T2>(1L));
+
+
+    template <class S> auto hash_detector_msvc_helper(long) -> decltype(std::hash<S>{}(std::declval<S>()));
+    template <class S> can_not_apply hash_detector_msvc_helper(int);
+    template <class T1, class T2> using hash_detector = decltype(hash_detector_msvc_helper<T1,T2>(1L));
+
+
+    template <class S, class T> auto ostreamable_detector_msvc_helper(long) -> decltype(std::declval<S>() << std::declval<T>());
+    template <class S, class T> can_not_apply ostreamable_detector_msvc_helper(int);
+    template <class S, class T> using ostreamable_detector = decltype(ostreamable_detector_msvc_helper<S,T>(1L));
+
+    template <class S, class T> auto istreamable_detector_msvc_helper(long) -> decltype(std::declval<S>() >> std::declval<T>());
+    template <class S, class T> can_not_apply istreamable_detector_msvc_helper(int);
+    template <class S, class T> using istreamable_detector = decltype(istreamable_detector_msvc_helper<S,T>(1L));
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_DETECTORS_HPP
+
+
+
+/// \file boost/pfr/ops.hpp
+/// Contains comparison and hashing functions.
+/// If type is comparable using its own operator or its conversion operator, then the types operator is used. Otherwise
+/// the operation is done via corresponding function from boost/pfr/ops.hpp header.
+///
+/// \b Example:
+/// \code
+///     #include <boost/pfr/ops.hpp>
+///     struct comparable_struct {      // No operators defined for that structure
+///         int i; short s; char data[7]; bool bl; int a,b,c,d,e,f;
+///     };
+///     // ...
+///
+///     comparable_struct s1 {0, 1, "Hello", false, 6,7,8,9,10,11};
+///     comparable_struct s2 {0, 1, "Hello", false, 6,7,8,9,10,11111};
+///     assert(boost::pfr::lt(s1, s2));
+/// \endcode
+///
+/// \podops for other ways to define operators and more details.
+///
+/// \b Synopsis:
+namespace boost { namespace pfr {
+
+namespace detail {
+
+///////////////////// Helper typedefs that are used by all the ops
+    template <template <class, class> class Detector, class T, class U>
+    using enable_not_comp_base_t = std::enable_if_t<
+        not_appliable<Detector, T const&, U const&>::value,
+        bool
+    >;
+
+    template <template <class, class> class Detector, class T, class U>
+    using enable_comp_base_t = std::enable_if_t<
+        !not_appliable<Detector, T const&, U const&>::value,
+        bool
+    >;
+///////////////////// std::enable_if_t like functions that enable only if types do not support operation
+
+    template <class T, class U> using enable_not_eq_comp_t = enable_not_comp_base_t<comp_eq_detector, T, U>;
+    template <class T, class U> using enable_not_ne_comp_t = enable_not_comp_base_t<comp_ne_detector, T, U>;
+    template <class T, class U> using enable_not_lt_comp_t = enable_not_comp_base_t<comp_lt_detector, T, U>;
+    template <class T, class U> using enable_not_le_comp_t = enable_not_comp_base_t<comp_le_detector, T, U>;
+    template <class T, class U> using enable_not_gt_comp_t = enable_not_comp_base_t<comp_gt_detector, T, U>;
+    template <class T, class U> using enable_not_ge_comp_t = enable_not_comp_base_t<comp_ge_detector, T, U>;
+
+    template <class T> using enable_not_hashable_t = std::enable_if_t<
+        not_appliable<hash_detector, const T&, const T&>::value,
+        std::size_t
+    >;
+///////////////////// std::enable_if_t like functions that enable only if types do support operation
+
+    template <class T, class U> using enable_eq_comp_t = enable_comp_base_t<comp_eq_detector, T, U>;
+    template <class T, class U> using enable_ne_comp_t = enable_comp_base_t<comp_ne_detector, T, U>;
+    template <class T, class U> using enable_lt_comp_t = enable_comp_base_t<comp_lt_detector, T, U>;
+    template <class T, class U> using enable_le_comp_t = enable_comp_base_t<comp_le_detector, T, U>;
+    template <class T, class U> using enable_gt_comp_t = enable_comp_base_t<comp_gt_detector, T, U>;
+    template <class T, class U> using enable_ge_comp_t = enable_comp_base_t<comp_ge_detector, T, U>;
+
+    template <class T> using enable_hashable_t = std::enable_if_t<
+        !not_appliable<hash_detector, const T&, const T&>::value,
+        std::size_t
+    >;
+} // namespace detail
+
+
+/// \brief Compares lhs and rhs for equality using their own comparison and conversion operators; if no operators available returns \forcedlink{eq_fields}(lhs, rhs).
+///
+/// \returns true if lhs is equal to rhs; false otherwise
+template <class T, class U>
+constexpr detail::enable_not_eq_comp_t<T, U> eq(const T& lhs, const U& rhs) noexcept {
+    return boost::pfr::eq_fields(lhs, rhs);
+}
+
+/// \overload eq
+template <class T, class U>
+constexpr detail::enable_eq_comp_t<T, U> eq(const T& lhs, const U& rhs) {
+    return lhs == rhs;
+}
+
+
+/// \brief Compares lhs and rhs for inequality using their own comparison and conversion operators; if no operators available returns \forcedlink{ne_fields}(lhs, rhs).
+///
+/// \returns true if lhs is not equal to rhs; false otherwise
+template <class T, class U>
+constexpr detail::enable_not_ne_comp_t<T, U> ne(const T& lhs, const U& rhs) noexcept {
+    return boost::pfr::ne_fields(lhs, rhs);
+}
+
+/// \overload ne
+template <class T, class U>
+constexpr detail::enable_ne_comp_t<T, U> ne(const T& lhs, const U& rhs) {
+    return lhs != rhs;
+}
+
+
+/// \brief Compares lhs and rhs for less-than using their own comparison and conversion operators; if no operators available returns \forcedlink{lt_fields}(lhs, rhs).
+///
+/// \returns true if lhs is less than rhs; false otherwise
+template <class T, class U>
+constexpr detail::enable_not_lt_comp_t<T, U> lt(const T& lhs, const U& rhs) noexcept {
+    return boost::pfr::lt_fields(lhs, rhs);
+}
+
+/// \overload lt
+template <class T, class U>
+constexpr detail::enable_lt_comp_t<T, U> lt(const T& lhs, const U& rhs) {
+    return lhs < rhs;
+}
+
+
+/// \brief Compares lhs and rhs for greater-than using their own comparison and conversion operators; if no operators available returns \forcedlink{lt_fields}(lhs, rhs).
+///
+/// \returns true if lhs is greater than rhs; false otherwise
+template <class T, class U>
+constexpr detail::enable_not_gt_comp_t<T, U> gt(const T& lhs, const U& rhs) noexcept {
+    return boost::pfr::gt_fields(lhs, rhs);
+}
+
+/// \overload gt
+template <class T, class U>
+constexpr detail::enable_gt_comp_t<T, U> gt(const T& lhs, const U& rhs) {
+    return lhs > rhs;
+}
+
+
+/// \brief Compares lhs and rhs for less-equal using their own comparison and conversion operators; if no operators available returns \forcedlink{le_fields}(lhs, rhs).
+///
+/// \returns true if lhs is less or equal to rhs; false otherwise
+template <class T, class U>
+constexpr detail::enable_not_le_comp_t<T, U> le(const T& lhs, const U& rhs) noexcept {
+    return boost::pfr::le_fields(lhs, rhs);
+}
+
+/// \overload le
+template <class T, class U>
+constexpr detail::enable_le_comp_t<T, U> le(const T& lhs, const U& rhs) {
+    return lhs <= rhs;
+}
+
+
+/// \brief Compares lhs and rhs for greater-equal using their own comparison and conversion operators; if no operators available returns \forcedlink{ge_fields}(lhs, rhs).
+///
+/// \returns true if lhs is greater or equal to rhs; false otherwise
+template <class T, class U>
+constexpr detail::enable_not_ge_comp_t<T, U> ge(const T& lhs, const U& rhs) noexcept {
+    return boost::pfr::ge_fields(lhs, rhs);
+}
+
+/// \overload ge
+template <class T, class U>
+constexpr detail::enable_ge_comp_t<T, U> ge(const T& lhs, const U& rhs) {
+    return lhs >= rhs;
+}
+
+
+/// \brief Hashes value using its own std::hash specialization; if no std::hash specialization available returns \forcedlink{hash_fields}(value).
+///
+/// \returns std::size_t with hash of the value
+template <class T>
+constexpr detail::enable_not_hashable_t<T> hash_value(const T& value) noexcept {
+    return boost::pfr::hash_fields(value);
+}
+
+/// \overload hash_value
+template <class T>
+constexpr detail::enable_hashable_t<T> hash_value(const T& value) {
+    return std::hash<T>{}(value);
+}
+
+}} // namespace boost::pfr
+
+#endif // BOOST_PFR_OPS_HPP
+
+
+/// \file boost/pfr/functors.hpp
+/// Contains functors that are close to the Standard Library ones.
+/// Each functor calls corresponding Boost.PFR function from boost/pfr/ops.hpp
+///
+/// \b Example:
+/// \code
+///     #include <boost/pfr/functors.hpp>
+///     struct my_struct {      // No operators defined for that structure
+///         int i; short s; char data[7]; bool bl; int a,b,c,d,e,f;
+///     };
+///     // ...
+///
+///     std::unordered_set<
+///         my_struct,
+///         boost::pfr::hash<>,
+///         boost::pfr::equal_to<>
+///     > my_set;
+/// \endcode
+///
+/// \b Synopsis:
+namespace boost { namespace pfr {
+
+///////////////////// Comparisons
+
+/// \brief std::equal_to like comparator that returns \forcedlink{eq}(x, y)
+template <class T = void> struct equal_to {
+    /// \return \b true if each field of \b x equals the field with same index of \b y.
+    bool operator()(const T& x, const T& y) const {
+        return boost::pfr::eq(x, y);
+    }
+
+#ifdef BOOST_PFR_DOXYGEN_INVOKED
+    /// This typedef exists only if T \b is void
+    typedef std::true_type is_transparent;
+
+    /// This operator allows comparison of \b x and \b y that have different type.
+    /// \pre Exists only if T \b is void.
+    template <class V, class U> bool operator()(const V& x, const U& y) const;
+#endif
+};
+
+/// @cond
+template <> struct equal_to<void> {
+    template <class T, class U>
+    bool operator()(const T& x, const U& y) const {
+        return boost::pfr::eq(x, y);
+    }
+
+    typedef std::true_type is_transparent;
+};
+/// @endcond
+
+/// \brief std::not_equal like comparator that returns \forcedlink{ne}(x, y)
+template <class T = void> struct not_equal {
+    /// \return \b true if at least one field \b x not equals the field with same index of \b y.
+    bool operator()(const T& x, const T& y) const {
+        return boost::pfr::ne(x, y);
+    }
+
+#ifdef BOOST_PFR_DOXYGEN_INVOKED
+    /// This typedef exists only if T \b is void
+    typedef std::true_type is_transparent;
+
+    /// This operator allows comparison of \b x and \b y that have different type.
+    /// \pre Exists only if T \b is void.
+    template <class V, class U> bool operator()(const V& x, const U& y) const;
+#endif
+};
+
+/// @cond
+template <> struct not_equal<void> {
+    template <class T, class U>
+    bool operator()(const T& x, const U& y) const {
+        return boost::pfr::ne(x, y);
+    }
+
+    typedef std::true_type is_transparent;
+};
+/// @endcond
+
+/// \brief std::greater like comparator that returns \forcedlink{gt}(x, y)
+template <class T = void> struct greater {
+    /// \return \b true if field of \b x greater than the field with same index of \b y and all previous fields of \b x equal to the same fields of \b y.
+    bool operator()(const T& x, const T& y) const {
+        return boost::pfr::gt(x, y);
+    }
+
+#ifdef BOOST_PFR_DOXYGEN_INVOKED
+    /// This typedef exists only if T \b is void
+    typedef std::true_type is_transparent;
+
+    /// This operator allows comparison of \b x and \b y that have different type.
+    /// \pre Exists only if T \b is void.
+    template <class V, class U> bool operator()(const V& x, const U& y) const;
+#endif
+};
+
+/// @cond
+template <> struct greater<void> {
+    template <class T, class U>
+    bool operator()(const T& x, const U& y) const {
+        return boost::pfr::gt(x, y);
+    }
+
+    typedef std::true_type is_transparent;
+};
+/// @endcond
+
+/// \brief std::less like comparator that returns \forcedlink{lt}(x, y)
+template <class T = void> struct less {
+    /// \return \b true if field of \b x less than the field with same index of \b y and all previous fields of \b x equal to the same fields of \b y.
+    bool operator()(const T& x, const T& y) const {
+        return boost::pfr::lt(x, y);
+    }
+
+#ifdef BOOST_PFR_DOXYGEN_INVOKED
+    /// This typedef exists only if T \b is void
+    typedef std::true_type is_transparent;
+
+    /// This operator allows comparison of \b x and \b y that have different type.
+    /// \pre Exists only if T \b is void.
+    template <class V, class U> bool operator()(const V& x, const U& y) const;
+#endif
+};
+
+/// @cond
+template <> struct less<void> {
+    template <class T, class U>
+    bool operator()(const T& x, const U& y) const {
+        return boost::pfr::lt(x, y);
+    }
+
+    typedef std::true_type is_transparent;
+};
+/// @endcond
+
+/// \brief std::greater_equal like comparator that returns \forcedlink{ge}(x, y)
+template <class T = void> struct greater_equal {
+    /// \return \b true if field of \b x greater than the field with same index of \b y and all previous fields of \b x equal to the same fields of \b y;
+    /// or if each field of \b x equals the field with same index of \b y.
+    bool operator()(const T& x, const T& y) const {
+        return boost::pfr::ge(x, y);
+    }
+
+#ifdef BOOST_PFR_DOXYGEN_INVOKED
+    /// This typedef exists only if T \b is void
+    typedef std::true_type is_transparent;
+
+    /// This operator allows comparison of \b x and \b y that have different type.
+    /// \pre Exists only if T \b is void.
+    template <class V, class U> bool operator()(const V& x, const U& y) const;
+#endif
+};
+
+/// @cond
+template <> struct greater_equal<void> {
+    template <class T, class U>
+    bool operator()(const T& x, const U& y) const {
+        return boost::pfr::ge(x, y);
+    }
+
+    typedef std::true_type is_transparent;
+};
+/// @endcond
+
+/// \brief std::less_equal like comparator that returns \forcedlink{le}(x, y)
+template <class T = void> struct less_equal {
+    /// \return \b true if field of \b x less than the field with same index of \b y and all previous fields of \b x equal to the same fields of \b y;
+    /// or if each field of \b x equals the field with same index of \b y.
+    bool operator()(const T& x, const T& y) const {
+        return boost::pfr::le(x, y);
+    }
+
+#ifdef BOOST_PFR_DOXYGEN_INVOKED
+    /// This typedef exists only if T \b is void
+    typedef std::true_type is_transparent;
+
+    /// This operator allows comparison of \b x and \b y that have different type.
+    /// \pre Exists only if T \b is void.
+    template <class V, class U> bool operator()(const V& x, const U& y) const;
+#endif
+};
+
+/// @cond
+template <> struct less_equal<void> {
+    template <class T, class U>
+    bool operator()(const T& x, const U& y) const {
+        return boost::pfr::le(x, y);
+    }
+
+    typedef std::true_type is_transparent;
+};
+/// @endcond
+
+
+/// \brief std::hash like functor that returns \forcedlink{hash_value}(x)
+template <class T> struct hash {
+    /// \return hash value of \b x.
+    std::size_t operator()(const T& x) const {
+        return boost::pfr::hash_value(x);
+    }
+};
+
+}} // namespace boost::pfr
+
+#endif // BOOST_PFR_FUNCTORS_HPP
+// Copyright (c) 2016-2023 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_IO_HPP
+#define BOOST_PFR_IO_HPP
+
+
+
+/// \file boost/pfr/io.hpp
+/// Contains IO stream manipulator \forcedlink{io} for types.
+/// If type is streamable using its own operator or its conversion operator, then the types operator is used.
+///
+/// \b Example:
+/// \code
+///     #include <boost/pfr/io.hpp>
+///     struct comparable_struct {      // No operators defined for that structure
+///         int i; short s; char data[7]; bool bl; int a,b,c,d,e,f;
+///     };
+///     // ...
+///
+///     comparable_struct s1 {0, 1, "Hello", false, 6,7,8,9,10,11};
+///     std::cout << boost::pfr::io(s1);  // Outputs: {0, 1, H, e, l, l, o, , , 0, 6, 7, 8, 9, 10, 11}
+/// \endcode
+///
+/// \podops for other ways to define operators and more details.
+///
+/// \b Synopsis:
+namespace boost { namespace pfr {
+
+namespace detail {
+
+///////////////////// Helper typedefs
+    template <class Stream, class Type>
+    using enable_not_ostreamable_t = std::enable_if_t<
+        not_appliable<ostreamable_detector, Stream&, const std::remove_reference_t<Type>&>::value,
+        Stream&
+    >;
+
+    template <class Stream, class Type>
+    using enable_not_istreamable_t = std::enable_if_t<
+        not_appliable<istreamable_detector, Stream&, Type&>::value,
+        Stream&
+    >;
+
+    template <class Stream, class Type>
+    using enable_ostreamable_t = std::enable_if_t<
+        !not_appliable<ostreamable_detector, Stream&, const std::remove_reference_t<Type>&>::value,
+        Stream&
+    >;
+
+    template <class Stream, class Type>
+    using enable_istreamable_t = std::enable_if_t<
+        !not_appliable<istreamable_detector, Stream&, Type&>::value,
+        Stream&
+    >;
+
+///////////////////// IO impl
+
+template <class T>
+struct io_impl {
+    T value;
+};
+
+template <class Char, class Traits, class T>
+enable_not_ostreamable_t<std::basic_ostream<Char, Traits>, T> operator<<(std::basic_ostream<Char, Traits>& out, io_impl<T>&& x) {
+    return out << boost::pfr::io_fields(std::forward<T>(x.value));
+}
+
+template <class Char, class Traits, class T>
+enable_ostreamable_t<std::basic_ostream<Char, Traits>, T> operator<<(std::basic_ostream<Char, Traits>& out, io_impl<T>&& x) {
+    return out << x.value;
+}
+
+template <class Char, class Traits, class T>
+enable_not_istreamable_t<std::basic_istream<Char, Traits>, T> operator>>(std::basic_istream<Char, Traits>& in, io_impl<T>&& x) {
+    return in >> boost::pfr::io_fields(std::forward<T>(x.value));
+}
+
+template <class Char, class Traits, class T>
+enable_istreamable_t<std::basic_istream<Char, Traits>, T> operator>>(std::basic_istream<Char, Traits>& in, io_impl<T>&& x) {
+    return in >> x.value;
+}
+
+} // namespace detail
+
+/// IO manipulator to read/write \aggregate `value` using its IO stream operators or using \forcedlink{io_fields} if operators are not available.
+///
+/// \b Example:
+/// \code
+///     struct my_struct { int i; short s; };
+///     my_struct x;
+///     std::stringstream ss;
+///     ss << "{ 12, 13 }";
+///     ss >> boost::pfr::io(x);
+///     assert(x.i == 12);
+///     assert(x.s == 13);
+/// \endcode
+///
+/// \customio
+template <class T>
+auto io(T&& value) noexcept {
+    return detail::io_impl<T>{std::forward<T>(value)};
+}
+
+}} // namespace boost::pfr
+
+#endif // BOOST_PFR_IO_HPP
+// Copyright (c) 2022 Denis Mikhailov
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_TRAITS_FWD_HPP
+#define BOOST_PFR_DETAIL_TRAITS_FWD_HPP
+
+
+namespace boost { namespace pfr {
+
+template<class T, class WhatFor>
+struct is_reflectable;
+
+}} // namespace boost::pfr
+
+#endif // BOOST_PFR_DETAIL_TRAITS_FWD_HPP
+
+
+// Copyright (c) 2022 Denis Mikhailov
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_TRAITS_HPP
+#define BOOST_PFR_TRAITS_HPP
+
+
+// Copyright (c) 2022 Denis Mikhailov
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PFR_DETAIL_POSSIBLE_REFLECTABLE_HPP
+#define BOOST_PFR_DETAIL_POSSIBLE_REFLECTABLE_HPP
+
+
+#include <type_traits> // for std::is_aggregate
+
+namespace boost { namespace pfr { namespace detail {
+
+///////////////////// Returns false when the type exactly wasn't be reflectable
+template <class T, class WhatFor>
+constexpr decltype(is_reflectable<T, WhatFor>::value) possible_reflectable(long) noexcept {
+    return is_reflectable<T, WhatFor>::value;
+}
+
+#if BOOST_PFR_ENABLE_IMPLICIT_REFLECTION
+
+template <class T, class WhatFor>
+constexpr bool possible_reflectable(int) noexcept {
+#   if  defined(__cpp_lib_is_aggregate)
+    using type = std::remove_cv_t<T>;
+    return std::is_aggregate<type>();
+#   else
+    return true;
+#   endif
+}
+
+#else
+
+template <class T, class WhatFor>
+constexpr bool possible_reflectable(int) noexcept {
+    // negative answer here won't change behaviour in PFR-dependent libraries(like Fusion)
+    return false;
+}
+
+#endif
+
+}}} // namespace boost::pfr::detail
+
+#endif // BOOST_PFR_DETAIL_POSSIBLE_REFLECTABLE_HPP
+
+
+#include <type_traits>
+
+/// \file boost/pfr/traits.hpp
+/// Contains traits \forcedlink{is_reflectable} and \forcedlink{is_implicitly_reflectable} for detecting an ability to reflect type.
+///
+/// \b Synopsis:
+
+namespace boost { namespace pfr {
+
+/// Has a static const member variable `value` when it is known that type T can or can't be reflected using Boost.PFR; otherwise, there is no member variable.
+/// Every user may (and in some difficult cases - should) specialize is_reflectable on his own.
+///
+/// \b Example:
+/// \code
+///     namespace boost { namespace pfr {
+///         template<class All> struct is_reflectable<A, All> : std::false_type {};       // 'A' won't be interpreted as reflectable everywhere
+///         template<> struct is_reflectable<B, boost_fusion_tag> : std::false_type {};   // 'B' won't be interpreted as reflectable in only Boost Fusion
+///     }}
+/// \endcode
+/// \note is_reflectable affects is_implicitly_reflectable, the decision made by is_reflectable is used by is_implicitly_reflectable.
+template<class T, class WhatFor>
+struct is_reflectable { /*  does not have 'value' because value is unknown */ };
+
+// these specs can't be inherited from 'std::integral_constant< bool, boost::pfr::is_reflectable<T, WhatFor>::value >',
+// because it will break the sfinae-friendliness
+template<class T, class WhatFor>
+struct is_reflectable<const T, WhatFor> : boost::pfr::is_reflectable<T, WhatFor> {};
+
+template<class T, class WhatFor>
+struct is_reflectable<volatile T, WhatFor> : boost::pfr::is_reflectable<T, WhatFor> {};
+
+template<class T, class WhatFor>
+struct is_reflectable<const volatile T, WhatFor> : boost::pfr::is_reflectable<T, WhatFor> {};
+
+/// Checks the input type for the potential to be reflected.
+/// Specialize is_reflectable if you disagree with is_implicitly_reflectable's default decision.
+template<class T, class WhatFor>
+using is_implicitly_reflectable = std::integral_constant< bool, boost::pfr::detail::possible_reflectable<T, WhatFor>(1L) >;
+
+/// Checks the input type for the potential to be reflected.
+/// Specialize is_reflectable if you disagree with is_implicitly_reflectable_v's default decision.
+template<class T, class WhatFor>
+constexpr bool is_implicitly_reflectable_v = is_implicitly_reflectable<T, WhatFor>::value;
+
+}} // namespace boost::pfr
+
+#endif // BOOST_PFR_TRAITS_HPP
+
+
+#endif // BOOST_PFR_HPP
+#define CPPGRES_USE_BOOST_PFR 1
+/*
+// This has been commented out while Boost.PFR is embedded with Cppgres
+
+#if __has_include(<boost/pfr.hpp>)
+#include <boost/pfr.hpp>
+#define CPPGRES_USE_BOOST_PFR 1
+#else
+#define CPPGRES_USE_BOOST_PFR 0
+#endif
+*/
+namespace cppgres::utils {
+
+// Primary template: if T is not an optional, just yield T.
+template <typename T> struct remove_optional {
+  using type = T;
+};
+
+// Partial specialization for std::optional.
+template <typename T> struct remove_optional<std::optional<T>> {
+  using type = T;
+};
+
+// Convenience alias template.
+template <typename T> using remove_optional_t = typename utils::remove_optional<T>::type;
+
+template <typename T>
+concept is_optional =
+    requires { typename T::value_type; } && std::same_as<T, std::optional<typename T::value_type>>;
+
+template <typename T> constexpr std::string_view type_name() {
+#ifdef __clang__
+  constexpr std::string_view p = __PRETTY_FUNCTION__;
+  constexpr std::string_view key = "T = ";
+  const auto start = p.find(key) + key.size();
+  const auto end = p.find(']', start);
+  return p.substr(start, end - start);
+#elif defined(__GNUC__)
+  constexpr std::string_view p = __PRETTY_FUNCTION__;
+  constexpr std::string_view key = "T = ";
+  const auto start = p.find(key) + key.size();
+  const auto end = p.find(';', start);
+  return p.substr(start, end - start);
+#elif defined(_MSC_VER)
+  constexpr std::string_view p = __FUNCSIG__;
+  constexpr std::string_view key = "type_name<";
+  const auto start = p.find(key) + key.size();
+  const auto end = p.find(">(void)");
+  return p.substr(start, end - start);
+#else
+  return "Unsupported compiler";
+#endif
+}
+
+template <typename T, typename = void> struct tuple_traits_impl {
+  using tuple_size_type = std::integral_constant<std::size_t, 1>;
+
+  template <std::size_t I, typename U = T> static constexpr decltype(auto) get(U &&t) noexcept {
+    return std::forward<U>(t);
+  }
+
+  struct tuple_element_t {
+    using type = T;
+  };
+
+  template <std::size_t I> using tuple_element = tuple_element_t;
+};
+
+// Primary implementation: for types that already have a tuple-like interface
+template <typename T>
+struct tuple_traits_impl<T, std::void_t<decltype(std::tuple_size<T>::value)>> {
+  using tuple_size_type = std::tuple_size<T>;
+
+  template <std::size_t I, typename U = T> static constexpr decltype(auto) get(U &&t) noexcept {
+    return std::get<I>(std::forward<U>(t));
+  }
+
+  template <std::size_t I> using tuple_element = std::tuple_element<I, T>;
+};
+
+// Specialization: for aggregates that Boost.PFR can handle.
+// This specialization is enabled if the type is an aggregate
+#if CPPGRES_USE_BOOST_PFR
+template <typename T> struct tuple_traits_impl<T, std::enable_if_t<std::is_aggregate_v<T>>> {
+  using tuple_size_type = boost::pfr::tuple_size<T>;
+
+  template <std::size_t I, typename U = T> static constexpr decltype(auto) get(U &&t) noexcept {
+    return boost::pfr::get<I>(std::forward<U>(t));
+  }
+
+  template <std::size_t I> using tuple_element = boost::pfr::tuple_element<I, T>;
+};
+
+#endif
+
+template <typename T> using tuple_size = typename tuple_traits_impl<T>::tuple_size_type;
+
+template <typename T> constexpr std::size_t tuple_size_v = tuple_size<T>::value;
+
+template <std::size_t I, typename T>
+using tuple_element = typename tuple_traits_impl<T>::template tuple_element<I>;
+
+template <std::size_t I, typename T> using tuple_element_t = typename tuple_element<I, T>::type;
+
+template <std::size_t I, typename T> constexpr decltype(auto) get(T &&t) noexcept {
+  return tuple_traits_impl<std::remove_cv_t<std::remove_reference_t<T>>>::template get<I>(
+      std::forward<T>(t));
+}
+
+template <typename T> struct is_std_tuple : std::false_type {};
+
+template <typename... Ts> struct is_std_tuple<std::tuple<Ts...>> : std::true_type {};
+
+template <typename T>
+concept std_tuple = is_std_tuple<T>::value;
+
+template <typename T> decltype(auto) tie(T &val) {
+#if CPPGRES_USE_BOOST_PFR == 1
+  if constexpr (std::is_aggregate_v<T>) {
+    return boost::pfr::structure_tie(val);
+  } else
+#endif
+      if constexpr (std_tuple<T>) {
+    return val;
+  } else {
+    return std::tuple(val);
+  }
+}
+
+} // namespace cppgres::utils
+
+/**
+* \file
+ */
+#ifdef __cplusplus
+#endif
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wregister"
+#endif
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+#include <postgres.h>
+#include <fmgr.h>
+// clang-format on
+#include <access/amapi.h>
+#include <access/tableam.h>
+#include <access/tsmapi.h>
+#include <access/tupdesc.h>
+#include <catalog/namespace.h>
+#include <catalog/pg_class.h>
+#include <catalog/pg_proc.h>
+#include <catalog/pg_type.h>
+#include <commands/event_trigger.h>
+#include <executor/spi.h>
+#include <foreign/fdwapi.h>
+#include <funcapi.h>
+#include <miscadmin.h>
+#include <nodes/execnodes.h>
+#include <nodes/extensible.h>
+#include <nodes/memnodes.h>
+#if __has_include(<nodes/miscnodes.h>)
+#include <nodes/miscnodes.h>
+#endif
+#include <nodes/nodes.h>
+#include <nodes/parsenodes.h>
+#include <nodes/pathnodes.h>
+#include <nodes/replnodes.h>
+#include <nodes/supportnodes.h>
+#include <nodes/tidbitmap.h>
+#include <storage/ipc.h>
+#include <utils/builtins.h>
+#include <utils/expandeddatum.h>
+#include <utils/memutils.h>
+#include <utils/snapmgr.h>
+#include <utils/syscache.h>
+#include <utils/tuplestore.h>
+#include <utils/typcache.h>
+#ifdef __cplusplus
+}
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+/**
+* \file
+ */
+
+#include <concepts>
+#include <memory>
+
+/**
+* \file
+ */
+
+extern "C" {
+#include <setjmp.h>
+}
+
+#include <iostream>
+#include <utility>
+
+/**
+ * \file
+ */
+
+#include <string>
+#include <tuple>
+
+#include <iostream>
+
+/**
+ * \file
+ */
+
+namespace cppgres {
+class pg_exception : public std::exception {
+  ::MemoryContext mcxt;
+  ::MemoryContext error_cxt;
+  ::ErrorData *error;
+
+  pg_exception(::MemoryContext mcxt);
+
+  const char *what() const noexcept override { return error->message; }
+
+  template <typename Func> friend struct ffi_guard;
+
+public:
+  const char *message() const noexcept { return error->message; }
+  ~pg_exception();
+};
+} // namespace cppgres
+
+namespace cppgres {
+
+inline void error(pg_exception e);
+inline void error(pg_exception e) {
+  ::errstart(ERROR, TEXTDOMAIN);
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
+#endif
+  ::errmsg("%s", e.message());
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+  ::errfinish(__FILE__, __LINE__, __func__);
+  __builtin_unreachable();
+}
+
+template <typename T>
+concept error_formattable =
+    std::integral<std::decay_t<T>> ||
+    (std::is_pointer_v<std::decay_t<T>> &&
+     std::same_as<std::remove_cv_t<std::remove_pointer_t<std::decay_t<T>>>, char>) ||
+    std::is_pointer_v<std::decay_t<T>>;
+
+template <std::size_t N, error_formattable... Args>
+inline void report(int elevel, const char (&fmt)[N], Args... args) {
+  ::errstart(elevel, TEXTDOMAIN);
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
+#endif
+  ::errmsg(fmt, args...);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+  ::errfinish(__FILE__, __LINE__, __func__);
+  if (elevel >= ERROR) {
+    __builtin_unreachable();
+  }
+}
+} // namespace cppgres
+/**
+* \file
+ */
+
+namespace cppgres::utils::function_traits {
+// Primary template (will be specialized below)
+template <typename T> struct function_traits;
+
+// Specialization for function pointers.
+template <typename R, typename... Args> struct function_traits<R (*)(Args...)> {
+  using argument_types = std::tuple<Args...>;
+  static constexpr std::size_t arity = sizeof...(Args);
+};
+
+// Specialization for function references.
+template <typename R, typename... Args> struct function_traits<R (&)(Args...)> {
+  using argument_types = std::tuple<Args...>;
+  static constexpr std::size_t arity = sizeof...(Args);
+};
+
+// Specialization for function types themselves.
+template <typename R, typename... Args> struct function_traits<R(Args...)> {
+  using argument_types = std::tuple<Args...>;
+  static constexpr std::size_t arity = sizeof...(Args);
+};
+
+// Specialization for member function pointers (e.g. for lambdas' operator())
+template <typename C, typename R, typename... Args>
+struct function_traits<R (C:: *)(Args...) const> {
+  using argument_types = std::tuple<Args...>;
+  static constexpr std::size_t arity = sizeof...(Args);
+};
+
+// Fallback for functors/lambdas that are not plain function pointers.
+// This will delegate to the member function pointer version.
+template <typename T> struct function_traits : function_traits<decltype(&T::operator())> {};
+
+// Primary template (left undefined)
+template <typename Func, typename Tuple> struct invoke_result_from_tuple;
+
+// Partial specialization for when Tuple is a std::tuple<Args...>
+template <typename Func, typename... Args>
+struct invoke_result_from_tuple<Func, std::tuple<Args...>> {
+  using type = std::invoke_result_t<Func, Args...>;
+};
+
+// Convenience alias template.
+template <typename Func, typename Tuple>
+using invoke_result_from_tuple_t = typename invoke_result_from_tuple<Func, Tuple>::type;
+
+} // namespace cppgres::utils::function_traits
+
+namespace cppgres {
+
+template <typename Func> struct ffi_guard {
+  Func func;
+
+  explicit ffi_guard(Func f) : func(std::move(f)) {}
+
+  template <typename... Args>
+  auto operator()(Args &&...args) -> decltype(func(std::forward<Args>(args)...)) {
+    int state;
+    sigjmp_buf *pbuf;
+    ::ErrorContextCallback *cb;
+    sigjmp_buf buf;
+    ::MemoryContext mcxt = ::CurrentMemoryContext;
+
+    pbuf = ::PG_exception_stack;
+    cb = ::error_context_stack;
+    ::PG_exception_stack = &buf;
+
+    // restore state upon exit
+    std::shared_ptr<void> defer(nullptr, [&](...) {
+      ::error_context_stack = cb;
+      ::PG_exception_stack = pbuf;
+    });
+
+    state = sigsetjmp(buf, 1);
+
+    if (state == 0) {
+      return func(std::forward<Args>(args)...);
+    } else if (state == 1) {
+      throw pg_exception(mcxt);
+    }
+    __builtin_unreachable();
+  }
+};
+
+/**
+ * @brief Wraps a C++ function to catch exceptions and report them as Postgres errors
+ *
+ * It ensures that if the C++ exception throws an error, it'll be caught and transformed into
+ * a Postgres error report.
+ *
+ * @note It will also handle Postgres errors caught during the call that were automatically transformed
+ *       into @ref cppgres::pg_exception by @ref cppgres::ffi_guard and report them as errors.
+ *
+ * @tparam Func C++ function to call
+ */
+template <typename Func> struct exception_guard {
+  Func func;
+
+  explicit exception_guard(Func f) : func(std::move(f)) {}
+
+  template <typename... Args>
+  auto operator()(Args &&...args) -> decltype(func(std::forward<Args>(args)...)) {
+    try {
+      return func(std::forward<Args>(args)...);
+    } catch (const pg_exception &e) {
+      error(e);
+    } catch (const std::exception &e) {
+      report(ERROR, "exception: %s", e.what());
+    } catch (...) {
+      report(ERROR, "some exception occurred");
+    }
+    __builtin_unreachable();
+  }
+};
+
+} // namespace cppgres
+
+namespace cppgres {
+
+struct abstract_memory_context {
+
+  template <typename T = std::byte> T *alloc(size_t n = 1) {
+    return static_cast<T *>(ffi_guard{::MemoryContextAlloc}(_memory_context(), sizeof(T) * n));
+  }
+  template <typename T = void> void free(T *ptr) { ffi_guard{::pfree}(ptr); }
+
+  void reset() { ffi_guard{::MemoryContextReset}(_memory_context()); }
+
+  bool operator==(abstract_memory_context &c) { return _memory_context() == c._memory_context(); }
+  bool operator!=(abstract_memory_context &c) { return _memory_context() != c._memory_context(); }
+
+  operator ::MemoryContext() { return _memory_context(); }
+
+  ::MemoryContextCallback *register_reset_callback(::MemoryContextCallbackFunction func,
+                                                   void *arg) {
+    auto cb = alloc<::MemoryContextCallback>(sizeof(::MemoryContextCallback));
+    cb->func = func;
+    cb->arg = arg;
+    ffi_guard{::MemoryContextRegisterResetCallback}(_memory_context(), cb);
+    return cb;
+  }
+
+  void delete_context() { ffi_guard{::MemoryContextDelete}(_memory_context()); }
+
+protected:
+  virtual ::MemoryContext _memory_context() = 0;
+};
+
+struct owned_memory_context : public abstract_memory_context {
+  friend struct memory_context;
+
+protected:
+  owned_memory_context(::MemoryContext context) : context(context), moved(false) {}
+
+  ~owned_memory_context() {
+    if (!moved) {
+      delete_context();
+    }
+  }
+
+  ::MemoryContext context;
+  bool moved;
+
+  ::MemoryContext _memory_context() override { return context; }
+};
+
+struct memory_context : public abstract_memory_context {
+
+  friend struct owned_memory_context;
+
+  explicit memory_context() : context(::CurrentMemoryContext) {}
+  explicit memory_context(::MemoryContext context) : context(context) {}
+  explicit memory_context(abstract_memory_context &&context) : context(context) {}
+
+  explicit memory_context(owned_memory_context &&ctx) : context(ctx) { ctx.moved = true; }
+
+  static memory_context for_pointer(void *ptr) {
+    if (ptr == nullptr || ptr != (void *)MAXALIGN(ptr)) {
+      throw std::runtime_error("invalid pointer");
+    }
+    return memory_context(ffi_guard{::GetMemoryChunkContext}(ptr));
+  }
+
+  template <typename C> requires std::derived_from<C, abstract_memory_context>
+  friend struct tracking_memory_context;
+
+protected:
+  ::MemoryContext context;
+
+  ::MemoryContext _memory_context() override { return context; }
+};
+
+struct always_current_memory_context : public abstract_memory_context {
+  always_current_memory_context() = default;
+
+protected:
+  ::MemoryContext _memory_context() override { return ::CurrentMemoryContext; }
+};
+
+struct alloc_set_memory_context : public owned_memory_context {
+  using owned_memory_context::owned_memory_context;
+  alloc_set_memory_context()
+      : owned_memory_context(ffi_guard{::AllocSetContextCreateInternal}(
+            ::CurrentMemoryContext, nullptr, ALLOCSET_DEFAULT_SIZES)) {}
+  alloc_set_memory_context(memory_context &ctx)
+      : owned_memory_context(
+            ffi_guard{::AllocSetContextCreateInternal}(ctx, nullptr, ALLOCSET_DEFAULT_SIZES)) {}
+
+  alloc_set_memory_context(memory_context &&ctx)
+      : owned_memory_context(
+            ffi_guard{::AllocSetContextCreateInternal}(ctx, nullptr, ALLOCSET_DEFAULT_SIZES)) {}
+};
+
+inline memory_context top_memory_context() { return memory_context(TopMemoryContext); };
+
+template <typename C> requires std::derived_from<C, abstract_memory_context>
+struct tracking_memory_context : public abstract_memory_context {
+  explicit tracking_memory_context(tracking_memory_context<C> const &context)
+      : ctx(context.ctx), counter(context.counter), cb(context.cb) {
+    cb->arg = this;
+  }
+
+  explicit tracking_memory_context(C ctx)
+      : ctx(ctx), counter(0),
+        cb(std::shared_ptr<::MemoryContextCallback>(
+            this->register_reset_callback(
+                [](void *i) { static_cast<struct tracking_memory_context<C> *>(i)->counter++; },
+                this),
+            /* custom deleter */
+            [](auto) {})) {}
+
+  tracking_memory_context(tracking_memory_context &&other) noexcept
+      : ctx(std::move(other.ctx)), counter(std::move(other.counter)), cb(std::move(other.cb)) {
+    other.cb = nullptr;
+    cb->arg = this;
+  }
+
+  tracking_memory_context(tracking_memory_context &other) noexcept
+      : ctx(std::move(other.ctx)), counter(std::move(other.counter)), cb(std::move(other.cb)) {
+    cb->arg = this;
+    other.cb = nullptr;
+  }
+
+  tracking_memory_context &operator=(tracking_memory_context &&other) noexcept {
+    ctx = other.ctx;
+    cb = other.cb;
+    counter = other.counter;
+    cb->arg = this;
+    return *this;
+  }
+
+  ~tracking_memory_context() {
+    if (cb != nullptr) {
+      if (cb.use_count() == 1) {
+        cb->func = [](void *) {};
+      }
+    }
+  }
+
+  uint64_t resets() const { return counter; }
+  C &get_memory_context() { return ctx; }
+
+private:
+  template <typename T> requires std::integral<T>
+  struct shared_counter {
+    T value;
+    constexpr explicit shared_counter(T init = 0) noexcept : value(init) {}
+
+    shared_counter &operator=(T v) noexcept {
+      value = v;
+      return *this;
+    }
+
+    shared_counter &operator++() noexcept {
+      ++value;
+      return *this;
+    }
+
+    T operator++(int) noexcept {
+      T old = value;
+      ++value;
+      return old;
+    }
+
+    constexpr operator T() const noexcept { return value; }
+  };
+  C ctx;
+  shared_counter<uint64_t> counter;
+  std::shared_ptr<::MemoryContextCallback> cb;
+
+protected:
+  ::MemoryContext _memory_context() override { return ctx._memory_context(); }
+};
+
+template <typename T>
+concept a_memory_context =
+    std::derived_from<T, abstract_memory_context> && std::default_initializable<T>;
+
+template <a_memory_context Context> struct memory_context_scope {
+  explicit memory_context_scope(Context &ctx)
+      : previous(::CurrentMemoryContext), ctx(ctx.operator ::MemoryContext()) {
+    ::CurrentMemoryContext = ctx;
+  }
+  explicit memory_context_scope(Context &&ctx)
+      : previous(::CurrentMemoryContext), ctx(ctx.operator ::MemoryContext()) {
+    ::CurrentMemoryContext = ctx;
+  }
+
+  ~memory_context_scope() { ::CurrentMemoryContext = previous; }
+
+private:
+  ::MemoryContext previous;
+  ::MemoryContext ctx;
+};
+
+template <class T, a_memory_context Context = memory_context> struct memory_context_allocator {
+  using value_type = T;
+  memory_context_allocator() noexcept : context(Context()), explicit_deallocation(false) {}
+  memory_context_allocator(Context &&ctx, bool explicit_deallocation) noexcept
+      : context(std::move(ctx)), explicit_deallocation(explicit_deallocation) {}
+
+  constexpr memory_context_allocator(const memory_context_allocator<T> &c) noexcept
+      : context(c.context) {}
+
+  [[nodiscard]] T *allocate(std::size_t n) {
+    try {
+      return context.template alloc<T>(n);
+    } catch (pg_exception &e) {
+      throw std::bad_alloc();
+    }
+  }
+
+  void deallocate(T *p, std::size_t n) noexcept {
+    if (explicit_deallocation || context == top_memory_context()) {
+      context.free(p);
+    }
+  }
+
+  bool operator==(const memory_context_allocator &c) { return context == c.context; }
+  bool operator!=(const memory_context_allocator &c) { return context != c.context; }
+
+  Context &memory_context() { return context; }
+
+private:
+  Context context;
+  bool explicit_deallocation;
+};
+
+struct pointer_gone_exception : public std::exception {
+  const char *what() const noexcept override {
+    return "pointer belongs to a MemoryContext that has been reset or deleted";
+  }
+};
+
+} // namespace cppgres
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace cppgres {
+
+struct oid {
+  oid(::Oid oid) : oid_(oid) {}
+  oid(oid &oid) : oid_(oid.oid_) {}
+
+  bool operator==(const oid &rhs) const { return oid_ == rhs.oid_; }
+  bool operator!=(const oid &rhs) const { return !(rhs == *this); }
+
+  bool operator==(const ::Oid &rhs) const { return oid_ == rhs; }
+  bool operator!=(const ::Oid &rhs) const { return oid_ != rhs; }
+
+  operator ::Oid() const { return oid_; }
+  operator ::Oid &() { return oid_; }
+
+private:
+  ::Oid oid_;
+};
+static_assert(sizeof(::Oid) == sizeof(oid));
+
+struct datum {
+  template <typename T, typename> friend struct datum_conversion;
+
+  operator const ::Datum &() const { return _datum; }
+
+  operator Pointer() const { return reinterpret_cast<Pointer>(_datum); }
+
+  datum() : _datum(0) {}
+  explicit datum(::Datum datum) : _datum(datum) {}
+
+  bool operator==(const datum &other) const { return _datum == other._datum; }
+
+private:
+  ::Datum _datum;
+  friend struct nullable_datum;
+};
+
+class null_datum_exception : public std::exception {
+  const char *what() const noexcept override { return "passed datum is null"; }
+};
+
+struct nullable_datum {
+
+  bool is_null() const noexcept { return _ndatum.isnull; }
+
+  operator struct datum &() {
+    if (_ndatum.isnull) {
+      throw null_datum_exception();
+    }
+    return _datum;
+  }
+
+  operator const ::Datum &() {
+    if (_ndatum.isnull) {
+      throw null_datum_exception();
+    }
+    return _datum.operator const ::Datum &();
+  }
+
+  operator const struct datum &() const {
+    if (_ndatum.isnull) {
+      throw null_datum_exception();
+    }
+    return _datum;
+  }
+
+  explicit nullable_datum(::NullableDatum d) : _ndatum(d) {}
+
+  explicit nullable_datum() : _ndatum({.isnull = true}) {}
+
+  explicit nullable_datum(::Datum d) : _ndatum({.value = d, .isnull = false}) {}
+  explicit nullable_datum(datum d) : _ndatum({.value = d._datum, .isnull = false}) {}
+
+  bool operator==(const nullable_datum &other) const {
+    if (is_null()) {
+      return other.is_null();
+    }
+    if (other.is_null()) {
+      return is_null();
+    }
+    return _datum.operator==(other._datum);
+  }
+
+private:
+  union {
+    ::NullableDatum _ndatum;
+    datum _datum;
+  };
+};
+
+/**
+ * @brief A trait to convert from and into a @ref cppgres::datum
+ *
+ * @tparam T C++ type to convert into and from
+ */
+template <typename T, typename = void> struct datum_conversion {
+
+  /**
+   * @brief Convert from a nullable datum
+   *
+   * Gets an optional @ref cppgres::memory_context when available to be able to determine the source
+   * of the (pointer) datum.
+   */
+  static T from_nullable_datum(const nullable_datum &d, const oid oid,
+                               std::optional<memory_context> context = std::nullopt) = delete;
+
+  /**
+   * @brief Convert from a datum
+   *
+   * Gets an optional @ref cppgres::memory_context when available to be able to determine the source
+   * of the (pointer) datum.
+   */
+  static T from_datum(const datum &, const oid,
+                      std::optional<memory_context> context = std::nullopt) = delete;
+  /**
+   * @brief Convert datum into a type
+   *
+   * Unlike @ref from_datum, gets no memory context.
+   */
+  static datum into_datum(const T &d) = delete;
+
+  /**
+   * @brief Convert into a nullable datum
+   */
+  static nullable_datum into_nullable_datum(const T &d) = delete;
+};
+
+template <typename T, typename R = T> struct default_datum_conversion {
+  /**
+   * @brief Convert from a nullable datum
+   *
+   * Gets an optional @ref cppgres::memory_context when available to be able to determine the source
+   * of the (pointer) datum.
+   */
+  static R from_nullable_datum(const nullable_datum &d, const oid oid,
+                               std::optional<memory_context> context = std::nullopt) {
+    if (d.is_null()) {
+      throw std::runtime_error(cppgres::fmt::format("datum is null and can't be coerced into {}",
+                                                    utils::type_name<T>()));
+    }
+    return datum_conversion<T>::from_datum(d, oid, context);
+  }
+
+  /**
+   * @brief Convert into a nullable datum
+   */
+  static nullable_datum into_nullable_datum(const T &d) {
+    return nullable_datum(datum_conversion<T>::into_datum(d));
+  }
+};
+
+template <typename T>
+concept convertible_into_datum = requires(T t) {
+  { datum_conversion<T, void>::into_datum(std::declval<T>()) } -> std::same_as<datum>;
+};
+
+template <typename T>
+concept convertible_from_datum = requires(datum d, oid oid, std::optional<memory_context> context) {
+  { datum_conversion<T, void>::from_datum(d, oid, context) } -> std::same_as<T>;
+};
+
+template <typename T> struct unsupported_type {};
+
+template <typename T>
+requires convertible_from_datum<std::remove_cv_t<T>>
+T from_nullable_datum(const nullable_datum &d, const oid oid,
+                      std::optional<memory_context> context = std::nullopt) {
+  return datum_conversion<std::remove_cv_t<T>>::from_nullable_datum(d, oid, context);
+}
+
+template <typename T> nullable_datum into_nullable_datum(const std::optional<T> &v) {
+  if (v.has_value()) {
+    return nullable_datum(datum_conversion<T>::into_datum(v.value()));
+  } else {
+    return nullable_datum();
+  }
+}
+
+template <typename T> nullable_datum into_nullable_datum(const T &v) {
+  if constexpr (std::same_as<nullable_datum, T>) {
+    return v;
+  }
+  return datum_conversion<T>::into_nullable_datum(v);
+}
+
+template <typename T>
+concept convertible_from_nullable_datum = requires {
+  {
+    cppgres::from_nullable_datum<T>(std::declval<nullable_datum>(), std::declval<oid>(),
+                                    std::declval<std::optional<memory_context>>())
+  } -> std::same_as<T>;
+};
+
+template <typename T>
+concept convertible_into_nullable_datum = requires {
+  { cppgres::into_nullable_datum(std::declval<T>()) } -> std::same_as<nullable_datum>;
+};
+
+template <typename T> struct all_from_nullable_datum {
+private:
+  static constexpr std::size_t N = utils::tuple_size_v<T>;
+
+  template <std::size_t... I> static constexpr bool impl(std::index_sequence<I...>) {
+    return (
+        ... &&
+        convertible_from_nullable_datum<utils::remove_optional_t<utils::tuple_element_t<I, T>>>);
+  }
+
+public:
+  static constexpr bool value = impl(std::make_index_sequence<N>{});
+};
+
+} // namespace cppgres
+
+
+
+namespace cppgres {
+
+struct name {
+
+  template <int N> requires(N < NAMEDATALEN)
+  name(const char name[N]) : _name({.data = name}) {}
+
+  name(const char *name) { strncpy(NameStr(_name), name, NAMEDATALEN - 1); }
+
+  operator NameData &() const { return _name; }
+
+private:
+  mutable NameData _name;
+};
+
+} // namespace cppgres
+
+
+/**
+ * \file
+ */
+
+#include <stack>
+
+extern "C" {
+#include <access/xact.h>
+}
+
+namespace cppgres {
+
+using command_id = ::CommandId;
+
+struct transaction_id {
+
+  transaction_id() : id_(InvalidTransactionId) {}
+  transaction_id(::TransactionId id) : id_(id) {}
+  transaction_id(const transaction_id &id) : id_(id.id_) {}
+
+  static transaction_id current(bool acquire = true) {
+    return transaction_id(
+        ffi_guard{acquire ? ::GetCurrentTransactionId : ::GetCurrentTransactionIdIfAny}());
+  }
+
+  bool is_valid() const { return TransactionIdIsValid(id_); }
+
+  bool operator==(const transaction_id &other) const { return TransactionIdEquals(id_, other.id_); }
+  bool operator>(const transaction_id &other) const { return TransactionIdFollows(id_, other.id_); }
+  bool operator>=(const transaction_id &other) const {
+    return TransactionIdFollowsOrEquals(id_, other.id_);
+  }
+  bool operator<(const transaction_id &other) const {
+    return TransactionIdPrecedes(id_, other.id_);
+  }
+  bool operator<=(const transaction_id &other) const {
+    return TransactionIdPrecedesOrEquals(id_, other.id_);
+  }
+
+  bool did_abort() const { return is_valid() && TransactionIdDidAbort(id_); }
+  bool did_commit() const { return is_valid() && TransactionIdDidCommit(id_); }
+
+private:
+  ::TransactionId id_;
+};
+
+static_assert(sizeof(transaction_id) == sizeof(::TransactionId));
+
+struct internal_subtransaction {
+  internal_subtransaction(bool commit = true)
+      : owner(::CurrentResourceOwner), commit(commit), name("") {
+    if (txns.empty()) {
+      ffi_guard{::BeginInternalSubTransaction}(nullptr);
+      txns.push(this);
+    } else {
+      throw std::runtime_error("internal subtransaction already started");
+    }
+  }
+
+  internal_subtransaction(std::string_view name, bool commit = true)
+      : owner(::CurrentResourceOwner), commit(commit), name(name) {
+    if (txns.empty()) {
+      ffi_guard{::BeginInternalSubTransaction}(this->name.c_str());
+      txns.push(this);
+    } else {
+      throw std::runtime_error("internal subtransaction already started");
+    }
+  }
+
+  ~internal_subtransaction() {
+    txns.pop();
+    if (commit) {
+      ffi_guard{::ReleaseCurrentSubTransaction}();
+    } else {
+      ffi_guard{::RollbackAndReleaseCurrentSubTransaction}();
+    }
+    ::CurrentResourceOwner = owner;
+  }
+
+private:
+  ::ResourceOwner owner;
+  bool commit;
+  std::string name;
+  static inline std::stack<internal_subtransaction *> txns;
+};
+
+struct transaction {
+  transaction(bool commit = true) : should_commit(commit), released(false) {
+    ffi_guard([]() {
+      if (!::IsTransactionState()) {
+        ::SetCurrentStatementStartTimestamp();
+        ::StartTransactionCommand();
+        ::PushActiveSnapshot(::GetTransactionSnapshot());
+      }
+    })();
+  }
+
+  ~transaction() {
+    if (!released) {
+      ffi_guard([this]() {
+        ::PopActiveSnapshot();
+        if (should_commit) {
+          ::CommitTransactionCommand();
+        } else {
+          ::AbortCurrentTransaction();
+        }
+      })();
+    }
+  }
+
+  void commit() {
+    ffi_guard([]() {
+      ::PopActiveSnapshot();
+      ::CommitTransactionCommand();
+    })();
+    released = true;
+  }
+
+  void rollback() {
+    ffi_guard([]() {
+      ::PopActiveSnapshot();
+      ::AbortCurrentTransaction();
+    })();
+    released = true;
+  }
+
+private:
+  bool should_commit;
+  bool released;
+};
+
+} // namespace cppgres
+
+namespace cppgres {
+
+/**
+ * @brief Heap tuple convenience wrapper
+ */
+struct heap_tuple {
+
+  heap_tuple(::HeapTuple tuple) : tuple_(tuple) {}
+
+  operator ::HeapTuple() const { return tuple_; }
+
+  transaction_id xmin(bool raw = false) const {
+    return raw ? HeapTupleHeaderGetRawXmin(tuple_->t_data) : HeapTupleHeaderGetXmin(tuple_->t_data);
+  }
+
+  transaction_id xmax() const { return HeapTupleHeaderGetRawXmax(tuple_->t_data); }
+
+  transaction_id update_xid() const { return HeapTupleHeaderGetUpdateXid(tuple_->t_data); }
+
+  command_id cmin() const { return HeapTupleHeaderGetCmin(tuple_->t_data); }
+  command_id cmax() const { return HeapTupleHeaderGetCmax(tuple_->t_data); }
+
+private:
+  HeapTuple tuple_;
+};
+
+static_assert(sizeof(heap_tuple) == sizeof(::HeapTuple));
+
+} // namespace cppgres
+
+namespace cppgres {
+
+template <typename T> struct syscache_traits {};
+
+template <> struct syscache_traits<Form_pg_type> {
+  static constexpr ::SysCacheIdentifier cache_id = TYPEOID;
+};
+
+template <> struct syscache_traits<Form_pg_proc> {
+  static constexpr ::SysCacheIdentifier cache_id = PROCOID;
+};
+
+template <typename T>
+concept syscached = requires(T t) {
+  { *t };
+  { syscache_traits<T>::cache_id } -> std::same_as<const ::SysCacheIdentifier &>;
+};
+
+template <syscached T, convertible_into_datum... D> struct syscache {
+  syscache(const D &...key) : syscache(syscache_traits<T>::cache_id, key...) {}
+  syscache(::SysCacheIdentifier cache_id, const D &...key)
+      requires(sizeof...(key) > 0 && sizeof...(key) < 5)
+      : cache_id(cache_id), tuple([&]() {
+          datum keys[4] = {datum_conversion<D>::into_datum(key)...};
+          return ffi_guard{::SearchSysCache}(cache_id, keys[0], keys[1], keys[2], keys[3]);
+        }()) {
+    if (!HeapTupleIsValid(tuple)) {
+      throw std::runtime_error("invalid tuple");
+    }
+  }
+
+  ~syscache() { ReleaseSysCache(tuple); }
+
+  decltype(*std::declval<T>()) &operator*() {
+    return *reinterpret_cast<T>(GETSTRUCT(tuple.operator HeapTuple()));
+  }
+  const decltype(*std::declval<T>()) &operator*() const {
+    return *reinterpret_cast<T>(GETSTRUCT(tuple.operator HeapTuple()));
+  }
+
+  /**
+   * @brief Get an attribute by index
+   *
+   * @tparam V type to convert to
+   * @param attr attribute index
+   * @return
+   */
+  template <convertible_from_datum V> std::optional<V> get_attribute(int attr) {
+    bool isnull;
+    Datum ret = ffi_guard{::SysCacheGetAttr}(cache_id, tuple, attr, &isnull);
+    if (isnull) {
+      return std::nullopt;
+    }
+    return from_nullable_datum<V>(nullable_datum(ret), oid(/*FIXME*/ InvalidOid));
+  }
+
+  operator const heap_tuple &() const { return tuple; }
+
+private:
+  ::SysCacheIdentifier cache_id;
+  heap_tuple tuple;
+};
+
+} // namespace cppgres
+/**
+* \file
+ */
+
+#include <cstddef>
+#include <span>
+#include <string>
+
+
+namespace cppgres {
+
+/**
+ * @brief Postgres type
+ */
+struct type {
+  ::Oid oid;
+
+  /**
+   * @brief Type name as defined in Postgres
+   *
+   * @param qualified if set to true (false by default), it will always include the schema name.
+   *                  Otherwise, if the schema is in the `search_path`, the schema will not be
+   *                  included.
+   */
+  std::string_view name(bool qualified = false) {
+    if (!OidIsValid(oid)) {
+      throw std::runtime_error("invalid type");
+    }
+    return (qualified ? ffi_guard{::format_type_be_qualified}
+                      : ffi_guard{::format_type_be})(oid);
+  }
+
+  bool operator==(const type &other) const { return oid == other.oid; }
+};
+
+template <typename T, typename = void> struct type_traits {
+  type_traits() {}
+  type_traits(const T &) {}
+  bool is(const type &t) { return false; }
+  type type_for() = delete;
+};
+
+template <typename T> requires std::is_reference_v<T>
+struct type_traits<T> {
+  type_traits() {}
+  type_traits(const T &) {}
+  constexpr type type_for() { return type_traits<std::remove_reference_t<T>>().type_for(); }
+};
+
+template <typename T> struct type_traits<std::optional<T>> {
+  type_traits() {}
+  type_traits(const std::optional<T> &) {}
+  bool is(const type &t) { return type_traits<T>().is(t); }
+  constexpr type type_for() { return type_traits<T>().type_for(); }
+};
+
+struct non_by_value_type : public type {
+  friend struct datum;
+
+  non_by_value_type(std::pair<const struct datum &, std::optional<memory_context>> init)
+      : non_by_value_type(init.first, init.second) {}
+  non_by_value_type(const struct datum &datum, std::optional<memory_context> ctx)
+      : value_datum(datum),
+        ctx(tracking_memory_context(ctx.has_value() ? *ctx : top_memory_context())) {}
+
+  non_by_value_type(const non_by_value_type &other)
+      : value_datum(other.value_datum), ctx(other.ctx) {}
+  non_by_value_type(non_by_value_type &&other) noexcept
+      : value_datum(std::move(other.value_datum)), ctx(std::move(other.ctx)) {}
+  non_by_value_type &operator=(non_by_value_type &&other) noexcept {
+    value_datum = std::move(other.value_datum);
+    ctx = std::move(other.ctx);
+    return *this;
+  }
+
+  memory_context &get_memory_context() { return ctx.get_memory_context(); }
+
+  datum get_datum() const { return value_datum; }
+
+protected:
+  datum value_datum;
+  tracking_memory_context<memory_context> ctx;
+  void *ptr(bool tracked = true) const {
+    if (tracked && ctx.resets() > 0) {
+      throw pointer_gone_exception();
+    }
+    return reinterpret_cast<void *>(value_datum.operator const ::Datum &());
+  }
+};
+
+static_assert(std::copy_constructible<non_by_value_type>);
+
+struct varlena : public non_by_value_type {
+  using non_by_value_type::non_by_value_type;
+
+  operator void *() { return VARDATA_ANY(detoasted_ptr()); }
+
+  datum get_datum() const { return value_datum; }
+
+  bool is_detoasted() const { return detoasted != nullptr; }
+
+protected:
+  void *detoasted = nullptr;
+  void *detoasted_ptr() {
+    if (detoasted != nullptr) {
+      return detoasted;
+    }
+    detoasted = ffi_guard{::pg_detoast_datum}(reinterpret_cast<::varlena *>(ptr()));
+    return detoasted;
+  }
+};
+
+struct text : public varlena {
+  using varlena::varlena;
+
+  operator std::string_view() {
+    return {static_cast<char *>(this->operator void *()), VARSIZE_ANY_EXHDR(this->detoasted_ptr())};
+  }
+};
+
+using byte_array = std::span<const std::byte>;
+
+struct bytea : public varlena {
+  using varlena::varlena;
+
+  bytea(const byte_array &ba, memory_context ctx)
+      : varlena(([&]() {
+                  auto alloc = ctx.alloc<std::byte>(VARHDRSZ + ba.size_bytes());
+                  SET_VARSIZE(alloc, VARHDRSZ + ba.size_bytes());
+                  auto ptr = VARDATA_ANY(alloc);
+                  std::copy(ba.begin(), ba.end(), reinterpret_cast<std::byte *>(ptr));
+                  return datum(PointerGetDatum(alloc));
+                })(),
+                ctx) {}
+
+  operator byte_array() {
+    return {reinterpret_cast<std::byte *>(this->operator void *()),
+            VARSIZE_ANY_EXHDR(this->detoasted_ptr())};
+  }
+};
+
+template <typename T>
+concept flattenable = requires(T t, std::span<std::byte> span) {
+  { T::type() } -> std::same_as<type>;
+  { t.flat_size() } -> std::same_as<std::size_t>;
+  { t.flatten_into(span) };
+  { T::restore_from(span) } -> std::same_as<T>;
+};
+
+template <flattenable T> struct expanded_varlena : public varlena {
+  using flattenable_type = T;
+  using varlena::varlena;
+
+  expanded_varlena()
+      : varlena(([]() {
+          auto ctx = memory_context(std::move(alloc_set_memory_context()));
+          auto *e = new (ctx.alloc<expanded>()) expanded(T());
+          ctx.register_reset_callback(
+              [](void *arg) {
+                auto v = reinterpret_cast<expanded *>(arg);
+                v->inner.~T();
+              },
+              e);
+          init(&e->hdr, ctx);
+          return std::make_pair(datum(PointerGetDatum(e)), ctx);
+        })()),
+        detoasted_value(reinterpret_cast<expanded *>(DatumGetPointer(value_datum))) {}
+
+  operator T &() {
+    if (detoasted_value.has_value()) {
+      return detoasted_value.value()->inner;
+    } else {
+      auto *ptr1 = reinterpret_cast<std::byte *>(varlena::operator void *());
+      auto ctx = memory_context(std::move(alloc_set_memory_context()));
+      auto *value = new (ctx.alloc<expanded>())
+          expanded(T::restore_from(std::span(ptr1, VARSIZE_ANY_EXHDR(detoasted_ptr()))));
+      ctx.register_reset_callback(
+          [](void *arg) {
+            auto v = reinterpret_cast<expanded *>(arg);
+            v->inner.~T();
+          },
+          value);
+      init(&value->hdr, ctx);
+      detoasted_value = value;
+      return value->inner;
+    }
+  }
+
+  datum get_expanded_datum() const {
+    if (!detoasted_value.has_value()) {
+      throw std::runtime_error("hasn't been expanded yet");
+    }
+    return datum(EOHPGetRWDatum(&detoasted_value.value()->hdr));
+  }
+
+private:
+  struct expanded {
+    expanded(T &&t) : inner(std::move(t)) {}
+    ::ExpandedObjectHeader hdr;
+    T inner;
+  };
+  std::optional<expanded *> detoasted_value = std::nullopt;
+
+  static void init(ExpandedObjectHeader *hdr, memory_context &ctx) {
+    using header = int32_t;
+
+    static const ::ExpandedObjectMethods eom = {
+        .get_flat_size =
+            [](ExpandedObjectHeader *eohptr) {
+              auto *e = reinterpret_cast<expanded *>(eohptr);
+              T *inner = &e->inner;
+              return inner->flat_size() + sizeof(header);
+            },
+        .flatten_into =
+            [](ExpandedObjectHeader *eohptr, void *result, size_t allocated_size) {
+              auto *e = reinterpret_cast<expanded *>(eohptr);
+              T *inner = &e->inner;
+              SET_VARSIZE(reinterpret_cast<header *>(result), allocated_size);
+              auto bytes = reinterpret_cast<std::byte *>(result) + sizeof(header);
+              std::span buffer(bytes, allocated_size - sizeof(header));
+              inner->flatten_into(buffer);
+            }};
+
+    ffi_guard{::EOH_init_header}(hdr, &eom, ctx);
+  }
+};
+
+template <typename T>
+concept expanded_varlena_type = requires { typename T::flattenable_type; };
+
+template <typename T>
+concept has_a_type = requires(type_traits<T> t) {
+  { t.type_for() } -> std::same_as<type>;
+};
+
+} // namespace cppgres
+/**
+ * \file
+ */
+
+#include <optional>
+#include <string>
+#include <utility>
+
+
+namespace cppgres {
+
+template <> struct type_traits<void *> {
+  bool is(const type &t) { return t.oid == INTERNALOID; }
+  constexpr type type_for() { return type{.oid = INTERNALOID}; }
+};
+
+template <> struct type_traits<void> {
+  bool is(const type &t) { return t.oid == VOIDOID; }
+  constexpr type type_for() { return type{.oid = VOIDOID}; }
+};
+
+template <> struct type_traits<oid> {
+  static bool is(const type &t) { return t.oid == OIDOID; }
+  static constexpr type type_for() { return type{.oid = OIDOID}; }
+};
+
+template <> struct type_traits<nullable_datum> {
+  static bool is(const type &t) { return true; }
+  static constexpr type type_for() { return type{.oid = ANYOID}; }
+};
+
+template <> struct type_traits<datum> {
+  static bool is(const type &t) { return true; }
+  static constexpr type type_for() { return type{.oid = ANYOID}; }
+};
+
+template <typename S> struct type_traits<S, std::enable_if_t<utils::is_std_tuple<S>::value>> {
+  bool is(const type &t) {
+    if (t.oid == RECORDOID) {
+      return true;
+    } else if constexpr (std::tuple_size_v<S> == 1) {
+      // special case when we have a tuple of 1 matching the type
+      return type_traits<std::tuple_element_t<0, S>>().is(t);
+    }
+    return false;
+  }
+  constexpr type type_for() { return type{.oid = RECORDOID}; }
+};
+
+template <> struct type_traits<bool> {
+  type_traits() {}
+  type_traits(const bool &) {}
+  bool is(const type &t) { return t.oid == BOOLOID; }
+  constexpr type type_for() { return type{.oid = BOOLOID}; }
+};
+
+template <> struct type_traits<int64_t> {
+  type_traits() {}
+  type_traits(const int64_t &) {}
+  bool is(const type &t) { return t.oid == INT8OID || t.oid == INT4OID || t.oid == INT2OID; }
+  constexpr type type_for() { return type{.oid = INT8OID}; }
+};
+
+template <> struct type_traits<int32_t> {
+  type_traits() {}
+  type_traits(const int32_t &) {}
+  bool is(const type &t) { return t.oid == INT4OID || t.oid == INT2OID; }
+  constexpr type type_for() { return type{.oid = INT4OID}; }
+};
+
+template <> struct type_traits<int16_t> {
+  type_traits() {}
+  type_traits(const int16_t &) {}
+  bool is(const type &t) { return t.oid == INT2OID; }
+  constexpr type type_for() { return type{.oid = INT2OID}; }
+};
+
+template <> struct type_traits<int8_t> {
+  type_traits() {}
+  type_traits(const int8_t &) {}
+  bool is(const type &t) { return t.oid == INT2OID; }
+  constexpr type type_for() { return type{.oid = INT2OID}; }
+};
+
+template <> struct type_traits<double> {
+  type_traits() {}
+  type_traits(const double &) {}
+  bool is(const type &t) { return t.oid == FLOAT8OID || t.oid == FLOAT4OID; }
+  constexpr type type_for() { return type{.oid = FLOAT8OID}; }
+};
+
+template <> struct type_traits<float> {
+  type_traits() {}
+  type_traits(const float &) {}
+  bool is(const type &t) { return t.oid == FLOAT4OID; }
+  constexpr type type_for() { return type{.oid = FLOAT4OID}; }
+};
+
+template <> struct type_traits<text> {
+  type_traits() {}
+  type_traits(const text &) {}
+  bool is(const type &t) { return t.oid == TEXTOID; }
+  constexpr type type_for() { return type{.oid = TEXTOID}; }
+};
+
+template <> struct type_traits<std::string_view> {
+  type_traits() {}
+  type_traits(const std::string_view &) {}
+  bool is(const type &t) { return t.oid == TEXTOID; }
+  constexpr type type_for() { return type{.oid = TEXTOID}; }
+};
+
+template <> struct type_traits<std::string> {
+  type_traits() {}
+  type_traits(const std::string &) {}
+  bool is(const type &t) { return t.oid == TEXTOID; }
+  constexpr type type_for() { return type{.oid = TEXTOID}; }
+};
+
+template <> struct type_traits<byte_array> {
+  type_traits() {}
+  type_traits(const byte_array &) {}
+  bool is(const type &t) { return t.oid == BYTEAOID; }
+  constexpr type type_for() { return type{.oid = BYTEAOID}; }
+};
+
+template <> struct type_traits<bytea> {
+  type_traits() {}
+  type_traits(const bytea &) {}
+  bool is(const type &t) { return t.oid == BYTEAOID; }
+  constexpr type type_for() { return type{.oid = BYTEAOID}; }
+};
+
+template <> struct type_traits<char *> {
+  type_traits() {}
+  type_traits(const char *&) {}
+  bool is(const type &t) { return t.oid == CSTRINGOID; }
+  constexpr type type_for() { return type{.oid = CSTRINGOID}; }
+};
+
+template <> struct type_traits<const char *> {
+  type_traits() {}
+  type_traits(const char *&) {}
+  bool is(const type &t) { return t.oid == CSTRINGOID; }
+  constexpr type type_for() { return type{.oid = CSTRINGOID}; }
+};
+
+template <std::size_t N> struct type_traits<const char[N]> {
+  type_traits() {}
+  type_traits(const char (&)[N]) {}
+  bool is(const type &t) { return t.oid == CSTRINGOID; }
+  constexpr type type_for() { return type{.oid = CSTRINGOID}; }
+};
+
+template <flattenable F> struct type_traits<expanded_varlena<F>> {
+  type_traits() {}
+  type_traits(const expanded_varlena<F> &) {}
+  bool is(const type &t) { return t.oid == F::type().oid; }
+  constexpr type type_for() { return F::type(); }
+};
+
+template <> struct datum_conversion<datum> : default_datum_conversion<datum> {
+  static datum from_datum(const datum &d, oid, std::optional<memory_context>) { return d; }
+
+  static datum into_datum(const datum &t) { return t; }
+};
+
+template <> struct datum_conversion<nullable_datum> : default_datum_conversion<nullable_datum> {
+  static nullable_datum from_datum(const datum &d, oid, std::optional<memory_context>) {
+    return nullable_datum(d);
+  }
+
+  static datum into_datum(const nullable_datum &t) { return t.is_null() ? datum(0) : t; }
+};
+
+template <> struct datum_conversion<void *> : default_datum_conversion<void *> {
+  static void *from_datum(const datum &d, oid, std::optional<memory_context>) {
+    return reinterpret_cast<void *>(d.operator const ::Datum &());
+  }
+
+  static datum into_datum(const void *const &t) { return datum(reinterpret_cast<::Datum>(t)); }
+};
+
+template <> struct datum_conversion<oid> : default_datum_conversion<oid> {
+  static oid from_datum(const datum &d, oid, std::optional<memory_context>) {
+    return static_cast<oid>(d.operator const ::Datum &());
+  }
+
+  static datum into_datum(const oid &t) { return datum(static_cast<::Datum>(t)); }
+};
+
+template <> struct datum_conversion<size_t> : default_datum_conversion<size_t> {
+  static size_t from_datum(const datum &d, oid, std::optional<memory_context>) {
+    return static_cast<size_t>(d.operator const ::Datum &());
+  }
+
+  static datum into_datum(const size_t &t) { return datum(static_cast<::Datum>(t)); }
+};
+
+template <> struct datum_conversion<int64_t> : default_datum_conversion<int64_t> {
+  static int64_t from_datum(const datum &d, oid, std::optional<memory_context>) {
+    return static_cast<int64_t>(d.operator const ::Datum &());
+  }
+
+  static datum into_datum(const int64_t &t) { return datum(static_cast<::Datum>(t)); }
+};
+
+template <> struct datum_conversion<int32_t> : default_datum_conversion<int32_t> {
+  static int32_t from_datum(const datum &d, oid, std::optional<memory_context>) {
+    return static_cast<int32_t>(d.operator const ::Datum &());
+  }
+  static datum into_datum(const int32_t &t) { return datum(static_cast<::Datum>(t)); }
+};
+
+template <> struct datum_conversion<int16_t> : default_datum_conversion<int16_t> {
+  static int16_t from_datum(const datum &d, oid, std::optional<memory_context>) {
+    return static_cast<int16_t>(d.operator const ::Datum &());
+  }
+  static datum into_datum(const int16_t &t) { return datum(static_cast<::Datum>(t)); }
+};
+
+template <> struct datum_conversion<bool> : default_datum_conversion<bool> {
+  static bool from_datum(const datum &d, oid, std::optional<memory_context>) {
+    return static_cast<bool>(d.operator const ::Datum &());
+  }
+  static datum into_datum(const bool &t) { return datum(static_cast<::Datum>(t)); }
+};
+
+template <> struct datum_conversion<double> : default_datum_conversion<double> {
+  static double from_datum(const datum &d, oid, std::optional<memory_context>) {
+    return DatumGetFloat8(d.operator const ::Datum &());
+  }
+
+  static datum into_datum(const double &t) { return datum(Float8GetDatum(t)); }
+};
+
+template <> struct datum_conversion<float> : default_datum_conversion<float> {
+  static float from_datum(const datum &d, oid, std::optional<memory_context>) {
+    return DatumGetFloat4(d.operator const ::Datum &());
+  }
+
+  static datum into_datum(const float &t) { return datum(Float4GetDatum(t)); }
+};
+
+// Specializations for text and bytea:
+template <> struct datum_conversion<text> : default_datum_conversion<text> {
+  static text from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
+    return text{d, ctx};
+  }
+
+  static datum into_datum(const text &t) { return t.get_datum(); }
+};
+
+template <> struct datum_conversion<bytea> : default_datum_conversion<bytea> {
+  static bytea from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
+    return bytea{d, ctx};
+  }
+
+  static datum into_datum(const bytea &t) { return t.get_datum(); }
+};
+
+template <> struct datum_conversion<byte_array> : default_datum_conversion<byte_array> {
+  static byte_array from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
+    return bytea{d, ctx};
+  }
+
+  static datum into_datum(const byte_array &t) {
+    // This is not perfect if the data was already allocated with Postgres
+    // But once we're with the byte_array (std::span) we've lost this information
+    // TODO: can we do any better here?
+    return bytea(t, memory_context()).get_datum();
+  }
+};
+
+// Specializations for std::string_view and std::string.
+// Here we re-use the conversion for text.
+template <> struct datum_conversion<std::string_view> : default_datum_conversion<std::string_view> {
+  static std::string_view from_datum(const datum &d, oid oid, std::optional<memory_context> ctx) {
+    return datum_conversion<text>::from_datum(d, oid, ctx);
+  }
+
+  static datum into_datum(const std::string_view &t) {
+    size_t sz = t.size();
+    void *result = ffi_guard{::palloc}(sz + VARHDRSZ);
+    SET_VARSIZE(result, t.size() + VARHDRSZ);
+    memcpy(VARDATA(result), t.data(), sz);
+    return datum(reinterpret_cast<::Datum>(result));
+  }
+};
+
+template <> struct datum_conversion<std::string> : default_datum_conversion<std::string> {
+  static std::string from_datum(const datum &d, oid oid, std::optional<memory_context> ctx) {
+    // Convert the text to a std::string_view then construct a std::string.
+    return std::string(datum_conversion<text>::from_datum(d, oid, ctx).operator std::string_view());
+  }
+
+  static datum into_datum(const std::string &t) {
+    return datum_conversion<std::string_view>::into_datum(t);
+  }
+};
+
+template <> struct datum_conversion<const char *> : default_datum_conversion<const char *> {
+  static const char *from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
+    return DatumGetPointer(d);
+  }
+
+  static datum into_datum(const char *const &t) { return datum(PointerGetDatum(t)); }
+};
+
+template <std::size_t N>
+struct datum_conversion<char[N]> : default_datum_conversion<char[N], const char *> {
+  static const char *from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
+    return DatumGetPointer(d);
+  }
+
+  static datum into_datum(const char (&t)[N]) { return datum(PointerGetDatum(t)); }
+};
+
+template <typename T>
+struct datum_conversion<T, std::enable_if_t<expanded_varlena_type<T>>>
+    : default_datum_conversion<T> {
+  static T from_datum(const datum &d, oid, std::optional<memory_context> ctx) { return {d, ctx}; }
+
+  static datum into_datum(const T &t) { return t.get_expanded_datum(); }
+};
+
+template <typename T> struct datum_conversion<T, std::enable_if_t<utils::is_optional<T>>> {
+
+  static T from_nullable_datum(const nullable_datum &d, const oid oid,
+                               std::optional<memory_context> context = std::nullopt) {
+    if (d.is_null()) {
+      return std::nullopt;
+    }
+    return from_datum(d, oid, context);
+  }
+
+  static T from_datum(const datum &d, oid oid, std::optional<memory_context> ctx) {
+    return datum_conversion<utils::remove_optional_t<T>>::from_datum(d, oid, ctx);
+  }
+
+  static datum into_datum(const T &t) { return t.get_expanded_datum(); }
+};
+
+/**
+ * @brief Type identified by its name
+ *
+ * @note Once constructed, the resolved type stays the same and doesn't change during
+ *       the lifetime of the value.
+ */
+struct named_type : public type {
+  /**
+   * @brief Type identified by an unqualified name
+   *
+   * @param name unqualified type name
+   */
+  named_type(const std::string_view name) : type(type{.oid = ::TypenameGetTypid(name.data())}) {}
+  /**
+   * @brief Type identified by a qualified name
+   *
+   * @param schema schema name
+   * @param name type name
+   */
+  named_type(const std::string_view schema, const std::string_view name)
+      : type({.oid = ([&]() {
+                cppgres::oid nsoid = ffi_guard{::LookupExplicitNamespace}(schema.data(), false);
+                cppgres::oid oid = InvalidOid;
+                if (OidIsValid(nsoid)) {
+                  oid = (*syscache<Form_pg_type, const char *, cppgres::oid>(
+                             TYPENAMENSP, std::string(name).c_str(), nsoid))
+                            .oid;
+                }
+                return oid;
+              })()}) {}
+};
+
+} // namespace cppgres
+
+#include <ranges>
+
+namespace cppgres {
+
+/**
+ * @brief Tuple descriptor operator
+ *
+ * Allows to create new or manipulate existing tuple descriptors
+ */
+struct tuple_descriptor {
+
+  /**
+   * @brief Create a tuple descriptor for a given number of attributes
+   *
+   * @param nattrs number of attributes
+   * @param ctx memory context, current transaction context by default
+   */
+  tuple_descriptor(int nattrs, memory_context ctx = memory_context())
+      : tupdesc(([&]() {
+          memory_context_scope<memory_context> scope(ctx);
+          auto res = ffi_guard{::CreateTemplateTupleDesc}(nattrs);
+          return res;
+        }())),
+        blessed(false), owned(true) {
+    for (int i = 0; i < nattrs; i++) {
+      operator[](i).attcollation = InvalidOid;
+      operator[](i).attisdropped = false;
+    }
+  }
+  /**
+   * @brief Create a tuple descriptor for a given `TupleDesc`
+   *
+   * @param tupdesc existing attribute
+   * @param blessed true if already blessed (default)
+   */
+  tuple_descriptor(TupleDesc tupdesc, bool blessed = true)
+      : tupdesc(tupdesc), blessed(blessed), owned(false) {}
+
+  /**
+   * @brief Copy constructor
+   *
+   * Creates a copy instance of the tuple descriptor in the current memory contet
+   */
+  tuple_descriptor(tuple_descriptor &other)
+      : tupdesc(ffi_guard{::CreateTupleDescCopyConstr}(other.populate_compact_attribute())),
+        blessed(other.blessed), owned(other.owned) {}
+
+  /**
+   * @brief Move constructor
+   */
+  tuple_descriptor(tuple_descriptor &&other)
+      : tupdesc(other.tupdesc), blessed(other.blessed), owned(other.owned) {}
+
+  /**
+   * @brief Copy assignment
+   *
+   * Creates a copy instance of the tuple descriptor in the current memory contet
+   */
+  tuple_descriptor &operator=(const tuple_descriptor &other) {
+    tupdesc = ffi_guard{::CreateTupleDescCopyConstr}(other.populate_compact_attribute());
+    blessed = other.blessed;
+    return *this;
+  }
+
+  /**
+   * @brief Number of attributes
+   */
+  int attributes() const { return tupdesc->natts; }
+
+  /**
+   * @brief Get a reference to `Form_pg_attribute`
+   *
+   * @throws std::out_of_range when attribute index is out of range
+   */
+  ::FormData_pg_attribute &operator[](int n) const {
+    check_bounds(n);
+    return *TupleDescAttr(tupdesc, n);
+  }
+
+  type get_type(int n) const {
+    auto &att = operator[](n);
+    return {att.atttypid};
+  }
+
+  /**
+   * @brief Set attribute type
+   *
+   * @param n Zero-based attribute index
+   * @param type new attribute type
+   *
+   * @throws std::out_of_range when attribute index is out of range
+   */
+  void set_type(int n, const type &type) {
+    check_not_blessed();
+    syscache<Form_pg_type, oid> typ(type.oid);
+    auto &att = operator[](n);
+    att.atttypid = (*typ).oid;
+    att.attcollation = (*typ).typcollation;
+    att.attlen = (*typ).typlen;
+    att.attstorage = (*typ).typstorage;
+    att.attalign = (*typ).typalign;
+    att.atttypmod = (*typ).typtypmod;
+    att.attbyval = (*typ).typbyval;
+  }
+
+  std::string_view get_name(int n) {
+    auto &att = operator[](n);
+    return NameStr(att.attname);
+  }
+
+  /**
+   * @brief Set attribute name
+   *
+   * @param n Zero-based attribute index
+   * @param name new attribute name
+   *
+   * @throws std::out_of_range when attribute index is out of range
+   */
+  void set_name(int n, const name &name) {
+    check_not_blessed();
+    auto &att = operator[](n);
+    att.attname = name;
+  }
+
+  /**
+   * @brief returns a pointer to `TupleDesc`
+   *
+   * At this point, it'll be prepared and blessed.
+   */
+  operator TupleDesc() {
+    populate_compact_attribute();
+    if (!blessed) {
+      tupdesc = ffi_guard{::BlessTupleDesc}(tupdesc);
+      blessed = true;
+    }
+    return tupdesc;
+  }
+
+#if PG_MAJORVERSION_NUM > 16
+  /**
+   * @brief Determines whether two tuple descriptors have equal row types.
+   *
+   * This is used to check whether two record types are compatible, whether
+   * function return row types are the same, and other similar situations.
+   */
+  bool equal_row_types(const tuple_descriptor &other) {
+    return ffi_guard{::equalRowTypes}(tupdesc, other.tupdesc);
+  }
+#endif
+
+  /**
+   * @brief Determines whether two tuple descriptors have equal row types.
+   *
+   * This is used to check whether two record types are compatible, whether
+   * function return row types are the same, and other similar situations.
+   */
+  bool equal_types(const tuple_descriptor &other) {
+    if (tupdesc->natts != other.tupdesc->natts)
+      return false;
+    if (tupdesc->tdtypeid != other.tupdesc->tdtypeid)
+      return false;
+
+    for (int i = 0; i < other.attributes(); i++) {
+      FormData_pg_attribute &att1 = operator[](i);
+      FormData_pg_attribute &att2 = other[i];
+
+      if (att1.atttypid != att2.atttypid || att1.atttypmod != att2.atttypmod ||
+          att1.attcollation != att2.attcollation || att1.attisdropped != att2.attisdropped ||
+          att1.attlen != att2.attlen || att1.attalign != att2.attalign) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * @brief Compare two TupleDesc structures for logical equality
+   *
+   * @note This includes checking attribute names.
+   */
+  bool operator==(const tuple_descriptor &other) {
+    return ffi_guard{::equalTupleDescs}(tupdesc, other.tupdesc);
+  }
+
+  /**
+   * @brief Returns true if the tuple descriptor is blessed
+   */
+  bool is_blessed() const { return blessed; }
+
+  operator TupleDesc() const { return tupdesc; }
+
+private:
+  inline void check_bounds(int n) const {
+    if (n + 1 > tupdesc->natts || n < 0) {
+      throw std::out_of_range(cppgres::fmt::format(
+          "attribute index {} is out of bounds for the tuple descriptor with the size of {}", n,
+          tupdesc->natts));
+    }
+  }
+  inline void check_not_blessed() const {
+    if (blessed) {
+      throw std::runtime_error("tuple_descriptor already blessed");
+    }
+  }
+
+  TupleDesc populate_compact_attribute() const {
+#if PG_MAJORVERSION_NUM >= 18
+    for (int i = 0; i < tupdesc->natts; i++) {
+      ffi_guard{::populate_compact_attribute}(tupdesc, i);
+    }
+#endif
+    return tupdesc;
+  }
+
+  TupleDesc tupdesc;
+  bool blessed;
+  bool owned;
+};
+
+static_assert(std::copy_constructible<tuple_descriptor>);
+static_assert(std::move_constructible<tuple_descriptor>);
+static_assert(std::is_copy_assignable_v<tuple_descriptor>);
+
+/**
+ * @brief Runtime-typed value of `record` type
+ *
+ * These records don't have a structure known upfront, for example, when a value
+ * of this type (`record`) are passed into a function.
+ */
+struct record {
+
+  friend struct datum_conversion<record>;
+
+  record(HeapTupleHeader heap_tuple, abstract_memory_context &ctx)
+      : tupdesc(/* FIXME: can we use the non-copy version with refcounting? */ ffi_guard{
+            ::lookup_rowtype_tupdesc_copy}(HeapTupleHeaderGetTypeId(heap_tuple),
+                                           HeapTupleHeaderGetTypMod(heap_tuple))),
+        tuple(ctx.template alloc<HeapTupleData>()) {
+#if PG_MAJORVERSION_NUM < 18
+    tuple->t_len = HeapTupleHeaderGetDatumLength(tupdesc.operator TupleDesc());
+#else
+    tuple->t_len = HeapTupleHeaderGetDatumLength(heap_tuple);
+#endif
+    tuple->t_data = heap_tuple;
+  }
+  record(HeapTupleHeader heap_tuple, abstract_memory_context &&ctx) : record(heap_tuple, ctx) {}
+
+  template <std::input_iterator Iter>
+  requires convertible_into_nullable_datum<typename std::iterator_traits<Iter>::value_type>
+  record(tuple_descriptor &tupdesc, Iter begin, Iter end)
+      : tupdesc(tupdesc), tuple([&]() {
+          std::vector<::Datum> values;
+          std::vector<uint8_t> nulls;
+          for (auto it = begin; it != end; ++it) {
+            auto nd = into_nullable_datum(*it);
+            values.push_back(nd.is_null() ? ::Datum(0) : nd);
+            nulls.push_back(nd.is_null() ? 1 : 0);
+          }
+          return ffi_guard{::heap_form_tuple}(this->tupdesc, values.data(),
+                                              reinterpret_cast<bool *>(nulls.data()));
+        }()) {}
+
+  template <convertible_into_nullable_datum... D>
+  record(tuple_descriptor &tupdesc, D &&...args)
+      : tupdesc(tupdesc), tuple([&]() {
+          std::array<nullable_datum, sizeof...(D)> datums = {
+              cppgres::into_nullable_datum(std::move(args))...};
+          std::array<bool, sizeof...(D)> nulls;
+          std::ranges::copy(datums | std::views::transform([](auto &v) { return v.is_null(); }),
+                            nulls.begin());
+          std::array<::Datum, sizeof...(D)> values;
+          std::ranges::copy(
+              datums | std::views::transform([](auto &v) { return v.is_null() ? ::Datum(0) : v; }),
+              values.begin());
+          return ffi_guard{::heap_form_tuple}(this->tupdesc, values.data(), nulls.data());
+        }()) {}
+
+  /**
+   * @brief Number of attributes in the record
+   */
+  int attributes() const { return tupdesc.operator TupleDesc()->natts; }
+
+  /**
+   * @brief Type of attribute using a 0-based index
+   *
+   * @throws std::out_of_range
+   */
+  type attribute_type(int n) const {
+    check_bounds(n);
+    return {.oid = TupleDescAttr(tupdesc.operator TupleDesc(), n)->atttypid};
+  }
+
+  /**
+   * @brief Name of attribute using a 0-based index
+   *
+   * @throws std::out_of_range
+   */
+  std::string_view attribute_name(int n) const {
+    check_bounds(n);
+    return {NameStr(TupleDescAttr(tupdesc.operator TupleDesc(), n)->attname)};
+  }
+
+  /**
+   * @brief Get attribute value (datum) using a 0-based index
+   *
+   * @throws std::out_of_range
+   */
+  nullable_datum get_attribute(int n) {
+    bool isnull;
+    check_bounds(n);
+    auto _heap_getattr = ffi_guard{
+#if PG_MAJORVERSION_NUM < 15
+        // Handle the fact that it is a macro
+        [](::HeapTuple tup, int attnum, ::TupleDesc tupleDesc, bool *isnull) {
+          return heap_getattr(tup, attnum, tupleDesc, isnull);
+        }
+#else
+        ::heap_getattr
+#endif
+    };
+    datum d(_heap_getattr(tuple, n + 1, tupdesc.operator TupleDesc(), &isnull));
+    return isnull ? nullable_datum() : nullable_datum(d);
+  }
+
+  /**
+   * @brief Get attribute by name
+   *
+   * @throws std::out_of_range
+   */
+  nullable_datum operator[](std::string_view name) {
+    for (int i = 0; i < attributes(); i++) {
+      if (attribute_name(i) == name) {
+        return get_attribute(i);
+      }
+    }
+    throw std::out_of_range(cppgres::fmt::format("no attribute by the name of {}", name));
+  }
+
+  /**
+   * @brief Get attribute by 0-based index
+   *
+   * @throws std::out_of_range
+   */
+  nullable_datum operator[](int n) { return get_attribute(n); }
+
+  operator HeapTuple() const { return tuple; }
+
+  /**
+   * @brief Returns tuple descriptor
+   */
+  tuple_descriptor get_tuple_descriptor() const { return tupdesc; }
+
+  record(const record &other) : tupdesc(other.tupdesc), tuple(other.tuple) {}
+  record(const record &&other) : tupdesc(std::move(other.tupdesc)), tuple(other.tuple) {}
+  record &operator=(const record &other) {
+    tupdesc = other.tupdesc;
+    tuple = other.tuple;
+    return *this;
+  }
+
+private:
+  inline void check_bounds(int n) const {
+    if (n + 1 > attributes() || n < 0) {
+      throw std::out_of_range(cppgres::fmt::format(
+          "attribute index {} is out of bounds for record with the size of {}", n, attributes()));
+    }
+  }
+
+  tuple_descriptor tupdesc;
+  HeapTuple tuple;
+};
+static_assert(std::copy_constructible<record>);
+static_assert(std::move_constructible<record>);
+static_assert(std::is_copy_assignable_v<record>);
+
+template <> struct datum_conversion<record> : default_datum_conversion<record> {
+  static record from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
+    return {reinterpret_cast<HeapTupleHeader>(ffi_guard{::pg_detoast_datum}(
+                reinterpret_cast<struct ::varlena *>(d.operator const ::Datum &()))),
+            ctx.has_value() ? ctx.value() : memory_context()};
+  }
+
+  static datum into_datum(const record &t) { return datum(PointerGetDatum(t.tuple)); }
+};
+
+template <> struct type_traits<record> {
+  bool is(const type &t) {
+    if (t.oid == RECORDOID)
+      return true;
+    // Check if it is a composite type and therefore can be coerced to a record
+    syscache<Form_pg_type, oid> cache(t.oid);
+    return (*cache).typtype == 'c';
+  }
+  constexpr type type_for() { return {.oid = RECORDOID}; }
+};
+
+} // namespace cppgres
+/**
+* \file
+ */
+
+#include <iterator>
+
+
+namespace cppgres {
+
+template <typename I>
+concept datumable_iterator =
+    requires(I i) {
+      { std::begin(i) } -> std::input_iterator;
+      { std::end(i) } -> std::sentinel_for<decltype(std::begin(i))>;
+    } &&
+    all_from_nullable_datum<typename std::iterator_traits<decltype(std::begin(
+        std::declval<I &>()))>::value_type>::value;
+
+template <datumable_iterator I> struct set_iterator_traits {
+  using value_type = std::iterator_traits<decltype(std::begin(std::declval<I &>()))>::value_type;
+};
+
+template <typename I> requires datumable_iterator<I>
+struct type_traits<I> {
+  bool is(type &t) { return t.oid == RECORDOID; }
+};
+
+} // namespace cppgres
+
+
+namespace cppgres {
+
+struct value {
+
+  value(nullable_datum &&datum, type &&type) : datum_(datum), type_(type) {}
+
+  const type &get_type() const { return type_; }
+
+  const nullable_datum &get_nullable_datum() const { return datum_; };
+
+private:
+  nullable_datum datum_;
+  type type_;
+};
+
+template <> struct datum_conversion<value> {
+
+  static value from_nullable_datum(const nullable_datum &d, oid oid,
+                                   std::optional<memory_context>) {
+    return {nullable_datum(d), type{.oid = oid}};
+  }
+
+  static value from_datum(const datum &d, oid oid, std::optional<memory_context>) {
+    return {nullable_datum(d), type{.oid = oid}};
+  }
+
+  static datum into_datum(const value &t) { return t.get_nullable_datum(); }
+
+  static nullable_datum into_nullable_datum(const value &t) { return t.get_nullable_datum(); }
+};
+
+template <> struct type_traits<value> {
+  type_traits() : value_(std::nullopt) {}
+  type_traits(value &value) : value_(std::optional(std::ref(value))) {}
+  bool is(const type &t) { return !value_.has_value() || (*value_).get().get_type() == t; }
+  constexpr type type_for() {
+    if (value_.has_value()) {
+      return (*value_).get().get_type();
+    }
+    throw std::runtime_error("can't determine type for an uninitialized value");
+  }
+
+private:
+  std::optional<std::reference_wrapper<value>> value_;
+};
+
+} // namespace cppgres
+
+#include <array>
+#include <complex>
+#include <iostream>
+#include <stack>
+#include <tuple>
+#include <typeinfo>
+
+namespace cppgres {
+
+template <typename T>
+concept convertible_into_nullable_datum_or_set_iterator_or_void =
+    convertible_into_nullable_datum<T> || datumable_iterator<T> || std::same_as<T, void>;
+
+/**
+ * @brief Function that operates on values of Postgres types
+ *
+ * These functions take @ref cppgres::convertible_from_nullable_datum arguments and returns
+ * @ref cppgres::convertible_into_nullable_datum, or @ref cppgres::datumable_iterator
+ * (for [Set-Returning
+ * Functions](https://www.postgresql.org/docs/current/xfunc-c.html#XFUNC-C-RETURN-SET)).
+ */
+template <typename Func>
+concept datumable_function =
+    requires { typename utils::function_traits::function_traits<Func>::argument_types; } &&
+    all_from_nullable_datum<
+        typename utils::function_traits::function_traits<Func>::argument_types>::value &&
+    requires(Func f) {
+      {
+        std::apply(
+            f,
+            std::declval<typename utils::function_traits::function_traits<Func>::argument_types>())
+      } -> convertible_into_nullable_datum_or_set_iterator_or_void;
+    };
+
+struct function_call_info {
+  function_call_info(::FunctionCallInfo info) : info_(info) {}
+
+  operator FunctionCallInfo() const { return info_; }
+
+  /**
+   * @brief number of arguments actually passed
+   */
+  short nargs() const { return info_->nargs; }
+
+  /**
+   * @brief passed arguments
+   */
+
+  auto args() const {
+    return std::views::iota(0, nargs()) | std::views::transform([this](int i) -> nullable_datum {
+             return nullable_datum(info_->args[i]);
+           });
+  }
+
+  /**
+   * @brief argument types
+   */
+  auto arg_types() const {
+    return std::views::iota(0, nargs()) | std::views::transform([this](int i) -> type {
+             return {.oid = ffi_guard{::get_fn_expr_argtype}(info_->flinfo, i)};
+           });
+  }
+
+  /**
+   * @brief typed passed argument
+   */
+
+  auto arg_values() const {
+    return std::views::iota(0, nargs()) | std::views::transform([this](int i) -> value {
+             return value(nullable_datum(info_->args[i]),
+                          {.oid = ffi_guard{::get_fn_expr_argtype}(info_->flinfo, i)});
+           });
+  }
+
+  /**
+   * @brief called function OID
+   */
+  oid called_function_oid() const { return info_->flinfo->fn_oid; }
+
+  /**
+   * @brief return type
+   */
+  type return_type() const { return {.oid = ffi_guard{::get_fn_expr_rettype}(info_->flinfo)}; }
+
+private:
+  ::FunctionCallInfo info_;
+};
+
+struct current_postgres_function {
+
+  static std::optional<bool> atomic() {
+    if (!calls.empty()) {
+      auto ctx = calls.top()->context;
+      if (ctx != nullptr && IsA(ctx, CallContext)) {
+        return reinterpret_cast<::CallContext *>(ctx)->atomic;
+      }
+    }
+
+    return std::nullopt;
+  }
+
+  static std::optional<function_call_info> call_info() {
+    if (!calls.empty()) {
+      return calls.top();
+    }
+
+    return std::nullopt;
+  }
+
+  template <datumable_function Func> friend struct postgres_function;
+
+private:
+  struct handle {
+    ~handle() { calls.pop(); }
+
+    friend struct current_postgres_function;
+
+  private:
+    handle() {}
+  };
+
+  static handle push(::FunctionCallInfo fcinfo) {
+    calls.push(fcinfo);
+    return handle{};
+  }
+  static void pop() { calls.pop(); }
+
+  static inline std::stack<::FunctionCallInfo> calls;
+};
+
+/**
+ * @brief Postgres function implemented in C++
+ *
+ * It wraps a function to handle conversion of arguments and return, enforce arity, convert C++
+ * exceptions to errors. Additionally, it handles [Set-Returning
+ * Functions](https://www.postgresql.org/docs/current/xfunc-c.html#XFUNC-C-RETURN-SET) (SRFs),
+ * implemented by functions returning @ref cppgres::datumable_iterator.
+ *
+ * @tparam Func function (or lambda) that conforms to the @ref cppgres::datumable_function concept.
+ */
+template <datumable_function Func> struct postgres_function {
+  Func func;
+
+  explicit postgres_function(Func f) : func(f) {}
+
+  // Use the function_traits to extract argument types.
+  using traits = utils::function_traits::function_traits<Func>;
+  using argument_types = typename traits::argument_types;
+  using return_type = utils::function_traits::invoke_result_from_tuple_t<Func, argument_types>;
+  static constexpr std::size_t arity = traits::arity;
+
+  /**
+   * Invoke the function as per Postgres convention
+   */
+  auto operator()(FunctionCallInfo fc) -> ::Datum {
+
+    return exception_guard([&] {
+      // return type
+      auto rettype = type{.oid = ffi_guard{::get_fn_expr_rettype}(fc->flinfo)};
+      auto retset = fc->flinfo->fn_retset;
+
+      if constexpr (datumable_iterator<return_type>) {
+        // Check this before checking the type of `retset`
+        auto rsinfo = reinterpret_cast<::ReturnSetInfo *>(fc->resultinfo);
+        if (rsinfo == nullptr) {
+          report(ERROR, "caller is not expecting a set");
+        }
+      }
+
+      if (!OidIsValid(rettype.oid)) {
+        // TODO: not very efficient to look it up every time
+        syscache<Form_pg_proc, oid> cache(fc->flinfo->fn_oid);
+        rettype = type{.oid = (*cache).prorettype};
+        retset = (*cache).proretset;
+      }
+
+      if (retset) {
+        if constexpr (datumable_iterator<return_type>) {
+          using set_value_type = set_iterator_traits<return_type>::value_type;
+          if (!type_traits<set_value_type>().is(rettype)) {
+            report(ERROR, "unexpected set's return type, can't convert `%s` into `%.*s`",
+                   rettype.name().data(), utils::type_name<set_value_type>().length(),
+                   utils::type_name<set_value_type>().data());
+          }
+        } else {
+          report(ERROR,
+                 "unexpected return type, set is expected, but `%.*s` does not conform to "
+                 "`cppgres::datumable_iterator`",
+                 utils::type_name<return_type>().length(), utils::type_name<return_type>().data());
+        }
+      } else if (!type_traits<return_type>().is(rettype)) {
+        report(ERROR, "unexpected return type, can't convert `%s` into `%.*s`",
+               rettype.name().data(), utils::type_name<return_type>().length(),
+               utils::type_name<return_type>().data());
+      }
+
+      // arguments
+      short accounted_for_args = 0;
+      auto t = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+        return argument_types{([&]() -> utils::tuple_element_t<Is, argument_types> {
+          using ptyp = utils::tuple_element_t<Is, argument_types>;
+          auto typ = type{.oid = ffi_guard{::get_fn_expr_argtype}(fc->flinfo, Is)};
+          if (!OidIsValid(typ.oid)) {
+            // TODO: not very efficient to look it up every time
+            syscache<Form_pg_proc, oid> cache(fc->flinfo->fn_oid);
+            if ((*cache).proargtypes.dim1 > Is) {
+              typ = type{.oid = (*cache).proargtypes.values[Is]};
+            }
+          }
+          if (!type_traits<ptyp>().is(typ)) {
+            report(ERROR, "unexpected type in position %d, can't convert `%s` into `%.*s`", Is,
+                   typ.name().data(), utils::type_name<ptyp>().length(),
+                   utils::type_name<ptyp>().data());
+          }
+          accounted_for_args++;
+          return from_nullable_datum<ptyp>(nullable_datum(fc->args[Is]), typ.oid);
+        }())...};
+      }(std::make_index_sequence<utils::tuple_size_v<argument_types>>{});
+
+      if (arity != accounted_for_args) {
+        report(ERROR, "expected %d arguments, got %d instead", arity, accounted_for_args);
+      }
+
+      auto call_handle = current_postgres_function::push(fc);
+
+      if constexpr (datumable_iterator<return_type>) {
+        auto rsinfo = reinterpret_cast<::ReturnSetInfo *>(fc->resultinfo);
+        // TODO: For now, let's assume materialized model
+        using set_value_type = set_iterator_traits<return_type>::value_type;
+        if constexpr (std::same_as<set_value_type, record>) {
+
+          auto natts = rsinfo->expectedDesc == nullptr ? -1 : rsinfo->expectedDesc->natts;
+
+          rsinfo->returnMode = SFRM_Materialize;
+
+          memory_context_scope scope(memory_context(rsinfo->econtext->ecxt_per_query_memory));
+
+          ::Tuplestorestate *tupstore = ffi_guard{::tuplestore_begin_heap}(
+              (rsinfo->allowedModes & SFRM_Materialize_Random) == SFRM_Materialize_Random, false,
+              work_mem);
+          rsinfo->setResult = tupstore;
+
+          auto res = std::apply(func, t);
+
+          bool checked = false;
+          for (auto r : res) {
+            auto nargs = r.attributes();
+            if (!checked) {
+              if (rsinfo->expectedDesc != nullptr && nargs != natts) {
+                throw std::runtime_error(
+                    cppgres::fmt::format("expected record with {} value{}, got {} instead", nargs,
+                                nargs == 1 ? "" : "s", natts));
+              }
+              if (rsinfo->expectedDesc != nullptr &&
+                  !r.get_tuple_descriptor().equal_types(
+                      cppgres::tuple_descriptor(rsinfo->expectedDesc))) {
+                throw std::runtime_error("expected and returned records do not match");
+              }
+              checked = true;
+            }
+
+            ffi_guard{::tuplestore_puttuple}(tupstore, r);
+          }
+          fc->isnull = true;
+          return ::Datum(0);
+        } else {
+          constexpr auto nargs = utils::tuple_size_v<set_value_type>;
+
+          auto natts = rsinfo->expectedDesc->natts;
+
+          if (nargs != natts) {
+            throw std::runtime_error(cppgres::fmt::format("expected set with {} value{}, got {} instead",
+                                                 nargs, nargs == 1 ? "" : "s", natts));
+          }
+
+          [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            (([&] {
+               auto oid = ffi_guard{::SPI_gettypeid}(rsinfo->expectedDesc, Is + 1);
+               auto t = type{.oid = oid};
+               using typ = utils::tuple_element_t<Is, set_value_type>;
+               if (!type_traits<typ>().is(t)) {
+                 throw std::invalid_argument(
+                     cppgres::fmt::format("invalid type in record's position {} ({}), got OID {}", Is,
+                                 utils::type_name<typ>(), oid));
+               }
+             }()),
+             ...);
+          }(std::make_index_sequence<nargs>{});
+
+          rsinfo->returnMode = SFRM_Materialize;
+
+          memory_context_scope scope(memory_context(rsinfo->econtext->ecxt_per_query_memory));
+
+          ::Tuplestorestate *tupstore = ffi_guard{::tuplestore_begin_heap}(
+              (rsinfo->allowedModes & SFRM_Materialize_Random) == SFRM_Materialize_Random, false,
+              work_mem);
+          rsinfo->setResult = tupstore;
+
+          auto result = std::apply(func, t);
+
+          for (auto it : result) {
+            CHECK_FOR_INTERRUPTS();
+            std::array<::Datum, nargs> values = std::apply(
+                [](auto &&...elems) -> std::array<::Datum, sizeof...(elems)> {
+                  return {into_nullable_datum(elems)...};
+                },
+                utils::tie(it));
+            std::array<bool, nargs> isnull = std::apply(
+                [](auto &&...elems) -> std::array<bool, sizeof...(elems)> {
+                  return {into_nullable_datum(elems).is_null()...};
+                },
+                utils::tie(it));
+            ffi_guard{::tuplestore_putvalues}(tupstore, rsinfo->expectedDesc, values.data(),
+                                              isnull.data());
+          }
+
+          fc->isnull = true;
+          return ::Datum(0);
+        }
+      } else {
+        if constexpr (std::same_as<return_type, void>) {
+          std::apply(func, t);
+          return ::Datum(0);
+        } else {
+          auto result = std::apply(func, t);
+          nullable_datum nd = into_nullable_datum(result);
+          if (nd.is_null()) {
+            fc->isnull = true;
+            return ::Datum(0);
+          }
+          return nd.operator const ::Datum &();
+        }
+      }
+    })();
+    __builtin_unreachable();
+  }
+};
+
+} // namespace cppgres
+
+namespace cppgres {
+
+template <class T, class... Args>
+concept aggregate = requires(T t, Args &&...args) {
+  { t.update(args...) };
+};
+
+template <class T, class... Args>
+concept finalizable_aggregate = aggregate<T, Args...> && requires(T t) {
+  { t.finalize() } -> convertible_into_datum;
+};
+
+template <class T, class... Args>
+concept serializable_aggregate = aggregate<T, Args...> && requires(T t, bytea &ba) {
+  { t.serialize() } -> std::same_as<bytea>;
+  { T(ba) } -> std::same_as<T>;
+};
+
+template <class T, class... Args>
+concept combinable_aggregate = aggregate<T, Args...> && requires(T &&t, T &&t1) {
+  { T(t, t1) } -> std::same_as<T>;
+};
+
+template <class Agg, typename... InTs> datum aggregate_sfunc(value state, InTs... args) {
+
+  MemoryContext aggctx;
+  if (!ffi_guard{::AggCheckCallContext}(current_postgres_function::call_info().operator*(),
+                                        &aggctx)) {
+    report(ERROR, "not aggregate context");
+  }
+
+  if constexpr (!convertible_into_datum<Agg> && finalizable_aggregate<Agg, InTs...>) {
+    Agg *state0;
+    if (state.get_nullable_datum().is_null()) {
+      state0 = memory_context(aggctx).alloc<Agg>();
+      std::construct_at(state0);
+    } else {
+      state0 = reinterpret_cast<Agg *>(
+          from_nullable_datum<void *>(state.get_nullable_datum(), state.get_type().oid));
+    }
+
+    state0->update(args...);
+
+    return datum_conversion<void *>::into_datum(reinterpret_cast<void *>(state0));
+  } else if constexpr (convertible_into_datum<Agg>) {
+    Agg state0 = datum_conversion<Agg>::from_nullable_datum(state.get_nullable_datum(), ANYOID);
+    state0.update(args...);
+    return datum_conversion<Agg>::into_datum(state0);
+  }
+  report(ERROR, "not supported");
+  __builtin_unreachable();
+}
+
+template <class Agg, typename... InTs> nullable_datum aggregate_ffunc(value state) {
+  if constexpr (finalizable_aggregate<Agg, InTs...>) {
+    Agg *state0;
+    if (state.get_nullable_datum().is_null()) {
+      state0 = memory_context(memory_context()).alloc<Agg>();
+      std::construct_at(state0);
+    } else {
+      state0 = reinterpret_cast<Agg *>(
+          from_nullable_datum<void *>(state.get_nullable_datum(), state.get_type().oid));
+    }
+    return into_nullable_datum(state0->finalize());
+  } else {
+    report(ERROR, "this aggregate does not support final function");
+    __builtin_unreachable();
+  }
+}
+
+template <class Agg, typename... InTs> bytea aggregate_serial(value state) {
+  if constexpr (serializable_aggregate<Agg, InTs...>) {
+    if (state.get_type().oid == INTERNALOID) {
+      Agg *state0;
+      state0 = reinterpret_cast<Agg *>(
+          from_nullable_datum<void *>(state.get_nullable_datum(), state.get_type().oid));
+      bytea ba = state0->serialize();
+      return ba;
+    }
+  }
+  report(ERROR, "this aggregate does not support serialize");
+  __builtin_unreachable();
+}
+
+template <class Agg, typename... InTs> datum aggregate_deserial(bytea ba, value) {
+  if constexpr (serializable_aggregate<Agg, InTs...>) {
+    MemoryContext aggctx;
+    if (!ffi_guard{::AggCheckCallContext}(current_postgres_function::call_info().operator*(),
+                                          &aggctx)) {
+      report(ERROR, "not aggregate context");
+    }
+    Agg *state0 = memory_context(aggctx).alloc<Agg>();
+    std::construct_at(state0, ba);
+    return datum_conversion<void *>::into_datum(reinterpret_cast<void *>(state0));
+  }
+  report(ERROR, "this aggregate does not support serialize");
+  __builtin_unreachable();
+}
+
+template <class Agg, typename... InTs> datum aggregate_combine(value state, value other) {
+  MemoryContext aggctx;
+  if (!ffi_guard{::AggCheckCallContext}(current_postgres_function::call_info().operator*(),
+                                        &aggctx)) {
+    report(ERROR, "not aggregate context");
+  }
+  if constexpr (combinable_aggregate<Agg, InTs...>) {
+    if constexpr (!convertible_into_datum<Agg> && finalizable_aggregate<Agg, InTs...>) {
+      Agg *state0;
+      if (state.get_nullable_datum().is_null()) {
+        state0 = memory_context(aggctx).alloc<Agg>();
+        std::construct_at(state0);
+      } else {
+        state0 = reinterpret_cast<Agg *>(
+            from_nullable_datum<void *>(state.get_nullable_datum(), state.get_type().oid));
+      }
+
+      Agg *state1;
+      if (other.get_nullable_datum().is_null()) {
+        state1 = memory_context(aggctx).alloc<Agg>();
+        std::construct_at(state1);
+      } else {
+        state1 = reinterpret_cast<Agg *>(
+            from_nullable_datum<void *>(other.get_nullable_datum(), other.get_type().oid));
+      }
+
+      Agg *newstate = memory_context(aggctx).alloc<Agg>();
+      std::construct_at(newstate, *state0, *state1);
+
+      return datum_conversion<void *>::into_datum(reinterpret_cast<void *>(newstate));
+    } else if constexpr (convertible_into_datum<Agg>) {
+      Agg state0 = datum_conversion<Agg>::from_nullable_datum(state.get_nullable_datum(), ANYOID);
+      Agg state1 = datum_conversion<Agg>::from_nullable_datum(state.get_nullable_datum(), ANYOID);
+      return datum_conversion<Agg>::into_datum(Agg(state0, state1));
+    }
+  }
+  report(ERROR, "not supported");
+  __builtin_unreachable();
+}
+
+} // namespace cppgres
+
+#define declare_aggregate(name, typname, ...)                                                      \
+  static_assert(::cppgres::aggregate<typname, ##__VA_ARGS__>);                                     \
+  static_assert(::cppgres::convertible_into_datum<typname> ||                                      \
+                    ::cppgres::finalizable_aggregate<typname, ##__VA_ARGS__>,                   \
+                "must be convertible to datum or have finalize()");                                \
+  postgres_function(name##_sfunc, (cppgres::aggregate_sfunc<typname, ##__VA_ARGS__>));             \
+  postgres_function(name##_ffunc, (cppgres::aggregate_ffunc<typname, ##__VA_ARGS__>));             \
+  postgres_function(name##_serial, (cppgres::aggregate_serial<typname, ##__VA_ARGS__>));           \
+  postgres_function(name##_deserial, (cppgres::aggregate_deserial<typname, ##__VA_ARGS__>));       \
+  postgres_function(name##_combine, (cppgres::aggregate_combine<typname, ##__VA_ARGS__>));
+/**
+ * \file
+ */
+
+
+
+namespace cppgres {
+
+enum q { backend };
+
+namespace backend_type {
+
+/**
+ * @brief Backend type
+ *
+ * A copy of Postgres' BackendType with minor renaming
+ */
+enum type {
+  invalid = B_INVALID,
+  backend = B_BACKEND,
+  autovac_launcher = B_AUTOVAC_LAUNCHER,
+  autovac_worker = B_AUTOVAC_WORKER,
+  bg_worker = B_BG_WORKER,
+  wal_sender = B_WAL_SENDER,
+#if PG_MAJORVERSION_NUM >= 17
+  slotsync_worker = B_SLOTSYNC_WORKER,
+  standalone_backend = B_STANDALONE_BACKEND,
+#endif
+  archiver = B_ARCHIVER,
+  bg_writer = B_BG_WRITER,
+  checkpointer = B_CHECKPOINTER,
+  startup = B_STARTUP,
+  wal_receiver = B_WAL_RECEIVER,
+#if PG_MAJORVERSION_NUM >= 17
+  wal_summarizer = B_WAL_SUMMARIZER,
+#endif
+  wal_writer = B_WAL_WRITER,
+  logger = B_LOGGER
+};
+}
+
+/**
+ * @brief Backend management
+ */
+struct backend {
+  /**
+   * @brief get current backend type
+   * @return backend type
+   */
+  static backend_type::type type() { return static_cast<backend_type::type>(::MyBackendType); };
+
+  /**
+   * @brief Register a callback for when Postgres will be exiting
+   *
+   * This allows passing a lambda with a closure (not just a plain C function / lambda without a
+   * closure), it'll initialize the closure in the top memory context.
+   */
+  template <typename T> requires requires(T t, int code) {
+    { t(code) };
+  }
+  static void atexit(T &&func) {
+    T *raw_mem = top_memory_context().alloc<T>();
+    T *allocation = new (raw_mem) T(std::forward<T>(func));
+
+    ffi_guard{::on_proc_exit}(
+        [](int code, ::Datum datum) {
+          T *func = reinterpret_cast<T *>(DatumGetPointer(datum));
+          (*func)(code);
+        },
+        PointerGetDatum(allocation));
+  }
+};
+
+} // namespace cppgres
+#include <functional>
+#include <variant>
+
+namespace cppgres::utils {
+
+template <typename T> struct maybe_ref {
+  // In-place constructor: constructs T inside the variant using forwarded arguments.
+  template <typename... Args> maybe_ref(Args &&...args) : data(std::forward<Args>(args)...) {}
+  maybe_ref(const T &value) : data(value) {}
+  maybe_ref(T &ref) : data(std::ref(ref)) {}
+
+  operator T &() {
+    if (std::holds_alternative<T>(data))
+      return std::get<T>(data);
+    else
+      return std::get<std::reference_wrapper<T>>(data).get();
+  }
+
+  operator const T &() const {
+    if (std::holds_alternative<T>(data))
+      return std::get<T>(data);
+    else
+      return std::get<std::reference_wrapper<T>>(data).get();
+  }
+
+  T *operator->() { return &operator T &(); }
+  const T *operator->() const { return &operator const T &(); }
+
+  bool is_ref() const { return !std::holds_alternative<T>(data); }
+
+private:
+  std::variant<T, std::reference_wrapper<T>> data;
+};
+} // namespace cppgres::utils
+
+namespace cppgres {
+/**
+ * @brief Background worker construction and operations
+ */
+struct background_worker {
+
+  /**
+   * @brief Initialize background worker specification
+   *
+   * @note Initializes pid notification to be directed to the current process by default,
+   *       can be overriden by notify_pid(pid_t)
+   */
+  background_worker() { worker->bgw_notify_pid = ::MyProcPid; }
+
+  /**
+   * Initializes from a background worker specification reference
+   * @param worker
+   */
+  background_worker(::BackgroundWorker &worker) : worker(worker) {}
+
+  background_worker &name(std::string_view name) {
+    size_t n = std::min(name.size(), static_cast<size_t>(sizeof(worker->bgw_name) - 1));
+    std::copy_n(name.data(), n, worker->bgw_name);
+    worker->bgw_name[n] = '\0';
+    return *this;
+  }
+  std::string_view name() { return worker->bgw_name; }
+
+  background_worker &type(std::string_view name) {
+    size_t n = std::min(name.size(), static_cast<size_t>(sizeof(worker->bgw_type) - 1));
+    std::copy_n(name.data(), n, worker->bgw_type);
+    worker->bgw_type[n] = '\0';
+    return *this;
+  }
+  std::string_view type() { return worker->bgw_type; }
+
+  background_worker &library_name(std::string_view name) {
+    size_t n = std::min(name.size(), static_cast<size_t>(sizeof(worker->bgw_library_name) - 1));
+    std::copy_n(name.data(), n, worker->bgw_library_name);
+    worker->bgw_library_name[n] = '\0';
+    return *this;
+  }
+  std::string_view library_name() { return worker->bgw_library_name; }
+
+  background_worker &function_name(std::string_view name) {
+    size_t n = std::min(name.size(), static_cast<size_t>(sizeof(worker->bgw_function_name) - 1));
+    std::copy_n(name.data(), n, worker->bgw_function_name);
+    worker->bgw_function_name[n] = '\0';
+    return *this;
+  }
+  std::string_view function_name() { return worker->bgw_function_name; }
+
+  background_worker &start_time(BgWorkerStartTime time) {
+    worker->bgw_start_time = time;
+    return *this;
+  }
+
+  ::BgWorkerStartTime start_time() const { return worker->bgw_start_time; }
+
+  background_worker &restart_time(int time) {
+    worker->bgw_restart_time = time;
+    return *this;
+  }
+
+  int restart_time() const { return worker->bgw_restart_time; }
+
+  background_worker &flags(int flags) {
+    worker->bgw_flags = flags;
+    return *this;
+  }
+
+  int flags() const { return worker->bgw_flags; }
+
+  background_worker &main_arg(datum datum) {
+    worker->bgw_main_arg = datum;
+    return *this;
+  }
+
+  datum main_arg() const { return datum(worker->bgw_main_arg); }
+
+  background_worker &extra(std::string_view name) {
+    size_t n = std::min(name.size(), static_cast<size_t>(sizeof(worker->bgw_extra) - 1));
+    std::copy_n(name.data(), n, worker->bgw_extra);
+    worker->bgw_extra[n] = '\0';
+    return *this;
+  }
+  std::string_view extra() { return worker->bgw_extra; }
+
+  background_worker &notify_pid(pid_t pid) {
+    worker->bgw_notify_pid = pid;
+    return *this;
+  }
+
+  pid_t notify_pid() const { return worker->bgw_notify_pid; }
+
+  operator BackgroundWorker &() { return worker; }
+  operator BackgroundWorker *() { return worker.operator->(); }
+
+  struct worker_stopped : public std::exception {
+    const char *what() const noexcept override { return "Background worker stopped"; }
+  };
+
+  struct worker_not_yet_started : public std::exception {
+    const char *what() const noexcept override {
+      return "Background worker hasn't been started yet";
+    }
+  };
+
+  struct postmaster_died : public std::exception {
+    const char *what() const noexcept override { return "postmaster died"; }
+  };
+
+  struct handle {
+    handle() : handle_(nullptr) {}
+    handle(::BackgroundWorkerHandle *handle) : handle_(handle) {}
+
+    ::BackgroundWorkerHandle *operator->() { return handle_; }
+
+    bool has_value() const { return handle_ != nullptr; }
+    ::BackgroundWorkerHandle *value() { return handle_; }
+
+    pid_t wait_for_startup() {
+      if (has_value()) {
+        pid_t pid;
+        ffi_guard{::WaitForBackgroundWorkerStartup}(value(), &pid);
+        return pid;
+      }
+      throw std::logic_error("Attempting to wait for a background worker with no handle");
+    }
+
+    void wait_for_shutdown() {
+      if (has_value()) {
+        ffi_guard{::WaitForBackgroundWorkerShutdown}(value());
+        return;
+      }
+      throw std::logic_error("Attempting to wait for a background worker with no handle");
+    }
+
+    void terminate() {
+      if (has_value()) {
+        ffi_guard{::TerminateBackgroundWorker}(value());
+        return;
+      }
+      throw std::logic_error("Attempting to terminate a background worker with no handle");
+    }
+
+    pid_t get_pid() {
+      if (has_value()) {
+        pid_t pid;
+        auto rc = ffi_guard{::GetBackgroundWorkerPid}(value(), &pid);
+        switch (rc) {
+        case BGWH_STARTED:
+          return pid;
+        case BGWH_STOPPED:
+          throw worker_stopped();
+        case BGWH_NOT_YET_STARTED:
+          throw worker_not_yet_started();
+        case BGWH_POSTMASTER_DIED:
+          throw postmaster_died();
+        }
+      }
+      throw std::logic_error("Attempting to get a PID of a background worker with no handle");
+    }
+
+    const char *worker_type() { return ffi_guard{::GetBackgroundWorkerTypeByPid}(get_pid()); }
+
+  private:
+    ::BackgroundWorkerHandle *handle_;
+  };
+
+  handle start(bool dynamic = true) {
+    if (!dynamic) {
+      if (::IsUnderPostmaster || !::IsPostmasterEnvironment) {
+        throw std::runtime_error(
+            "static background worker can only be start in the postmaster process");
+      }
+      ffi_guard{::RegisterBackgroundWorker}(operator BackgroundWorker *());
+      return {};
+    }
+    ::BackgroundWorkerHandle *handle;
+    ffi_guard{::RegisterDynamicBackgroundWorker}(operator BackgroundWorker *(), &handle);
+    return {handle};
+  }
+
+private:
+  utils::maybe_ref<::BackgroundWorker> worker = {};
+};
+
+struct background_worker_database_conection_flag {
+  virtual int flag() const { return 0; }
+};
+
+struct background_worker_bypass_allow_connection
+    : public background_worker_database_conection_flag {
+  int flag() const override { return BGWORKER_BYPASS_ALLOWCONN; }
+};
+
+#if PG_MAJORVERSION_NUM >= 17
+struct background_worker_bypass_role_login_check
+    : public background_worker_database_conection_flag {
+  int flag() const override { return BGWORKER_BYPASS_ROLELOGINCHECK; }
+};
+#endif
+
+struct current_background_worker : public background_worker {
+  friend std::optional<current_background_worker> get_current_background_worker();
+
+  /**
+   * @brief gets current background worker's entry
+   *
+   * @throws std::logic_error if not in a background worker; to check the backend type
+   *         use cppgres::backend::type()
+   */
+  current_background_worker() : background_worker(*::MyBgworkerEntry) {
+    if (backend::type() != backend_type::bg_worker) {
+      throw std::logic_error("can't access current background worker in a different backend type");
+    }
+  }
+
+  void unblock_signals() { ffi_guard{::BackgroundWorkerUnblockSignals}(); }
+
+  void block_signals() { ffi_guard{::BackgroundWorkerBlockSignals}(); }
+
+  /**
+   * @brief Connect to the database using db name and, optionally, username
+   *
+   * @tparam Flags connection flags of @ref cppgres::background_worker_database_conection_flag
+   *               derived flags
+   * @param dbname database name
+   * @param user user name
+   * @param flags connection flags of @ref cppgres::background_worker_database_conection_flag
+   * derived flags
+   */
+  template <typename... Flags>
+  void connect(std::string dbname, std::optional<std::string> user = std::nullopt, Flags... flags)
+      requires(
+          std::conjunction_v<std::is_base_of<background_worker_database_conection_flag, Flags>...>)
+  {
+    ffi_guard{::BackgroundWorkerInitializeConnection}(
+        dbname.c_str(), user.has_value() ? user.value().c_str() : nullptr,
+        (flags.flag() | ... | 0));
+  }
+
+  /**
+   * @brief Connect to the database using db oid and, optionally, user oid
+   *
+   * @tparam Flags connection flags of @ref cppgres::background_worker_database_conection_flag
+   *               derived flags
+   * @param db database oid
+   * @param user user oid
+   * @param flags connection flags of @ref cppgres::background_worker_database_conection_flag
+   * derived flags
+   */
+  template <typename... Flags>
+  void connect(oid db, std::optional<oid> user = std::nullopt, Flags... flags) requires(
+      std::conjunction_v<std::is_base_of<background_worker_database_conection_flag, Flags>...>)
+  {
+    ffi_guard{::BackgroundWorkerInitializeConnectionByOid}(
+        db, user.has_value() ? user.value() : oid(InvalidOid), (flags.flag() | ... | 0));
+  }
+};
+
+} // namespace cppgres
+/**
+* \file
+ */
+
+
+namespace cppgres {
+
+inline pg_exception::pg_exception(::MemoryContext mcxt) : mcxt(mcxt) {
+  ::CurrentMemoryContext = error_cxt =
+      memory_context(std::move(alloc_set_memory_context(top_memory_context())));
+  error = ffi_guard{::CopyErrorData}();
+  ::CurrentMemoryContext = mcxt;
+  ffi_guard{::FlushErrorState}();
+}
+
+inline pg_exception::~pg_exception() { memory_context(error_cxt).delete_context(); }
+
+} // namespace cppgres
+/**
+ * \file
+ */
+
+#include <string>
+#include <string_view>
+
+namespace cppgres::utils {
+
+template <typename T>
+concept is_cstring = std::same_as<T, char *> || std::same_as<T, const char *>;
+
+template <typename T>
+concept c_str_available = requires(T t) {
+  { t.c_str() } -> std::same_as<const char *>;
+};
+
+template <typename T>
+concept data_length_available = requires(T t) {
+  { t.data() } -> std::same_as<const char *>;
+  { t.length() } -> std::same_as<std::size_t>;
+} && !c_str_available<T>;
+
+template <typename T>
+concept convertible_to_cstring = is_cstring<T> || c_str_available<T> || data_length_available<T>;
+
+template <is_cstring S> const char *to_cstring(S string) {
+  return const_cast<const char *>(string);
+}
+
+template <c_str_available S> const char *to_cstring(S &&string) { return string.c_str(); }
+
+struct owned_cstring {
+  owned_cstring(std::string s) : str_(s) {}
+
+  operator const char *() const { return str_.c_str(); }
+
+private:
+  std::string str_;
+};
+
+template <data_length_available S> owned_cstring to_cstring(S &&string) {
+  return std::string(string.data(), string.length());
+}
+
+} // namespace cppgres::utils
+
+#include <iterator>
+#include <optional>
+#include <stack>
+#include <vector>
+
+namespace cppgres {
+
+template <typename T>
+concept convertible_into_nullable_datum_and_has_a_type =
+    convertible_into_nullable_datum<T> && has_a_type<T>;
+
+template <convertible_from_nullable_datum... Args> struct spi_plan {
+  friend struct spi_executor;
+
+  spi_plan(spi_plan &&p) : kept(p.kept), plan(p.plan), ctx(std::move(p.ctx)) { p.kept = false; }
+
+  operator ::SPIPlanPtr() {
+    if (ctx.resets() > 0) {
+      throw pointer_gone_exception();
+    }
+    return plan;
+  }
+
+  void keep() {
+    ffi_guard{::SPI_keepplan}(*this);
+    kept = true;
+  }
+
+  ~spi_plan() {
+    if (kept) {
+      ffi_guard{::SPI_freeplan}(*this);
+    }
+  }
+
+private:
+  spi_plan(::SPIPlanPtr plan)
+      : kept(false), plan(plan), ctx(tracking_memory_context(memory_context::for_pointer(plan))) {}
+
+  bool kept;
+  ::SPIPlanPtr plan;
+  tracking_memory_context<memory_context> ctx;
+};
+
+struct executor {};
+
+template <typename T>
+concept a_vector = requires {
+  typename T::value_type;
+  typename T::allocator_type;
+} && std::same_as<T, std::vector<typename T::value_type, typename T::allocator_type>>;
+
+/**
+ * @brief [SPI](https://www.postgresql.org/docs/current/spi.html) executor API
+ */
+struct spi_executor : public executor {
+  /**
+   * @brief Creates an SPI executor
+   */
+  spi_executor() : spi_executor(0) {}
+  ~spi_executor() {
+    ffi_guard{::SPI_finish}();
+    executors.pop();
+  }
+
+  template <typename T> struct result_iterator {
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+
+    ::SPITupleTable *tuptable;
+    size_t index;
+    mutable std::vector<std::optional<T>> tuples;
+
+    constexpr result_iterator() noexcept {}
+
+    constexpr result_iterator(::SPITupleTable *tuptable) noexcept
+        : tuptable(tuptable), index(0),
+          tuples(std::vector<std::optional<T>>(tuptable->numvals, std::nullopt)) {
+      tuples.reserve(tuptable->numvals);
+    }
+    constexpr result_iterator(::SPITupleTable *tuptable, size_t n) noexcept
+        : tuptable(tuptable), index(n),
+          tuples(std::vector<std::optional<T>>(tuptable->numvals, std::nullopt)) {
+      tuples.reserve(tuptable->numvals);
+    }
+
+    bool operator==(size_t end_index) const { return index == end_index; }
+    bool operator!=(size_t end_index) const { return index != end_index; }
+
+    constexpr T &operator*() const { return this->operator[](static_cast<difference_type>(index)); }
+
+    constexpr result_iterator &operator++() noexcept {
+      index++;
+      return *this;
+    }
+    constexpr result_iterator operator++(int) noexcept {
+      index++;
+      return this;
+    }
+
+    constexpr result_iterator &operator--() noexcept {
+      index--;
+      return this;
+    }
+    constexpr result_iterator operator--(int) noexcept {
+      index--;
+      return this;
+    }
+
+    constexpr result_iterator operator+(const difference_type n) const noexcept {
+      return result_iterator(tuptable, index + n);
+    }
+
+    result_iterator &operator+=(difference_type n) noexcept {
+      index += n;
+      return this;
+    }
+
+    constexpr result_iterator operator-(difference_type n) const noexcept {
+      return result_iterator(tuptable, index - n);
+    }
+
+    result_iterator &operator-=(difference_type n) noexcept {
+      index -= n;
+      return this;
+    }
+
+    constexpr difference_type operator-(const result_iterator &other) const noexcept {
+      return index - other.index;
+    }
+
+    T &operator[](difference_type n) const {
+      if (tuples.at(n).has_value()) {
+        return tuples.at(n).value();
+      }
+      if constexpr (convertible_from_datum<T>) {
+        if (tuptable->tupdesc->natts == 1) {
+          // if a special case of a directly convertible type
+          bool isnull;
+          ::Datum value =
+              ffi_guard{::SPI_getbinval}(tuptable->vals[n], tuptable->tupdesc, 1, &isnull);
+          ::NullableDatum datum = {.value = value, .isnull = isnull};
+          auto ret = from_nullable_datum<T>(nullable_datum(datum),
+                                            ffi_guard{::SPI_gettypeid}(tuptable->tupdesc, 1),
+                                            memory_context(tuptable->tuptabcxt));
+          tuples.emplace(std::next(tuples.begin(), n), std::in_place, ret);
+          return tuples.at(n).value();
+        }
+      }
+      if constexpr (a_vector<T>) {
+        T ret;
+        for (int i = 0; i < tuptable->tupdesc->natts; i++) {
+          bool isnull;
+          ::Datum value =
+              ffi_guard{::SPI_getbinval}(tuptable->vals[n], tuptable->tupdesc, i + 1, &isnull);
+          ::NullableDatum datum = {.value = value, .isnull = isnull};
+          auto nd = nullable_datum(datum);
+          ret.emplace_back(from_nullable_datum<typename T::value_type>(
+              nd, ffi_guard{::SPI_gettypeid}(tuptable->tupdesc, i + 1),
+              memory_context(tuptable->tuptabcxt)));
+        }
+        tuples.emplace(std::next(tuples.begin(), n), std::in_place, ret);
+      } else {
+        auto ret = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+          return T{([&] {
+            bool isnull;
+            ::Datum value =
+                ffi_guard{::SPI_getbinval}(tuptable->vals[n], tuptable->tupdesc, Is + 1, &isnull);
+            ::NullableDatum datum = {.value = value, .isnull = isnull};
+            auto nd = nullable_datum(datum);
+            return from_nullable_datum<utils::tuple_element_t<Is, T>>(
+                nd, ffi_guard{::SPI_gettypeid}(tuptable->tupdesc, Is + 1),
+                memory_context(tuptable->tuptabcxt));
+          }())...};
+        }(std::make_index_sequence<utils::tuple_size_v<T>>{});
+        tuples.emplace(std::next(tuples.begin(), n), std::in_place, ret);
+      }
+      return tuples.at(n).value();
+    }
+
+    constexpr bool operator==(const result_iterator &other) const noexcept {
+      return tuptable == other.tuptable && index == other.index;
+    }
+    constexpr bool operator!=(const result_iterator &other) const noexcept {
+      return !(tuptable == other.tuptable && index == other.index);
+    }
+    constexpr bool operator<(const result_iterator &other) const noexcept {
+      return index < other.index;
+    }
+    constexpr bool operator>(const result_iterator &other) const noexcept {
+      return index > other.index;
+    }
+    constexpr bool operator<=(const result_iterator &other) const noexcept {
+      return index <= other.index;
+    }
+    constexpr bool operator>=(const result_iterator &other) const noexcept {
+      return index >= other.index;
+    }
+
+    operator const heap_tuple() const { return tuptable->vals[index]; }
+
+  private:
+  };
+
+  template <typename Ret> struct results {
+    ::SPITupleTable *table;
+
+    results(::SPITupleTable *table) : table(table) {
+      auto natts = table->tupdesc->natts;
+      if constexpr (a_vector<Ret>) {
+        for (int i = 0; i < natts; i++) {
+          auto oid = ffi_guard{::SPI_gettypeid}(table->tupdesc, i + 1);
+          auto t = type{.oid = oid};
+          if (!type_traits<typename Ret::value_type>().is(t)) {
+            throw std::invalid_argument(
+                cppgres::fmt::format("invalid return type in position {} ({}), got OID {}", i,
+                                     utils::type_name<typename Ret::value_type>(), oid));
+          }
+        }
+      } else {
+        if (natts != utils::tuple_size_v<Ret>) {
+          if (natts == 1 && convertible_from_datum<Ret>) {
+            // okay, this is just a type we can convert
+          } else {
+            throw std::runtime_error(cppgres::fmt::format("expected {} return values, got {}",
+                                                          utils::tuple_size_v<Ret>, natts));
+          }
+        } else {
+          [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            (([&] {
+               auto oid = ffi_guard{::SPI_gettypeid}(table->tupdesc, Is + 1);
+               auto t = type{.oid = oid};
+               if (!type_traits<utils::tuple_element_t<Is, Ret>>().is(t)) {
+                 throw std::invalid_argument(cppgres::fmt::format(
+                     "invalid return type in position {} ({}), got OID {}", Is,
+                     utils::type_name<utils::tuple_element_t<Is, Ret>>(), oid));
+               }
+             }()),
+             ...);
+          }(std::make_index_sequence<utils::tuple_size_v<Ret>>{});
+        }
+      }
+    }
+
+    result_iterator<Ret> begin() const { return result_iterator<Ret>(table); }
+    size_t end() const { return count(); }
+
+    size_t count() const { return table->numvals; }
+
+    tuple_descriptor get_tuple_descriptor() const { return table->tupdesc; }
+  };
+
+  struct options {
+    explicit options() : read_only_(false), count_(0) {}
+    options(bool read_only) : read_only_(read_only), count_(0) {}
+    options(int count) : read_only_(false), count_(count) {}
+    options(bool read_only, int count) : read_only_(read_only), count_(count) {}
+
+    bool read_only() const { return read_only_; }
+    int count() const { return count_; }
+
+  private:
+    bool read_only_;
+    int count_;
+  };
+
+  /**
+   * @brief Queries using a string view
+   *
+   * @param query Query string
+   * @param args Query arguments
+   *
+   * @note if you need to be able to configure the execution, use another version of
+   *       the function with @ref cppgres::spi_executor::options argument
+   *
+   * @return Iterable @ref cppgres::spi_executor::results, can be a single value
+   *
+   * @throws std::runtime_error if there's another SPI executor in scope
+   * @throws std::runtime_error if there's an SPI error
+   */
+  template <typename Ret, convertible_into_nullable_datum_and_has_a_type... Args>
+  results<Ret> query(utils::convertible_to_cstring auto query, Args &&...args) {
+    return this->query<Ret>(query, options(), std::forward<Args>(args)...);
+  }
+
+  /**
+   * @brief Queries using a string view
+   *
+   * @param query Query string
+   * @param opts Execution options
+   * @param args Query arguments
+   *
+   * @return Iterable @ref cppgres::spi_executor::results, can be a single value
+   *
+   * @throws std::runtime_error if there's another SPI executor in scope
+   * @throws std::runtime_error if there's an SPI error
+   */
+  template <typename Ret, convertible_into_nullable_datum_and_has_a_type... Args>
+  results<Ret> query(utils::convertible_to_cstring auto query, options &&opts, Args &&...args) {
+    if (executors.top() != this) {
+      throw std::runtime_error("not a current SPI executor");
+    }
+    constexpr size_t nargs = sizeof...(Args);
+    std::array<::Oid, nargs> types = {type_traits<Args>(args...).type_for().oid...};
+    std::array<::Datum, nargs> datums = {into_nullable_datum(args)...};
+    std::array<const char, nargs> nulls = {into_nullable_datum(args).is_null() ? 'n' : ' ' ...};
+    auto rc = ffi_guard{::SPI_execute_with_args}(utils::to_cstring(query), nargs, types.data(),
+                                                 datums.data(), nulls.data(), opts.read_only(),
+                                                 opts.count());
+    if (rc > 0) {
+      //      static_assert(std::random_access_iterator<result_iterator<Ret>>);
+      return results<Ret>(SPI_tuptable);
+    } else {
+      throw std::runtime_error("spi error");
+    }
+  }
+
+  template <convertible_into_nullable_datum_and_has_a_type... Args>
+  spi_plan<Args...> plan(utils::convertible_to_cstring auto query) {
+    if (executors.top() != this) {
+      throw std::runtime_error("not a current SPI executor");
+    }
+    constexpr size_t nargs = sizeof...(Args);
+    std::array<::Oid, nargs> types = {type_traits<Args>().type_for().oid...};
+    return spi_plan<Args...>(
+        ffi_guard{::SPI_prepare}(utils::to_cstring(query), nargs, types.data()));
+  }
+
+  template <typename Ret, convertible_into_nullable_datum... Args>
+  results<Ret> query(spi_plan<Args...> &query, Args &&...args) {
+    return this->query<Ret, Args...>(query, options(), std::forward<Args>(args)...);
+  }
+
+  template <typename Ret, convertible_into_nullable_datum... Args>
+  results<Ret> query(spi_plan<Args...> &query, options &&opts, Args &&...args) {
+    if (executors.top() != this) {
+      throw std::runtime_error("not a current SPI executor");
+    }
+    constexpr size_t nargs = sizeof...(Args);
+    std::array<::Datum, nargs> datums = {into_nullable_datum(args)...};
+    std::array<const char, nargs> nulls = {into_nullable_datum(args).is_null() ? 'n' : ' ' ...};
+    auto rc = ffi_guard{::SPI_execute_plan}(query, datums.data(), nulls.data(), opts.read_only(),
+                                            opts.count());
+    if (rc > 0) {
+      //      static_assert(std::random_access_iterator<result_iterator<Ret>>);
+      return results<Ret>(SPI_tuptable);
+    } else {
+      throw std::runtime_error("spi error");
+    }
+  }
+
+  template <convertible_into_nullable_datum_and_has_a_type... Args>
+  uint64_t execute(std::string_view query, Args &&...args) {
+    return execute(query, options(), std::forward<Args>(args)...);
+  }
+
+  template <convertible_into_nullable_datum_and_has_a_type... Args>
+  uint64_t execute(std::string_view query, options &&opts, Args &&...args) {
+    if (executors.top() != this) {
+      throw std::runtime_error("not a current SPI executor");
+    }
+    constexpr size_t nargs = sizeof...(Args);
+    std::array<::Oid, nargs> types = {type_traits<Args>(args...).type_for().oid...};
+    std::array<::Datum, nargs> datums = {into_nullable_datum(args)...};
+    std::array<const char, nargs> nulls = {into_nullable_datum(args).is_null() ? 'n' : ' ' ...};
+    auto rc = ffi_guard{::SPI_execute_with_args}(query.data(), nargs, types.data(), datums.data(),
+                                                 nulls.data(), opts.read_only(), opts.count());
+    if (rc >= 0) {
+      return SPI_processed;
+    } else {
+      throw std::runtime_error(cppgres::fmt::format("spi error"));
+    }
+  }
+
+private:
+  ::MemoryContext before_spi;
+  ::MemoryContext spi;
+
+protected:
+  static inline std::stack<spi_executor *> executors;
+  spi_executor(int flags) : before_spi(::CurrentMemoryContext) {
+    ffi_guard{::SPI_connect_ext}(flags);
+    spi = ::CurrentMemoryContext;
+    ::CurrentMemoryContext = before_spi;
+    executors.push(this);
+  }
+};
+
+struct spi_nonatomic_executor : public spi_executor {
+  using spi_executor::spi_executor;
+
+  spi_nonatomic_executor() : spi_executor(SPI_OPT_NONATOMIC) {
+    auto atomic = cppgres::current_postgres_function::atomic();
+    if (atomic.has_value() && atomic.value()) {
+      throw std::runtime_error("must be called in a non-atomic context");
+    }
+  }
+
+  void commit(bool chain = false) {
+    if (executors.top() != this) {
+      throw std::runtime_error("not a current SPI executor");
+    }
+    ffi_guard(chain ? ::SPI_commit_and_chain : ::SPI_commit)();
+  }
+
+  void rollback(bool chain = false) {
+    if (executors.top() != this) {
+      throw std::runtime_error("not a current SPI executor");
+    }
+    ffi_guard(chain ? ::SPI_rollback_and_chain : ::SPI_rollback)();
+  }
+};
+
+} // namespace cppgres
+#include <concepts>
+#include <type_traits>
+
+
+namespace cppgres {
+
+using node_tag = ::NodeTag;
+
+template <typename T>
+concept node_tagged = std::is_standard_layout_v<T> && requires(T t) {
+  { t.type } -> std::convertible_to<node_tag>;
+} && (offsetof(T, type) == 0);
+
+template <typename T>
+concept node_xpr_tagged = std::is_standard_layout_v<T> && requires(T t) {
+  { t.xpr } -> std::convertible_to<::Expr>;
+} && (offsetof(T, xpr) == 0);
+
+template <typename T>
+concept node_inherited_base = std::is_standard_layout_v<std::remove_cvref_t<T>> && requires(T t) {
+  requires node_tagged<std::remove_cvref_t<decltype(boost::pfr::get<0>(t))>> ||
+               node_xpr_tagged<std::remove_cvref_t<decltype(boost::pfr::get<0>(t))>>;
+};
+
+template <typename T>
+concept node_inherited = std::is_standard_layout_v<std::remove_cvref_t<T>> && requires(T t) {
+  requires node_tagged<std::remove_cvref_t<decltype(boost::pfr::get<0>(t))>> ||
+               node_xpr_tagged<std::remove_cvref_t<decltype(boost::pfr::get<0>(t))>> ||
+               node_inherited_base<std::remove_cvref_t<decltype(boost::pfr::get<0>(t))>>;
+};
+
+template <typename T>
+concept node = node_tagged<T> || node_xpr_tagged<T> || node_inherited<T>;
+
+template <typename T> struct node_traits {
+  static inline bool is(auto &node) { return false; }
+};
+template <node_tag T> struct node_tag_traits;
+
+#define node_mapping(name)                                                                         \
+  namespace nodes {                                                                                \
+  struct name {                                                                                    \
+    using underlying_type = ::name;                                                                \
+    static constexpr inline node_tag tag = T_##name;                                               \
+    name(::name v) : val(v) {}                                                                     \
+    name() { reinterpret_cast<node_tag &>(val) = T_##name; }                                       \
+    ::name &operator*() { return val; }                                                            \
+                                                                                                   \
+  private:                                                                                         \
+    [[maybe_unused]] ::name val{};                                                                                  \
+  };                                                                                               \
+  }                                                                                                \
+  static_assert((sizeof(name) == sizeof(::name)) && (alignof(name) == alignof(::name)));           \
+  template <> struct node_tag_traits<node_tag::T_##name> {                                         \
+    using type = nodes::name;                                                                      \
+  };                                                                                               \
+  template <> struct node_traits<nodes::name> {                                                    \
+    static inline constexpr node_tag tag = node_tag::T_##name;                                     \
+    static inline bool is(::Node *node) {                                                          \
+      return *reinterpret_cast<node_tag *>(node) == node_tag::T_##name;                            \
+    }                                                                                              \
+    static inline bool is(::name *node) {                                                          \
+      return *reinterpret_cast<node_tag *>(node) == node_tag::T_##name;                            \
+    }                                                                                              \
+    static inline bool is(nodes::name &node) { return true; }                                      \
+    static inline bool is(auto &node) { return false; }                                            \
+    static inline nodes::name *allocate(abstract_memory_context &&ctx = memory_context()) {        \
+      auto ptr = ctx.alloc<nodes::name>();                                                         \
+      reinterpret_cast<node_tag &>(ptr) = tag;                                                     \
+      return ptr;                                                                                  \
+    }                                                                                              \
+  }
+
+#define node_mapping_no_node_traits(name)                                                          \
+  namespace nodes {                                                                                \
+  using name = ::name;                                                                             \
+  }                                                                                                \
+  template <> struct node_tag_traits<node_tag::T_##name> {                                         \
+    using type = nodes::name;                                                                      \
+    static_assert(::cppgres::node<name>);                                                          \
+  }
+
+node_mapping(List);
+node_mapping(Alias);
+node_mapping(RangeVar);
+node_mapping(TableFunc);
+node_mapping(IntoClause);
+node_mapping(Var);
+node_mapping(Const);
+node_mapping(Param);
+node_mapping(Aggref);
+node_mapping(GroupingFunc);
+node_mapping(WindowFunc);
+#if PG_MAJORVERSION_NUM >= 17
+node_mapping(WindowFuncRunCondition);
+node_mapping(MergeSupportFunc);
+#endif
+node_mapping(SubscriptingRef);
+node_mapping(FuncExpr);
+node_mapping(NamedArgExpr);
+node_mapping(OpExpr);
+node_mapping_no_node_traits(DistinctExpr);
+node_mapping_no_node_traits(NullIfExpr);
+node_mapping(ScalarArrayOpExpr);
+node_mapping(BoolExpr);
+node_mapping(SubLink);
+node_mapping(SubPlan);
+node_mapping(AlternativeSubPlan);
+node_mapping(FieldSelect);
+node_mapping(FieldStore);
+node_mapping(RelabelType);
+node_mapping(CoerceViaIO);
+node_mapping(ArrayCoerceExpr);
+node_mapping(ConvertRowtypeExpr);
+node_mapping(CollateExpr);
+node_mapping(CaseExpr);
+node_mapping(CaseWhen);
+node_mapping(CaseTestExpr);
+node_mapping(ArrayExpr);
+node_mapping(RowExpr);
+node_mapping(RowCompareExpr);
+node_mapping(CoalesceExpr);
+node_mapping(MinMaxExpr);
+node_mapping(SQLValueFunction);
+node_mapping(XmlExpr);
+#if PG_MAJORVERSION_NUM >= 16
+node_mapping(JsonFormat);
+node_mapping(JsonReturning);
+node_mapping(JsonValueExpr);
+node_mapping(JsonConstructorExpr);
+node_mapping(JsonIsPredicate);
+#endif
+#if PG_MAJORVERSION_NUM >= 17
+node_mapping(JsonBehavior);
+node_mapping(JsonExpr);
+node_mapping(JsonTablePath);
+node_mapping(JsonTablePathScan);
+node_mapping(JsonTableSiblingJoin);
+#endif
+node_mapping(NullTest);
+node_mapping(BooleanTest);
+#if PG_MAJORVERSION_NUM >= 15
+node_mapping(MergeAction);
+#endif
+node_mapping(CoerceToDomain);
+node_mapping(CoerceToDomainValue);
+node_mapping(SetToDefault);
+node_mapping(CurrentOfExpr);
+node_mapping(NextValueExpr);
+node_mapping(InferenceElem);
+#if PG_MAJORVERSION_NUM >= 18
+node_mapping(ReturningExpr);
+#endif
+node_mapping(TargetEntry);
+node_mapping(RangeTblRef);
+node_mapping(JoinExpr);
+node_mapping(FromExpr);
+node_mapping(OnConflictExpr);
+node_mapping(Query);
+node_mapping(TypeName);
+node_mapping(ColumnRef);
+node_mapping(ParamRef);
+node_mapping(A_Expr);
+node_mapping(A_Const);
+node_mapping(TypeCast);
+node_mapping(CollateClause);
+node_mapping(RoleSpec);
+node_mapping(FuncCall);
+node_mapping(A_Star);
+node_mapping(A_Indices);
+node_mapping(A_Indirection);
+node_mapping(A_ArrayExpr);
+node_mapping(ResTarget);
+node_mapping(MultiAssignRef);
+node_mapping(SortBy);
+node_mapping(WindowDef);
+node_mapping(RangeSubselect);
+node_mapping(RangeFunction);
+node_mapping(RangeTableFunc);
+node_mapping(RangeTableFuncCol);
+node_mapping(RangeTableSample);
+node_mapping(ColumnDef);
+node_mapping(TableLikeClause);
+node_mapping(IndexElem);
+node_mapping(DefElem);
+node_mapping(LockingClause);
+node_mapping(XmlSerialize);
+node_mapping(PartitionElem);
+#if PG_MAJORVERSION_NUM == 17
+node_mapping(SinglePartitionSpec);
+#endif
+node_mapping(PartitionSpec);
+node_mapping(PartitionBoundSpec);
+node_mapping(PartitionRangeDatum);
+node_mapping(PartitionCmd);
+node_mapping(RangeTblEntry);
+#if PG_MAJORVERSION_NUM >= 16
+node_mapping(RTEPermissionInfo);
+#endif
+node_mapping(RangeTblFunction);
+node_mapping(TableSampleClause);
+node_mapping(WithCheckOption);
+node_mapping(SortGroupClause);
+node_mapping(GroupingSet);
+node_mapping(WindowClause);
+node_mapping(RowMarkClause);
+node_mapping(WithClause);
+node_mapping(InferClause);
+node_mapping(OnConflictClause);
+#if PG_MAJORVERSION_NUM >= 14
+node_mapping(CTESearchClause);
+node_mapping(CTECycleClause);
+#endif
+node_mapping(CommonTableExpr);
+#if PG_MAJORVERSION_NUM >= 15
+node_mapping(MergeWhenClause);
+#endif
+#if PG_MAJORVERSION_NUM >= 18
+node_mapping(ReturningOption);
+node_mapping(ReturningClause);
+#endif
+node_mapping(TriggerTransition);
+#if PG_MAJORVERSION_NUM >= 16
+node_mapping(JsonOutput);
+#endif
+#if PG_MAJORVERSION_NUM >= 17
+node_mapping(JsonArgument);
+node_mapping(JsonFuncExpr);
+node_mapping(JsonTablePathSpec);
+node_mapping(JsonTable);
+node_mapping(JsonTableColumn);
+node_mapping(JsonKeyValue);
+node_mapping(JsonParseExpr);
+node_mapping(JsonScalarExpr);
+node_mapping(JsonSerializeExpr);
+#endif
+#if PG_MAJORVERSION_NUM >= 16
+node_mapping(JsonObjectConstructor);
+node_mapping(JsonArrayConstructor);
+node_mapping(JsonArrayQueryConstructor);
+node_mapping(JsonAggConstructor);
+node_mapping(JsonObjectAgg);
+node_mapping(JsonArrayAgg);
+#endif
+node_mapping(RawStmt);
+node_mapping(InsertStmt);
+node_mapping(DeleteStmt);
+node_mapping(UpdateStmt);
+#if PG_MAJORVERSION_NUM >= 15
+node_mapping(MergeStmt);
+#endif
+node_mapping(SelectStmt);
+node_mapping(SetOperationStmt);
+#if PG_MAJORVERSION_NUM >= 14
+node_mapping(ReturnStmt);
+#endif
+#if PG_MAJORVERSION_NUM >= 14
+node_mapping(PLAssignStmt);
+#endif
+node_mapping(CreateSchemaStmt);
+node_mapping(AlterTableStmt);
+node_mapping(AlterTableCmd);
+#if PG_MAJORVERSION_NUM >= 18
+node_mapping(ATAlterConstraint);
+#endif
+node_mapping(ReplicaIdentityStmt);
+node_mapping(AlterCollationStmt);
+node_mapping(AlterDomainStmt);
+node_mapping(GrantStmt);
+node_mapping(ObjectWithArgs);
+node_mapping(AccessPriv);
+node_mapping(GrantRoleStmt);
+node_mapping(AlterDefaultPrivilegesStmt);
+node_mapping(CopyStmt);
+node_mapping(VariableSetStmt);
+node_mapping(VariableShowStmt);
+node_mapping(CreateStmt);
+node_mapping(Constraint);
+node_mapping(CreateTableSpaceStmt);
+node_mapping(DropTableSpaceStmt);
+node_mapping(AlterTableSpaceOptionsStmt);
+node_mapping(AlterTableMoveAllStmt);
+node_mapping(CreateExtensionStmt);
+node_mapping(AlterExtensionStmt);
+node_mapping(AlterExtensionContentsStmt);
+node_mapping(CreateFdwStmt);
+node_mapping(AlterFdwStmt);
+node_mapping(CreateForeignServerStmt);
+node_mapping(AlterForeignServerStmt);
+node_mapping(CreateForeignTableStmt);
+node_mapping(CreateUserMappingStmt);
+node_mapping(AlterUserMappingStmt);
+node_mapping(DropUserMappingStmt);
+node_mapping(ImportForeignSchemaStmt);
+node_mapping(CreatePolicyStmt);
+node_mapping(AlterPolicyStmt);
+node_mapping(CreateAmStmt);
+node_mapping(CreateTrigStmt);
+node_mapping(CreateEventTrigStmt);
+node_mapping(AlterEventTrigStmt);
+node_mapping(CreatePLangStmt);
+node_mapping(CreateRoleStmt);
+node_mapping(AlterRoleStmt);
+node_mapping(AlterRoleSetStmt);
+node_mapping(DropRoleStmt);
+node_mapping(CreateSeqStmt);
+node_mapping(AlterSeqStmt);
+node_mapping(DefineStmt);
+node_mapping(CreateDomainStmt);
+node_mapping(CreateOpClassStmt);
+node_mapping(CreateOpClassItem);
+node_mapping(CreateOpFamilyStmt);
+node_mapping(AlterOpFamilyStmt);
+node_mapping(DropStmt);
+node_mapping(TruncateStmt);
+node_mapping(CommentStmt);
+node_mapping(SecLabelStmt);
+node_mapping(DeclareCursorStmt);
+node_mapping(ClosePortalStmt);
+node_mapping(FetchStmt);
+node_mapping(IndexStmt);
+node_mapping(CreateStatsStmt);
+#if PG_MAJORVERSION_NUM >= 14
+node_mapping(StatsElem);
+#endif
+node_mapping(AlterStatsStmt);
+node_mapping(CreateFunctionStmt);
+node_mapping(FunctionParameter);
+node_mapping(AlterFunctionStmt);
+node_mapping(DoStmt);
+node_mapping(InlineCodeBlock);
+node_mapping(CallStmt);
+node_mapping(CallContext);
+node_mapping(RenameStmt);
+node_mapping(AlterObjectDependsStmt);
+node_mapping(AlterObjectSchemaStmt);
+node_mapping(AlterOwnerStmt);
+node_mapping(AlterOperatorStmt);
+node_mapping(AlterTypeStmt);
+node_mapping(RuleStmt);
+node_mapping(NotifyStmt);
+node_mapping(ListenStmt);
+node_mapping(UnlistenStmt);
+node_mapping(TransactionStmt);
+node_mapping(CompositeTypeStmt);
+node_mapping(CreateEnumStmt);
+node_mapping(CreateRangeStmt);
+node_mapping(AlterEnumStmt);
+node_mapping(ViewStmt);
+node_mapping(LoadStmt);
+node_mapping(CreatedbStmt);
+node_mapping(AlterDatabaseStmt);
+#if PG_MAJORVERSION_NUM >= 15
+node_mapping(AlterDatabaseRefreshCollStmt);
+#endif
+node_mapping(AlterDatabaseSetStmt);
+node_mapping(DropdbStmt);
+node_mapping(AlterSystemStmt);
+node_mapping(ClusterStmt);
+node_mapping(VacuumStmt);
+node_mapping(VacuumRelation);
+node_mapping(ExplainStmt);
+node_mapping(CreateTableAsStmt);
+node_mapping(RefreshMatViewStmt);
+node_mapping(CheckPointStmt);
+node_mapping(DiscardStmt);
+node_mapping(LockStmt);
+node_mapping(ConstraintsSetStmt);
+node_mapping(ReindexStmt);
+node_mapping(CreateConversionStmt);
+node_mapping(CreateCastStmt);
+node_mapping(CreateTransformStmt);
+node_mapping(PrepareStmt);
+node_mapping(ExecuteStmt);
+node_mapping(DeallocateStmt);
+node_mapping(DropOwnedStmt);
+node_mapping(ReassignOwnedStmt);
+node_mapping(AlterTSDictionaryStmt);
+node_mapping(AlterTSConfigurationStmt);
+#if PG_MAJORVERSION_NUM >= 15
+node_mapping(PublicationTable);
+node_mapping(PublicationObjSpec);
+#endif
+node_mapping(CreatePublicationStmt);
+node_mapping(AlterPublicationStmt);
+node_mapping(CreateSubscriptionStmt);
+node_mapping(AlterSubscriptionStmt);
+node_mapping(DropSubscriptionStmt);
+node_mapping(PlannerGlobal);
+node_mapping(PlannerInfo);
+node_mapping(RelOptInfo);
+node_mapping(IndexOptInfo);
+node_mapping(ForeignKeyOptInfo);
+node_mapping(StatisticExtInfo);
+#if PG_MAJORVERSION_NUM >= 16
+node_mapping(JoinDomain);
+#endif
+node_mapping(EquivalenceClass);
+node_mapping(EquivalenceMember);
+node_mapping(PathKey);
+#if PG_MAJORVERSION_NUM >= 17
+node_mapping(GroupByOrdering);
+#endif
+node_mapping(PathTarget);
+node_mapping(ParamPathInfo);
+node_mapping(Path);
+node_mapping(IndexPath);
+node_mapping(IndexClause);
+node_mapping(BitmapHeapPath);
+node_mapping(BitmapAndPath);
+node_mapping(BitmapOrPath);
+node_mapping(TidPath);
+#if PG_MAJORVERSION_NUM >= 14
+node_mapping(TidRangePath);
+#endif
+node_mapping(SubqueryScanPath);
+node_mapping(ForeignPath);
+node_mapping(CustomPath);
+node_mapping(AppendPath);
+node_mapping(MergeAppendPath);
+node_mapping(GroupResultPath);
+node_mapping(MaterialPath);
+#if PG_MAJORVERSION_NUM >= 14
+node_mapping(MemoizePath);
+#endif
+node_mapping(UniquePath);
+node_mapping(GatherPath);
+node_mapping(GatherMergePath);
+node_mapping(NestPath);
+node_mapping(MergePath);
+node_mapping(HashPath);
+node_mapping(ProjectionPath);
+node_mapping(ProjectSetPath);
+node_mapping(SortPath);
+node_mapping(IncrementalSortPath);
+node_mapping(GroupPath);
+node_mapping(UpperUniquePath);
+node_mapping(AggPath);
+node_mapping(GroupingSetData);
+node_mapping(RollupData);
+node_mapping(GroupingSetsPath);
+node_mapping(MinMaxAggPath);
+node_mapping(WindowAggPath);
+node_mapping(SetOpPath);
+node_mapping(RecursiveUnionPath);
+node_mapping(LockRowsPath);
+node_mapping(ModifyTablePath);
+node_mapping(LimitPath);
+node_mapping(RestrictInfo);
+node_mapping(PlaceHolderVar);
+node_mapping(SpecialJoinInfo);
+#if PG_MAJORVERSION_NUM >= 16
+node_mapping(OuterJoinClauseInfo);
+#endif
+node_mapping(AppendRelInfo);
+#if PG_MAJORVERSION_NUM >= 14
+node_mapping(RowIdentityVarInfo);
+#endif
+node_mapping(PlaceHolderInfo);
+node_mapping(MinMaxAggInfo);
+node_mapping(PlannerParamItem);
+#if PG_MAJORVERSION_NUM >= 16
+node_mapping(AggInfo);
+node_mapping(AggTransInfo);
+#endif
+#if PG_MAJORVERSION_NUM >= 18
+node_mapping(UniqueRelInfo);
+#endif
+node_mapping(PlannedStmt);
+node_mapping(Result);
+node_mapping(ProjectSet);
+node_mapping(ModifyTable);
+node_mapping(Append);
+node_mapping(MergeAppend);
+node_mapping(RecursiveUnion);
+node_mapping(BitmapAnd);
+node_mapping(BitmapOr);
+node_mapping(SeqScan);
+node_mapping(SampleScan);
+node_mapping(IndexScan);
+node_mapping(IndexOnlyScan);
+node_mapping(BitmapIndexScan);
+node_mapping(BitmapHeapScan);
+node_mapping(TidScan);
+#if PG_MAJORVERSION_NUM >= 14
+node_mapping(TidRangeScan);
+#endif
+node_mapping(SubqueryScan);
+node_mapping(FunctionScan);
+node_mapping(ValuesScan);
+node_mapping(TableFuncScan);
+node_mapping(CteScan);
+node_mapping(NamedTuplestoreScan);
+node_mapping(WorkTableScan);
+node_mapping(ForeignScan);
+node_mapping(CustomScan);
+node_mapping(NestLoop);
+node_mapping(NestLoopParam);
+node_mapping(MergeJoin);
+node_mapping(HashJoin);
+node_mapping(Material);
+#if PG_MAJORVERSION_NUM >= 14
+node_mapping(Memoize);
+#endif
+node_mapping(Sort);
+node_mapping(IncrementalSort);
+node_mapping(Group);
+node_mapping(Agg);
+node_mapping(WindowAgg);
+node_mapping(Unique);
+node_mapping(Gather);
+node_mapping(GatherMerge);
+node_mapping(Hash);
+node_mapping(SetOp);
+node_mapping(LockRows);
+node_mapping(Limit);
+node_mapping(PlanRowMark);
+node_mapping(PartitionPruneInfo);
+node_mapping(PartitionedRelPruneInfo);
+node_mapping(PartitionPruneStepOp);
+node_mapping(PartitionPruneStepCombine);
+node_mapping(PlanInvalItem);
+node_mapping(ExprState);
+node_mapping(IndexInfo);
+node_mapping(ExprContext);
+node_mapping(ReturnSetInfo);
+node_mapping(ProjectionInfo);
+node_mapping(JunkFilter);
+node_mapping(OnConflictSetState);
+#if PG_MAJORVERSION_NUM >= 15
+node_mapping(MergeActionState);
+#endif
+node_mapping(ResultRelInfo);
+node_mapping(EState);
+node_mapping(WindowFuncExprState);
+node_mapping(SetExprState);
+node_mapping(SubPlanState);
+node_mapping(DomainConstraintState);
+node_mapping(ResultState);
+node_mapping(ProjectSetState);
+node_mapping(ModifyTableState);
+node_mapping(AppendState);
+node_mapping(MergeAppendState);
+node_mapping(RecursiveUnionState);
+node_mapping(BitmapAndState);
+node_mapping(BitmapOrState);
+node_mapping(ScanState);
+node_mapping(SeqScanState);
+node_mapping(SampleScanState);
+node_mapping(IndexScanState);
+node_mapping(IndexOnlyScanState);
+node_mapping(BitmapIndexScanState);
+node_mapping(BitmapHeapScanState);
+node_mapping(TidScanState);
+#if PG_MAJORVERSION_NUM >= 14
+node_mapping(TidRangeScanState);
+#endif
+node_mapping(SubqueryScanState);
+node_mapping(FunctionScanState);
+node_mapping(ValuesScanState);
+node_mapping(TableFuncScanState);
+node_mapping(CteScanState);
+node_mapping(NamedTuplestoreScanState);
+node_mapping(WorkTableScanState);
+node_mapping(ForeignScanState);
+node_mapping(CustomScanState);
+node_mapping(JoinState);
+node_mapping(NestLoopState);
+node_mapping(MergeJoinState);
+node_mapping(HashJoinState);
+node_mapping(MaterialState);
+#if PG_MAJORVERSION_NUM >= 14
+node_mapping(MemoizeState);
+#endif
+node_mapping(SortState);
+node_mapping(IncrementalSortState);
+node_mapping(GroupState);
+node_mapping(AggState);
+node_mapping(WindowAggState);
+node_mapping(UniqueState);
+node_mapping(GatherState);
+node_mapping(GatherMergeState);
+node_mapping(HashState);
+node_mapping(SetOpState);
+node_mapping(LockRowsState);
+node_mapping(LimitState);
+node_mapping(IndexAmRoutine);
+node_mapping(TableAmRoutine);
+node_mapping(TsmRoutine);
+node_mapping(EventTriggerData);
+node_mapping(TriggerData);
+node_mapping(TupleTableSlot);
+node_mapping(FdwRoutine);
+#if PG_MAJORVERSION_NUM >= 16
+node_mapping(Bitmapset);
+#endif
+node_mapping(ExtensibleNode);
+#if PG_MAJORVERSION_NUM >= 16
+node_mapping(ErrorSaveContext);
+#endif
+node_mapping(IdentifySystemCmd);
+node_mapping(BaseBackupCmd);
+node_mapping(CreateReplicationSlotCmd);
+node_mapping(DropReplicationSlotCmd);
+#if PG_MAJORVERSION_NUM >= 17
+node_mapping(AlterReplicationSlotCmd);
+#endif
+node_mapping(StartReplicationCmd);
+#if PG_MAJORVERSION_NUM >= 15
+node_mapping(ReadReplicationSlotCmd);
+#endif
+node_mapping(TimeLineHistoryCmd);
+#if PG_MAJORVERSION_NUM >= 17
+node_mapping(UploadManifestCmd);
+#endif
+node_mapping(SupportRequestSimplify);
+node_mapping(SupportRequestSelectivity);
+node_mapping(SupportRequestCost);
+node_mapping(SupportRequestRows);
+node_mapping(SupportRequestIndexCondition);
+#if PG_MAJORVERSION_NUM >= 15
+node_mapping(SupportRequestWFuncMonotonic);
+#endif
+#if PG_MAJORVERSION_NUM >= 17
+node_mapping(SupportRequestOptimizeWindowClause);
+#endif
+#if PG_MAJORVERSION_NUM >= 18
+node_mapping(SupportRequestModifyInPlace);
+#endif
+#if PG_MAJORVERSION_NUM >= 15
+node_mapping(Integer);
+node_mapping(Float);
+node_mapping(Boolean);
+node_mapping(String);
+node_mapping(BitString);
+#endif
+node_mapping(ForeignKeyCacheInfo);
+
+#undef node_mapping
+
+#define node_dispatch(name)                                                                        \
+  if (node_traits<nodes::name>::is(node)) {                                                        \
+    visitor(reinterpret_cast<nodes::name &>(node));                                                \
+    return;                                                                                        \
+  } else
+
+template <typename Visitor> void visit_node(auto node, Visitor &&visitor) {
+  // clang-format off
+node_dispatch(List)
+node_dispatch(Alias)
+node_dispatch(RangeVar)
+node_dispatch(TableFunc)
+node_dispatch(IntoClause)
+node_dispatch(Var)
+node_dispatch(Const)
+node_dispatch(Param)
+node_dispatch(Aggref)
+node_dispatch(GroupingFunc)
+node_dispatch(WindowFunc)
+#if PG_MAJORVERSION_NUM >= 17
+node_dispatch(WindowFuncRunCondition)
+node_dispatch(MergeSupportFunc)
+#endif
+node_dispatch(SubscriptingRef)
+node_dispatch(FuncExpr)
+node_dispatch(NamedArgExpr)
+node_dispatch(OpExpr)
+node_dispatch(DistinctExpr)
+node_dispatch(NullIfExpr)
+node_dispatch(ScalarArrayOpExpr)
+node_dispatch(BoolExpr)
+node_dispatch(SubLink)
+node_dispatch(SubPlan)
+node_dispatch(AlternativeSubPlan)
+node_dispatch(FieldSelect)
+node_dispatch(FieldStore)
+node_dispatch(RelabelType)
+node_dispatch(CoerceViaIO)
+node_dispatch(ArrayCoerceExpr)
+node_dispatch(ConvertRowtypeExpr)
+node_dispatch(CollateExpr)
+node_dispatch(CaseExpr)
+node_dispatch(CaseWhen)
+node_dispatch(CaseTestExpr)
+node_dispatch(ArrayExpr)
+node_dispatch(RowExpr)
+node_dispatch(RowCompareExpr)
+node_dispatch(CoalesceExpr)
+node_dispatch(MinMaxExpr)
+node_dispatch(SQLValueFunction)
+node_dispatch(XmlExpr)
+#if PG_MAJORVERSION_NUM >= 16
+node_dispatch(JsonFormat)
+node_dispatch(JsonReturning)
+node_dispatch(JsonValueExpr)
+node_dispatch(JsonConstructorExpr)
+node_dispatch(JsonIsPredicate)
+#endif
+#if PG_MAJORVERSION_NUM >= 17
+node_dispatch(JsonBehavior)
+node_dispatch(JsonExpr)
+node_dispatch(JsonTablePath)
+node_dispatch(JsonTablePathScan)
+node_dispatch(JsonTableSiblingJoin)
+#endif
+node_dispatch(NullTest)
+node_dispatch(BooleanTest)
+#if PG_MAJORVERSION_NUM >= 15
+node_dispatch(MergeAction)
+#endif
+node_dispatch(CoerceToDomain)
+node_dispatch(CoerceToDomainValue)
+node_dispatch(SetToDefault)
+node_dispatch(CurrentOfExpr)
+node_dispatch(NextValueExpr)
+node_dispatch(InferenceElem)
+#if PG_MAJORVERSION_NUM >= 18
+node_dispatch(ReturningExpr)
+#endif
+node_dispatch(TargetEntry)
+node_dispatch(RangeTblRef)
+node_dispatch(JoinExpr)
+node_dispatch(FromExpr)
+node_dispatch(OnConflictExpr)
+node_dispatch(Query)
+node_dispatch(TypeName)
+node_dispatch(ColumnRef)
+node_dispatch(ParamRef)
+node_dispatch(A_Expr)
+node_dispatch(A_Const)
+node_dispatch(TypeCast)
+node_dispatch(CollateClause)
+node_dispatch(RoleSpec)
+node_dispatch(FuncCall)
+node_dispatch(A_Star)
+node_dispatch(A_Indices)
+node_dispatch(A_Indirection)
+node_dispatch(A_ArrayExpr)
+node_dispatch(ResTarget)
+node_dispatch(MultiAssignRef)
+node_dispatch(SortBy)
+node_dispatch(WindowDef)
+node_dispatch(RangeSubselect)
+node_dispatch(RangeFunction)
+node_dispatch(RangeTableFunc)
+node_dispatch(RangeTableFuncCol)
+node_dispatch(RangeTableSample)
+node_dispatch(ColumnDef)
+node_dispatch(TableLikeClause)
+node_dispatch(IndexElem)
+node_dispatch(DefElem)
+node_dispatch(LockingClause)
+node_dispatch(XmlSerialize)
+node_dispatch(PartitionElem)
+#if PG_MAJORVERSION_NUM == 17
+node_dispatch(SinglePartitionSpec)
+#endif
+node_dispatch(PartitionSpec)
+node_dispatch(PartitionBoundSpec)
+node_dispatch(PartitionRangeDatum)
+node_dispatch(PartitionCmd)
+node_dispatch(RangeTblEntry)
+#if PG_MAJORVERSION_NUM >= 16
+node_dispatch(RTEPermissionInfo)
+#endif
+node_dispatch(RangeTblFunction)
+node_dispatch(TableSampleClause)
+node_dispatch(WithCheckOption)
+node_dispatch(SortGroupClause)
+node_dispatch(GroupingSet)
+node_dispatch(WindowClause)
+node_dispatch(RowMarkClause)
+node_dispatch(WithClause)
+node_dispatch(InferClause)
+node_dispatch(OnConflictClause)
+#if PG_MAJORVERSION_NUM >= 14
+node_dispatch(CTESearchClause)
+node_dispatch(CTECycleClause)
+#endif
+node_dispatch(CommonTableExpr)
+#if PG_MAJORVERSION_NUM >= 15
+node_dispatch(MergeWhenClause)
+#endif
+#if PG_MAJORVERSION_NUM >= 18
+node_dispatch(ReturningOption)
+node_dispatch(ReturningClause)
+#endif
+node_dispatch(TriggerTransition)
+#if PG_MAJORVERSION_NUM >= 16
+node_dispatch(JsonOutput)
+#endif
+#if PG_MAJORVERSION_NUM >= 17
+node_dispatch(JsonArgument)
+node_dispatch(JsonFuncExpr)
+node_dispatch(JsonTablePathSpec)
+node_dispatch(JsonTable)
+node_dispatch(JsonTableColumn)
+node_dispatch(JsonKeyValue)
+node_dispatch(JsonParseExpr)
+node_dispatch(JsonScalarExpr)
+node_dispatch(JsonSerializeExpr)
+#endif
+#if PG_MAJORVERSION_NUM >= 16
+node_dispatch(JsonObjectConstructor)
+node_dispatch(JsonArrayConstructor)
+node_dispatch(JsonArrayQueryConstructor)
+node_dispatch(JsonAggConstructor)
+node_dispatch(JsonObjectAgg)
+node_dispatch(JsonArrayAgg)
+#endif
+node_dispatch(RawStmt)
+node_dispatch(InsertStmt)
+node_dispatch(DeleteStmt)
+node_dispatch(UpdateStmt)
+#if PG_MAJORVERSION_NUM >= 15
+node_dispatch(MergeStmt)
+#endif
+node_dispatch(SelectStmt)
+node_dispatch(SetOperationStmt)
+#if PG_MAJORVERSION_NUM >= 14
+node_dispatch(ReturnStmt)
+#endif
+#if PG_MAJORVERSION_NUM >= 14
+node_dispatch(PLAssignStmt)
+#endif
+node_dispatch(CreateSchemaStmt)
+node_dispatch(AlterTableStmt)
+node_dispatch(AlterTableCmd)
+#if PG_MAJORVERSION_NUM >= 18
+node_dispatch(ATAlterConstraint)
+#endif
+node_dispatch(ReplicaIdentityStmt)
+node_dispatch(AlterCollationStmt)
+node_dispatch(AlterDomainStmt)
+node_dispatch(GrantStmt)
+node_dispatch(ObjectWithArgs)
+node_dispatch(AccessPriv)
+node_dispatch(GrantRoleStmt)
+node_dispatch(AlterDefaultPrivilegesStmt)
+node_dispatch(CopyStmt)
+node_dispatch(VariableSetStmt)
+node_dispatch(VariableShowStmt)
+node_dispatch(CreateStmt)
+node_dispatch(Constraint)
+node_dispatch(CreateTableSpaceStmt)
+node_dispatch(DropTableSpaceStmt)
+node_dispatch(AlterTableSpaceOptionsStmt)
+node_dispatch(AlterTableMoveAllStmt)
+node_dispatch(CreateExtensionStmt)
+node_dispatch(AlterExtensionStmt)
+node_dispatch(AlterExtensionContentsStmt)
+node_dispatch(CreateFdwStmt)
+node_dispatch(AlterFdwStmt)
+node_dispatch(CreateForeignServerStmt)
+node_dispatch(AlterForeignServerStmt)
+node_dispatch(CreateForeignTableStmt)
+node_dispatch(CreateUserMappingStmt)
+node_dispatch(AlterUserMappingStmt)
+node_dispatch(DropUserMappingStmt)
+node_dispatch(ImportForeignSchemaStmt)
+node_dispatch(CreatePolicyStmt)
+node_dispatch(AlterPolicyStmt)
+node_dispatch(CreateAmStmt)
+node_dispatch(CreateTrigStmt)
+node_dispatch(CreateEventTrigStmt)
+node_dispatch(AlterEventTrigStmt)
+node_dispatch(CreatePLangStmt)
+node_dispatch(CreateRoleStmt)
+node_dispatch(AlterRoleStmt)
+node_dispatch(AlterRoleSetStmt)
+node_dispatch(DropRoleStmt)
+node_dispatch(CreateSeqStmt)
+node_dispatch(AlterSeqStmt)
+node_dispatch(DefineStmt)
+node_dispatch(CreateDomainStmt)
+node_dispatch(CreateOpClassStmt)
+node_dispatch(CreateOpClassItem)
+node_dispatch(CreateOpFamilyStmt)
+node_dispatch(AlterOpFamilyStmt)
+node_dispatch(DropStmt)
+node_dispatch(TruncateStmt)
+node_dispatch(CommentStmt)
+node_dispatch(SecLabelStmt)
+node_dispatch(DeclareCursorStmt)
+node_dispatch(ClosePortalStmt)
+node_dispatch(FetchStmt)
+node_dispatch(IndexStmt)
+node_dispatch(CreateStatsStmt)
+#if PG_MAJORVERSION_NUM >= 14
+node_dispatch(StatsElem)
+#endif
+node_dispatch(AlterStatsStmt)
+node_dispatch(CreateFunctionStmt)
+node_dispatch(FunctionParameter)
+node_dispatch(AlterFunctionStmt)
+node_dispatch(DoStmt)
+node_dispatch(InlineCodeBlock)
+node_dispatch(CallStmt)
+node_dispatch(CallContext)
+node_dispatch(RenameStmt)
+node_dispatch(AlterObjectDependsStmt)
+node_dispatch(AlterObjectSchemaStmt)
+node_dispatch(AlterOwnerStmt)
+node_dispatch(AlterOperatorStmt)
+node_dispatch(AlterTypeStmt)
+node_dispatch(RuleStmt)
+node_dispatch(NotifyStmt)
+node_dispatch(ListenStmt)
+node_dispatch(UnlistenStmt)
+node_dispatch(TransactionStmt)
+node_dispatch(CompositeTypeStmt)
+node_dispatch(CreateEnumStmt)
+node_dispatch(CreateRangeStmt)
+node_dispatch(AlterEnumStmt)
+node_dispatch(ViewStmt)
+node_dispatch(LoadStmt)
+node_dispatch(CreatedbStmt)
+node_dispatch(AlterDatabaseStmt)
+#if PG_MAJORVERSION_NUM >= 15
+node_dispatch(AlterDatabaseRefreshCollStmt)
+#endif
+node_dispatch(AlterDatabaseSetStmt)
+node_dispatch(DropdbStmt)
+node_dispatch(AlterSystemStmt)
+node_dispatch(ClusterStmt)
+node_dispatch(VacuumStmt)
+node_dispatch(VacuumRelation)
+node_dispatch(ExplainStmt)
+node_dispatch(CreateTableAsStmt)
+node_dispatch(RefreshMatViewStmt)
+node_dispatch(CheckPointStmt)
+node_dispatch(DiscardStmt)
+node_dispatch(LockStmt)
+node_dispatch(ConstraintsSetStmt)
+node_dispatch(ReindexStmt)
+node_dispatch(CreateConversionStmt)
+node_dispatch(CreateCastStmt)
+node_dispatch(CreateTransformStmt)
+node_dispatch(PrepareStmt)
+node_dispatch(ExecuteStmt)
+node_dispatch(DeallocateStmt)
+node_dispatch(DropOwnedStmt)
+node_dispatch(ReassignOwnedStmt)
+node_dispatch(AlterTSDictionaryStmt)
+node_dispatch(AlterTSConfigurationStmt)
+#if PG_MAJORVERSION_NUM >= 15
+node_dispatch(PublicationTable)
+node_dispatch(PublicationObjSpec)
+#endif
+node_dispatch(CreatePublicationStmt)
+node_dispatch(AlterPublicationStmt)
+node_dispatch(CreateSubscriptionStmt)
+node_dispatch(AlterSubscriptionStmt)
+node_dispatch(DropSubscriptionStmt)
+node_dispatch(PlannerGlobal)
+node_dispatch(PlannerInfo)
+node_dispatch(RelOptInfo)
+node_dispatch(IndexOptInfo)
+node_dispatch(ForeignKeyOptInfo)
+node_dispatch(StatisticExtInfo)
+#if PG_MAJORVERSION_NUM >= 16
+node_dispatch(JoinDomain)
+#endif
+node_dispatch(EquivalenceClass)
+node_dispatch(EquivalenceMember)
+node_dispatch(PathKey)
+#if PG_MAJORVERSION_NUM >= 17
+node_dispatch(GroupByOrdering)
+#endif
+node_dispatch(PathTarget)
+node_dispatch(ParamPathInfo)
+node_dispatch(Path)
+node_dispatch(IndexPath)
+node_dispatch(IndexClause)
+node_dispatch(BitmapHeapPath)
+node_dispatch(BitmapAndPath)
+node_dispatch(BitmapOrPath)
+node_dispatch(TidPath)
+#if PG_MAJORVERSION_NUM >= 14
+node_dispatch(TidRangePath)
+#endif
+node_dispatch(SubqueryScanPath)
+node_dispatch(ForeignPath)
+node_dispatch(CustomPath)
+node_dispatch(AppendPath)
+node_dispatch(MergeAppendPath)
+node_dispatch(GroupResultPath)
+node_dispatch(MaterialPath)
+#if PG_MAJORVERSION_NUM >= 14
+node_dispatch(MemoizePath)
+#endif
+node_dispatch(UniquePath)
+node_dispatch(GatherPath)
+node_dispatch(GatherMergePath)
+node_dispatch(NestPath)
+node_dispatch(MergePath)
+node_dispatch(HashPath)
+node_dispatch(ProjectionPath)
+node_dispatch(ProjectSetPath)
+node_dispatch(SortPath)
+node_dispatch(IncrementalSortPath)
+node_dispatch(GroupPath)
+node_dispatch(UpperUniquePath)
+node_dispatch(AggPath)
+node_dispatch(GroupingSetData)
+node_dispatch(RollupData)
+node_dispatch(GroupingSetsPath)
+node_dispatch(MinMaxAggPath)
+node_dispatch(WindowAggPath)
+node_dispatch(SetOpPath)
+node_dispatch(RecursiveUnionPath)
+node_dispatch(LockRowsPath)
+node_dispatch(ModifyTablePath)
+node_dispatch(LimitPath)
+node_dispatch(RestrictInfo)
+node_dispatch(PlaceHolderVar)
+node_dispatch(SpecialJoinInfo)
+#if PG_MAJORVERSION_NUM >= 16
+node_dispatch(OuterJoinClauseInfo)
+#endif
+node_dispatch(AppendRelInfo)
+#if PG_MAJORVERSION_NUM >= 14
+node_dispatch(RowIdentityVarInfo)
+#endif
+node_dispatch(PlaceHolderInfo)
+node_dispatch(MinMaxAggInfo)
+node_dispatch(PlannerParamItem)
+#if PG_MAJORVERSION_NUM >= 16
+node_dispatch(AggInfo)
+node_dispatch(AggTransInfo)
+#endif
+#if PG_MAJORVERSION_NUM >= 18
+node_dispatch(UniqueRelInfo)
+#endif
+node_dispatch(PlannedStmt)
+node_dispatch(Result)
+node_dispatch(ProjectSet)
+node_dispatch(ModifyTable)
+node_dispatch(Append)
+node_dispatch(MergeAppend)
+node_dispatch(RecursiveUnion)
+node_dispatch(BitmapAnd)
+node_dispatch(BitmapOr)
+node_dispatch(SeqScan)
+node_dispatch(SampleScan)
+node_dispatch(IndexScan)
+node_dispatch(IndexOnlyScan)
+node_dispatch(BitmapIndexScan)
+node_dispatch(BitmapHeapScan)
+node_dispatch(TidScan)
+#if PG_MAJORVERSION_NUM >= 14
+node_dispatch(TidRangeScan)
+#endif
+node_dispatch(SubqueryScan)
+node_dispatch(FunctionScan)
+node_dispatch(ValuesScan)
+node_dispatch(TableFuncScan)
+node_dispatch(CteScan)
+node_dispatch(NamedTuplestoreScan)
+node_dispatch(WorkTableScan)
+node_dispatch(ForeignScan)
+node_dispatch(CustomScan)
+node_dispatch(NestLoop)
+node_dispatch(NestLoopParam)
+node_dispatch(MergeJoin)
+node_dispatch(HashJoin)
+node_dispatch(Material)
+#if PG_MAJORVERSION_NUM >= 14
+node_dispatch(Memoize)
+#endif
+node_dispatch(Sort)
+node_dispatch(IncrementalSort)
+node_dispatch(Group)
+node_dispatch(Agg)
+node_dispatch(WindowAgg)
+node_dispatch(Unique)
+node_dispatch(Gather)
+node_dispatch(GatherMerge)
+node_dispatch(Hash)
+node_dispatch(SetOp)
+node_dispatch(LockRows)
+node_dispatch(Limit)
+node_dispatch(PlanRowMark)
+node_dispatch(PartitionPruneInfo)
+node_dispatch(PartitionedRelPruneInfo)
+node_dispatch(PartitionPruneStepOp)
+node_dispatch(PartitionPruneStepCombine)
+node_dispatch(PlanInvalItem)
+node_dispatch(ExprState)
+node_dispatch(IndexInfo)
+node_dispatch(ExprContext)
+node_dispatch(ReturnSetInfo)
+node_dispatch(ProjectionInfo)
+node_dispatch(JunkFilter)
+node_dispatch(OnConflictSetState)
+#if PG_MAJORVERSION_NUM >= 15
+node_dispatch(MergeActionState)
+#endif
+node_dispatch(ResultRelInfo)
+node_dispatch(EState)
+node_dispatch(WindowFuncExprState)
+node_dispatch(SetExprState)
+node_dispatch(SubPlanState)
+node_dispatch(DomainConstraintState)
+node_dispatch(ResultState)
+node_dispatch(ProjectSetState)
+node_dispatch(ModifyTableState)
+node_dispatch(AppendState)
+node_dispatch(MergeAppendState)
+node_dispatch(RecursiveUnionState)
+node_dispatch(BitmapAndState)
+node_dispatch(BitmapOrState)
+node_dispatch(ScanState)
+node_dispatch(SeqScanState)
+node_dispatch(SampleScanState)
+node_dispatch(IndexScanState)
+node_dispatch(IndexOnlyScanState)
+node_dispatch(BitmapIndexScanState)
+node_dispatch(BitmapHeapScanState)
+node_dispatch(TidScanState)
+#if PG_MAJORVERSION_NUM >= 14
+node_dispatch(TidRangeScanState)
+#endif
+node_dispatch(SubqueryScanState)
+node_dispatch(FunctionScanState)
+node_dispatch(ValuesScanState)
+node_dispatch(TableFuncScanState)
+node_dispatch(CteScanState)
+node_dispatch(NamedTuplestoreScanState)
+node_dispatch(WorkTableScanState)
+node_dispatch(ForeignScanState)
+node_dispatch(CustomScanState)
+node_dispatch(JoinState)
+node_dispatch(NestLoopState)
+node_dispatch(MergeJoinState)
+node_dispatch(HashJoinState)
+node_dispatch(MaterialState)
+#if PG_MAJORVERSION_NUM >= 14
+node_dispatch(MemoizeState)
+#endif
+node_dispatch(SortState)
+node_dispatch(IncrementalSortState)
+node_dispatch(GroupState)
+node_dispatch(AggState)
+node_dispatch(WindowAggState)
+node_dispatch(UniqueState)
+node_dispatch(GatherState)
+node_dispatch(GatherMergeState)
+node_dispatch(HashState)
+node_dispatch(SetOpState)
+node_dispatch(LockRowsState)
+node_dispatch(LimitState)
+node_dispatch(IndexAmRoutine)
+node_dispatch(TableAmRoutine)
+node_dispatch(TsmRoutine)
+node_dispatch(EventTriggerData)
+node_dispatch(TriggerData)
+node_dispatch(TupleTableSlot)
+node_dispatch(FdwRoutine)
+#if PG_MAJORVERSION_NUM >= 16
+node_dispatch(Bitmapset)
+#endif
+node_dispatch(ExtensibleNode)
+#if PG_MAJORVERSION_NUM >= 16
+node_dispatch(ErrorSaveContext)
+#endif
+node_dispatch(IdentifySystemCmd)
+node_dispatch(BaseBackupCmd)
+node_dispatch(CreateReplicationSlotCmd)
+node_dispatch(DropReplicationSlotCmd)
+#if PG_MAJORVERSION_NUM >= 17
+node_dispatch(AlterReplicationSlotCmd)
+#endif
+node_dispatch(StartReplicationCmd)
+#if PG_MAJORVERSION_NUM >= 15
+node_dispatch(ReadReplicationSlotCmd)
+#endif
+node_dispatch(TimeLineHistoryCmd)
+#if PG_MAJORVERSION_NUM >= 17
+node_dispatch(UploadManifestCmd)
+#endif
+node_dispatch(SupportRequestSimplify)
+node_dispatch(SupportRequestSelectivity)
+node_dispatch(SupportRequestCost)
+node_dispatch(SupportRequestRows)
+node_dispatch(SupportRequestIndexCondition)
+#if PG_MAJORVERSION_NUM >= 15
+node_dispatch(SupportRequestWFuncMonotonic)
+#endif
+#if PG_MAJORVERSION_NUM >= 17
+node_dispatch(SupportRequestOptimizeWindowClause)
+#endif
+#if PG_MAJORVERSION_NUM >= 18
+node_dispatch(SupportRequestModifyInPlace)
+#endif
+#if PG_MAJORVERSION_NUM >= 15
+node_dispatch(Integer)
+node_dispatch(Float)
+node_dispatch(Boolean)
+node_dispatch(String)
+node_dispatch(BitString)
+#endif
+node_dispatch(ForeignKeyCacheInfo)
+      // clang-format on
+      throw std::runtime_error("unknown node tag");
+}
+
+#undef node_dispatch
+
+} // namespace cppgres
+
+#include <future>
+#include <queue>
+#include <type_traits>
+
+
+#ifdef __linux__
+#include <sys/syscall.h>
+#include <unistd.h>
+#elif __APPLE__
+#include <pthread.h>
+#endif
+
+namespace cppgres {
+
+#if defined(__linux__)
+static inline bool is_main_thread() { return gettid() == getpid(); }
+#elif defined(__APPLE__)
+static inline bool is_main_thread() { return pthread_main_np() != 0; }
+#else
+#warning "is_main_thread() not implemented"
+static inline bool is_main_thread() { return false; }
+#endif
+
+/**
+ * @brief Single-threaded Postgres workload worker
+ *
+ * @warning Use extreme caution and care when handling workload – ensure the worker does not
+ *          outlive the intended lifetime – and receives no interference – that is, no other
+ *          threads should be doing any Postgres workloads while this worker is alive.
+ */
+struct worker {
+  worker() : done(false), terminated(false) {}
+
+  ~worker() { terminate(); }
+
+  void terminate() {
+    {
+      std::scoped_lock lock(mutex);
+      if (terminated)
+        return;
+      done = true;
+      cv.notify_one();
+    }
+  }
+
+  template <typename F, typename... Args>
+  auto post(F &&f, Args &&...args) -> std::future<std::invoke_result_t<F, Args...>> {
+    using ReturnType = std::invoke_result_t<F, Args...>;
+
+    auto task = std::make_shared<std::packaged_task<ReturnType()>>(
+        [f = std::move(f), ... args = std::move(args)]() { return f(args...); });
+    std::future<ReturnType> result = task->get_future();
+
+    {
+      std::scoped_lock lock(mutex);
+      tasks.emplace([task]() { (*task)(); });
+    }
+    cv.notify_one();
+    return result;
+  }
+
+  /**
+   * @brief Run the worker
+   *
+   * @throws std::runtime_error if called on a secondary thread
+   */
+  void run() {
+    if (!is_main_thread()) {
+      throw std::runtime_error("Worker can only run on main thread");
+    }
+    while (true) {
+      std::function<void()> task;
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        cv.wait(lock, [&]() { return done.load() || !tasks.empty(); });
+        if (done.load() && tasks.empty())
+          break;
+        task = std::move(tasks.front());
+        tasks.pop();
+      }
+      task();
+    }
+    terminated = true;
+  }
+
+private:
+  std::mutex mutex;
+  std::condition_variable cv;
+  std::queue<std::function<void()>> tasks;
+  std::atomic<bool> done;
+  std::atomic<bool> terminated;
+};
+
+} // namespace cppgres
+
+/**
+ * @brief Export a C++ function as a Postgres function.
+ *
+ * Its argument types must conform to the @ref cppgres::convertible_from_nullable_datum concept and
+ * its return type must conform to the @ref cppgres::convertible_into_nullable_datum or
+ * @ref cppgres::datumable_iterator concepts. This requirement is inherited from @ref
+ * cppgres::postgres_function.
+ *
+ * \arg name Name to export it under
+ * \arg function C++ function or lambda
+ *
+ * \note You no longer need to use PG_FUNCTION_INFO_V1 macro.
+ *
+ */
+#define postgres_function(name, function)                                                          \
+  extern "C" {                                                                                     \
+  PG_FUNCTION_INFO_V1(name);                                                                       \
+  Datum name(PG_FUNCTION_ARGS) { return cppgres::postgres_function(function)(fcinfo); }            \
+  }
+
+#endif // cppgres_hpp

--- a/extensions/omni_csv/deps/csv.hpp
+++ b/extensions/omni_csv/deps/csv.hpp
@@ -1,0 +1,8606 @@
+#pragma once
+/*
+CSV for C++, version 2.3.0
+https://github.com/vincentlaucsb/csv-parser
+
+MIT License
+
+Copyright (c) 2017-2024 Vincent La
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef CSV_HPP
+#define CSV_HPP
+
+/** @file
+ *  @brief Defines functionality needed for basic CSV parsing
+ */
+
+
+#include <algorithm>
+#include <deque>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <sstream>
+#include <string>
+#include <vector>
+
+/* Copyright 2017 https://github.com/mandreyel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MIO_MMAP_HEADER
+#define MIO_MMAP_HEADER
+
+// #include "mio/page.hpp"
+/* Copyright 2017 https://github.com/mandreyel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MIO_PAGE_HEADER
+#define MIO_PAGE_HEADER
+
+#ifdef _WIN32
+# include <windows.h>
+#else
+# include <unistd.h>
+#endif
+
+namespace mio {
+
+/**
+ * This is used by `basic_mmap` to determine whether to create a read-only or
+ * a read-write memory mapping.
+ */
+enum class access_mode
+{
+    read,
+    write
+};
+
+/**
+ * Determines the operating system's page allocation granularity.
+ *
+ * On the first call to this function, it invokes the operating system specific syscall
+ * to determine the page size, caches the value, and returns it. Any subsequent call to
+ * this function serves the cached value, so no further syscalls are made.
+ */
+inline size_t page_size()
+{
+    static const size_t page_size = []
+    {
+#ifdef _WIN32
+        SYSTEM_INFO SystemInfo;
+        GetSystemInfo(&SystemInfo);
+        return SystemInfo.dwAllocationGranularity;
+#else
+        return sysconf(_SC_PAGE_SIZE);
+#endif
+    }();
+    return page_size;
+}
+
+/**
+ * Alligns `offset` to the operating's system page size such that it subtracts the
+ * difference until the nearest page boundary before `offset`, or does nothing if
+ * `offset` is already page aligned.
+ */
+inline size_t make_offset_page_aligned(size_t offset) noexcept
+{
+    const size_t page_size_ = page_size();
+    // Use integer division to round down to the nearest page alignment.
+    return offset / page_size_ * page_size_;
+}
+
+} // namespace mio
+
+#endif // MIO_PAGE_HEADER
+
+
+#include <iterator>
+#include <string>
+#include <system_error>
+#include <cstdint>
+
+#ifdef _WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif // WIN32_LEAN_AND_MEAN
+# include <windows.h>
+#else // ifdef _WIN32
+# define INVALID_HANDLE_VALUE -1
+#endif // ifdef _WIN32
+
+namespace mio {
+
+// This value may be provided as the `length` parameter to the constructor or
+// `map`, in which case a memory mapping of the entire file is created.
+enum { map_entire_file = 0 };
+
+#ifdef _WIN32
+using file_handle_type = HANDLE;
+#else
+using file_handle_type = int;
+#endif
+
+// This value represents an invalid file handle type. This can be used to
+// determine whether `basic_mmap::file_handle` is valid, for example.
+const static file_handle_type invalid_handle = INVALID_HANDLE_VALUE;
+
+template<access_mode AccessMode, typename ByteT>
+struct basic_mmap
+{
+    using value_type = ByteT;
+    using size_type = size_t;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using pointer = value_type*;
+    using const_pointer = const value_type*;
+    using difference_type = std::ptrdiff_t;
+    using iterator = pointer;
+    using const_iterator = const_pointer;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    using iterator_category = std::random_access_iterator_tag;
+    using handle_type = file_handle_type;
+
+    static_assert(sizeof(ByteT) == sizeof(char), "ByteT must be the same size as char.");
+
+private:
+    // Points to the first requested byte, and not to the actual start of the mapping.
+    pointer data_ = nullptr;
+
+    // Length--in bytes--requested by user (which may not be the length of the
+    // full mapping) and the length of the full mapping.
+    size_type length_ = 0;
+    size_type mapped_length_ = 0;
+
+    // Letting user map a file using both an existing file handle and a path
+    // introcudes some complexity (see `is_handle_internal_`).
+    // On POSIX, we only need a file handle to create a mapping, while on
+    // Windows systems the file handle is necessary to retrieve a file mapping
+    // handle, but any subsequent operations on the mapped region must be done
+    // through the latter.
+    handle_type file_handle_ = INVALID_HANDLE_VALUE;
+#ifdef _WIN32
+    handle_type file_mapping_handle_ = INVALID_HANDLE_VALUE;
+#endif
+
+    // Letting user map a file using both an existing file handle and a path
+    // introcudes some complexity in that we must not close the file handle if
+    // user provided it, but we must close it if we obtained it using the
+    // provided path. For this reason, this flag is used to determine when to
+    // close `file_handle_`.
+    bool is_handle_internal_;
+
+public:
+    /**
+     * The default constructed mmap object is in a non-mapped state, that is,
+     * any operation that attempts to access nonexistent underlying data will
+     * result in undefined behaviour/segmentation faults.
+     */
+    basic_mmap() = default;
+
+#ifdef __cpp_exceptions
+    /**
+     * The same as invoking the `map` function, except any error that may occur
+     * while establishing the mapping is wrapped in a `std::system_error` and is
+     * thrown.
+     */
+    template<typename String>
+    basic_mmap(const String& path, const size_type offset = 0, const size_type length = map_entire_file)
+    {
+        std::error_code error;
+        map(path, offset, length, error);
+        if(error) { throw std::system_error(error); }
+    }
+
+    /**
+     * The same as invoking the `map` function, except any error that may occur
+     * while establishing the mapping is wrapped in a `std::system_error` and is
+     * thrown.
+     */
+    basic_mmap(const handle_type handle, const size_type offset = 0, const size_type length = map_entire_file)
+    {
+        std::error_code error;
+        map(handle, offset, length, error);
+        if(error) { throw std::system_error(error); }
+    }
+#endif // __cpp_exceptions
+
+    /**
+     * `basic_mmap` has single-ownership semantics, so transferring ownership
+     * may only be accomplished by moving the object.
+     */
+    basic_mmap(const basic_mmap&) = delete;
+    basic_mmap(basic_mmap&&);
+    basic_mmap& operator=(const basic_mmap&) = delete;
+    basic_mmap& operator=(basic_mmap&&);
+
+    /**
+     * If this is a read-write mapping, the destructor invokes sync. Regardless
+     * of the access mode, unmap is invoked as a final step.
+     */
+    ~basic_mmap();
+
+    /**
+     * On UNIX systems 'file_handle' and 'mapping_handle' are the same. On Windows,
+     * however, a mapped region of a file gets its own handle, which is returned by
+     * 'mapping_handle'.
+     */
+    handle_type file_handle() const noexcept { return file_handle_; }
+    handle_type mapping_handle() const noexcept;
+
+    /** Returns whether a valid memory mapping has been created. */
+    bool is_open() const noexcept { return file_handle_ != invalid_handle; }
+
+    /**
+     * Returns true if no mapping was established, that is, conceptually the
+     * same as though the length that was mapped was 0. This function is
+     * provided so that this class has Container semantics.
+     */
+    bool empty() const noexcept { return length() == 0; }
+
+    /** Returns true if a mapping was established. */
+    bool is_mapped() const noexcept;
+
+    /**
+     * `size` and `length` both return the logical length, i.e. the number of bytes
+     * user requested to be mapped, while `mapped_length` returns the actual number of
+     * bytes that were mapped which is a multiple of the underlying operating system's
+     * page allocation granularity.
+     */
+    size_type size() const noexcept { return length(); }
+    size_type length() const noexcept { return length_; }
+    size_type mapped_length() const noexcept { return mapped_length_; }
+
+    /** Returns the offset relative to the start of the mapping. */
+    size_type mapping_offset() const noexcept
+    {
+        return mapped_length_ - length_;
+    }
+
+    /**
+     * Returns a pointer to the first requested byte, or `nullptr` if no memory mapping
+     * exists.
+     */
+    template<
+        access_mode A = AccessMode,
+        typename = typename std::enable_if<A == access_mode::write>::type
+    > pointer data() noexcept { return data_; }
+    const_pointer data() const noexcept { return data_; }
+
+    /**
+     * Returns an iterator to the first requested byte, if a valid memory mapping
+     * exists, otherwise this function call is undefined behaviour.
+     */
+    template<
+        access_mode A = AccessMode,
+        typename = typename std::enable_if<A == access_mode::write>::type
+    > iterator begin() noexcept { return data(); }
+    const_iterator begin() const noexcept { return data(); }
+    const_iterator cbegin() const noexcept { return data(); }
+
+    /**
+     * Returns an iterator one past the last requested byte, if a valid memory mapping
+     * exists, otherwise this function call is undefined behaviour.
+     */
+    template<
+        access_mode A = AccessMode,
+        typename = typename std::enable_if<A == access_mode::write>::type
+    > iterator end() noexcept { return data() + length(); }
+    const_iterator end() const noexcept { return data() + length(); }
+    const_iterator cend() const noexcept { return data() + length(); }
+
+    /**
+     * Returns a reverse iterator to the last memory mapped byte, if a valid
+     * memory mapping exists, otherwise this function call is undefined
+     * behaviour.
+     */
+    template<
+        access_mode A = AccessMode,
+        typename = typename std::enable_if<A == access_mode::write>::type
+    > reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
+    const_reverse_iterator rbegin() const noexcept
+    { return const_reverse_iterator(end()); }
+    const_reverse_iterator crbegin() const noexcept
+    { return const_reverse_iterator(end()); }
+
+    /**
+     * Returns a reverse iterator past the first mapped byte, if a valid memory
+     * mapping exists, otherwise this function call is undefined behaviour.
+     */
+    template<
+        access_mode A = AccessMode,
+        typename = typename std::enable_if<A == access_mode::write>::type
+    > reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+    const_reverse_iterator rend() const noexcept
+    { return const_reverse_iterator(begin()); }
+    const_reverse_iterator crend() const noexcept
+    { return const_reverse_iterator(begin()); }
+
+    /**
+     * Returns a reference to the `i`th byte from the first requested byte (as returned
+     * by `data`). If this is invoked when no valid memory mapping has been created
+     * prior to this call, undefined behaviour ensues.
+     */
+    reference operator[](const size_type i) noexcept { return data_[i]; }
+    const_reference operator[](const size_type i) const noexcept { return data_[i]; }
+
+    /**
+     * Establishes a memory mapping with AccessMode. If the mapping is unsuccesful, the
+     * reason is reported via `error` and the object remains in a state as if this
+     * function hadn't been called.
+     *
+     * `path`, which must be a path to an existing file, is used to retrieve a file
+     * handle (which is closed when the object destructs or `unmap` is called), which is
+     * then used to memory map the requested region. Upon failure, `error` is set to
+     * indicate the reason and the object remains in an unmapped state.
+     *
+     * `offset` is the number of bytes, relative to the start of the file, where the
+     * mapping should begin. When specifying it, there is no need to worry about
+     * providing a value that is aligned with the operating system's page allocation
+     * granularity. This is adjusted by the implementation such that the first requested
+     * byte (as returned by `data` or `begin`), so long as `offset` is valid, will be at
+     * `offset` from the start of the file.
+     *
+     * `length` is the number of bytes to map. It may be `map_entire_file`, in which
+     * case a mapping of the entire file is created.
+     */
+    template<typename String>
+    void map(const String& path, const size_type offset,
+            const size_type length, std::error_code& error);
+
+    /**
+     * Establishes a memory mapping with AccessMode. If the mapping is unsuccesful, the
+     * reason is reported via `error` and the object remains in a state as if this
+     * function hadn't been called.
+     *
+     * `path`, which must be a path to an existing file, is used to retrieve a file
+     * handle (which is closed when the object destructs or `unmap` is called), which is
+     * then used to memory map the requested region. Upon failure, `error` is set to
+     * indicate the reason and the object remains in an unmapped state.
+     * 
+     * The entire file is mapped.
+     */
+    template<typename String>
+    void map(const String& path, std::error_code& error)
+    {
+        map(path, 0, map_entire_file, error);
+    }
+
+    /**
+     * Establishes a memory mapping with AccessMode. If the mapping is
+     * unsuccesful, the reason is reported via `error` and the object remains in
+     * a state as if this function hadn't been called.
+     *
+     * `handle`, which must be a valid file handle, which is used to memory map the
+     * requested region. Upon failure, `error` is set to indicate the reason and the
+     * object remains in an unmapped state.
+     *
+     * `offset` is the number of bytes, relative to the start of the file, where the
+     * mapping should begin. When specifying it, there is no need to worry about
+     * providing a value that is aligned with the operating system's page allocation
+     * granularity. This is adjusted by the implementation such that the first requested
+     * byte (as returned by `data` or `begin`), so long as `offset` is valid, will be at
+     * `offset` from the start of the file.
+     *
+     * `length` is the number of bytes to map. It may be `map_entire_file`, in which
+     * case a mapping of the entire file is created.
+     */
+    void map(const handle_type handle, const size_type offset,
+            const size_type length, std::error_code& error);
+
+    /**
+     * Establishes a memory mapping with AccessMode. If the mapping is
+     * unsuccesful, the reason is reported via `error` and the object remains in
+     * a state as if this function hadn't been called.
+     *
+     * `handle`, which must be a valid file handle, which is used to memory map the
+     * requested region. Upon failure, `error` is set to indicate the reason and the
+     * object remains in an unmapped state.
+     * 
+     * The entire file is mapped.
+     */
+    void map(const handle_type handle, std::error_code& error)
+    {
+        map(handle, 0, map_entire_file, error);
+    }
+
+    /**
+     * If a valid memory mapping has been created prior to this call, this call
+     * instructs the kernel to unmap the memory region and disassociate this object
+     * from the file.
+     *
+     * The file handle associated with the file that is mapped is only closed if the
+     * mapping was created using a file path. If, on the other hand, an existing
+     * file handle was used to create the mapping, the file handle is not closed.
+     */
+    void unmap();
+
+    void swap(basic_mmap& other);
+
+    /** Flushes the memory mapped page to disk. Errors are reported via `error`. */
+    template<access_mode A = AccessMode>
+    typename std::enable_if<A == access_mode::write, void>::type
+    sync(std::error_code& error);
+
+    /**
+     * All operators compare the address of the first byte and size of the two mapped
+     * regions.
+     */
+
+private:
+    template<
+        access_mode A = AccessMode,
+        typename = typename std::enable_if<A == access_mode::write>::type
+    > pointer get_mapping_start() noexcept
+    {
+        return !data() ? nullptr : data() - mapping_offset();
+    }
+
+    const_pointer get_mapping_start() const noexcept
+    {
+        return !data() ? nullptr : data() - mapping_offset();
+    }
+
+    /**
+     * The destructor syncs changes to disk if `AccessMode` is `write`, but not
+     * if it's `read`, but since the destructor cannot be templated, we need to
+     * do SFINAE in a dedicated function, where one syncs and the other is a noop.
+     */
+    template<access_mode A = AccessMode>
+    typename std::enable_if<A == access_mode::write, void>::type
+    conditional_sync();
+    template<access_mode A = AccessMode>
+    typename std::enable_if<A == access_mode::read, void>::type conditional_sync();
+};
+
+template<access_mode AccessMode, typename ByteT>
+bool operator==(const basic_mmap<AccessMode, ByteT>& a,
+        const basic_mmap<AccessMode, ByteT>& b);
+
+template<access_mode AccessMode, typename ByteT>
+bool operator!=(const basic_mmap<AccessMode, ByteT>& a,
+        const basic_mmap<AccessMode, ByteT>& b);
+
+template<access_mode AccessMode, typename ByteT>
+bool operator<(const basic_mmap<AccessMode, ByteT>& a,
+        const basic_mmap<AccessMode, ByteT>& b);
+
+template<access_mode AccessMode, typename ByteT>
+bool operator<=(const basic_mmap<AccessMode, ByteT>& a,
+        const basic_mmap<AccessMode, ByteT>& b);
+
+template<access_mode AccessMode, typename ByteT>
+bool operator>(const basic_mmap<AccessMode, ByteT>& a,
+        const basic_mmap<AccessMode, ByteT>& b);
+
+template<access_mode AccessMode, typename ByteT>
+bool operator>=(const basic_mmap<AccessMode, ByteT>& a,
+        const basic_mmap<AccessMode, ByteT>& b);
+
+/**
+ * This is the basis for all read-only mmap objects and should be preferred over
+ * directly using `basic_mmap`.
+ */
+template<typename ByteT>
+using basic_mmap_source = basic_mmap<access_mode::read, ByteT>;
+
+/**
+ * This is the basis for all read-write mmap objects and should be preferred over
+ * directly using `basic_mmap`.
+ */
+template<typename ByteT>
+using basic_mmap_sink = basic_mmap<access_mode::write, ByteT>;
+
+/**
+ * These aliases cover the most common use cases, both representing a raw byte stream
+ * (either with a char or an unsigned char/uint8_t).
+ */
+using mmap_source = basic_mmap_source<char>;
+using ummap_source = basic_mmap_source<unsigned char>;
+
+using mmap_sink = basic_mmap_sink<char>;
+using ummap_sink = basic_mmap_sink<unsigned char>;
+
+/**
+ * Convenience factory method that constructs a mapping for any `basic_mmap` or
+ * `basic_mmap` type.
+ */
+template<
+    typename MMap,
+    typename MappingToken
+> MMap make_mmap(const MappingToken& token,
+        int64_t offset, int64_t length, std::error_code& error)
+{
+    MMap mmap;
+    mmap.map(token, offset, length, error);
+    return mmap;
+}
+
+/**
+ * Convenience factory method.
+ *
+ * MappingToken may be a String (`std::string`, `std::string_view`, `const char*`,
+ * `std::filesystem::path`, `std::vector<char>`, or similar), or a
+ * `mmap_source::handle_type`.
+ */
+template<typename MappingToken>
+mmap_source make_mmap_source(const MappingToken& token, mmap_source::size_type offset,
+        mmap_source::size_type length, std::error_code& error)
+{
+    return make_mmap<mmap_source>(token, offset, length, error);
+}
+
+template<typename MappingToken>
+mmap_source make_mmap_source(const MappingToken& token, std::error_code& error)
+{
+    return make_mmap_source(token, 0, map_entire_file, error);
+}
+
+/**
+ * Convenience factory method.
+ *
+ * MappingToken may be a String (`std::string`, `std::string_view`, `const char*`,
+ * `std::filesystem::path`, `std::vector<char>`, or similar), or a
+ * `mmap_sink::handle_type`.
+ */
+template<typename MappingToken>
+mmap_sink make_mmap_sink(const MappingToken& token, mmap_sink::size_type offset,
+        mmap_sink::size_type length, std::error_code& error)
+{
+    return make_mmap<mmap_sink>(token, offset, length, error);
+}
+
+template<typename MappingToken>
+mmap_sink make_mmap_sink(const MappingToken& token, std::error_code& error)
+{
+    return make_mmap_sink(token, 0, map_entire_file, error);
+}
+
+} // namespace mio
+
+// #include "detail/mmap.ipp"
+/* Copyright 2017 https://github.com/mandreyel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MIO_BASIC_MMAP_IMPL
+#define MIO_BASIC_MMAP_IMPL
+
+// #include "mio/mmap.hpp"
+
+// #include "mio/page.hpp"
+
+// #include "mio/detail/string_util.hpp"
+/* Copyright 2017 https://github.com/mandreyel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MIO_STRING_UTIL_HEADER
+#define MIO_STRING_UTIL_HEADER
+
+#include <type_traits>
+
+namespace mio {
+namespace detail {
+
+template<
+    typename S,
+    typename C = typename std::decay<S>::type,
+    typename = decltype(std::declval<C>().data()),
+    typename = typename std::enable_if<
+        std::is_same<typename C::value_type, char>::value
+#ifdef _WIN32
+        || std::is_same<typename C::value_type, wchar_t>::value
+#endif
+    >::type
+> struct char_type_helper {
+    using type = typename C::value_type;
+};
+
+template<class T>
+struct char_type {
+    using type = typename char_type_helper<T>::type;
+};
+
+// TODO: can we avoid this brute force approach?
+template<>
+struct char_type<char*> {
+    using type = char;
+};
+
+template<>
+struct char_type<const char*> {
+    using type = char;
+};
+
+template<size_t N>
+struct char_type<char[N]> {
+    using type = char;
+};
+
+template<size_t N>
+struct char_type<const char[N]> {
+    using type = char;
+};
+
+#ifdef _WIN32
+template<>
+struct char_type<wchar_t*> {
+    using type = wchar_t;
+};
+
+template<>
+struct char_type<const wchar_t*> {
+    using type = wchar_t;
+};
+
+template<size_t N>
+struct char_type<wchar_t[N]> {
+    using type = wchar_t;
+};
+
+template<size_t N>
+struct char_type<const wchar_t[N]> {
+    using type = wchar_t;
+};
+#endif // _WIN32
+
+template<typename CharT, typename S>
+struct is_c_str_helper
+{
+    static constexpr bool value = std::is_same<
+        CharT*,
+        // TODO: I'm so sorry for this... Can this be made cleaner?
+        typename std::add_pointer<
+            typename std::remove_cv<
+                typename std::remove_pointer<
+                    typename std::decay<
+                        S
+                    >::type
+                >::type
+            >::type
+        >::type
+    >::value;
+};
+
+template<typename S>
+struct is_c_str
+{
+    static constexpr bool value = is_c_str_helper<char, S>::value;
+};
+
+#ifdef _WIN32
+template<typename S>
+struct is_c_wstr
+{
+    static constexpr bool value = is_c_str_helper<wchar_t, S>::value;
+};
+#endif // _WIN32
+
+template<typename S>
+struct is_c_str_or_c_wstr
+{
+    static constexpr bool value = is_c_str<S>::value
+#ifdef _WIN32
+        || is_c_wstr<S>::value
+#endif
+        ;
+};
+
+template<
+    typename String,
+    typename = decltype(std::declval<String>().data()),
+    typename = typename std::enable_if<!is_c_str_or_c_wstr<String>::value>::type
+> const typename char_type<String>::type* c_str(const String& path)
+{
+    return path.data();
+}
+
+template<
+    typename String,
+    typename = decltype(std::declval<String>().empty()),
+    typename = typename std::enable_if<!is_c_str_or_c_wstr<String>::value>::type
+> bool empty(const String& path)
+{
+    return path.empty();
+}
+
+template<
+    typename String,
+    typename = typename std::enable_if<is_c_str_or_c_wstr<String>::value>::type
+> const typename char_type<String>::type* c_str(String path)
+{
+    return path;
+}
+
+template<
+    typename String,
+    typename = typename std::enable_if<is_c_str_or_c_wstr<String>::value>::type
+> bool empty(String path)
+{
+    return !path || (*path == 0);
+}
+
+} // namespace detail
+} // namespace mio
+
+#endif // MIO_STRING_UTIL_HEADER
+
+
+#include <algorithm>
+
+#ifndef _WIN32
+# include <unistd.h>
+# include <fcntl.h>
+# include <sys/mman.h>
+# include <sys/stat.h>
+#endif
+
+namespace mio {
+namespace detail {
+
+#ifdef _WIN32
+namespace win {
+
+/** Returns the 4 upper bytes of an 8-byte integer. */
+inline DWORD int64_high(int64_t n) noexcept
+{
+    return n >> 32;
+}
+
+/** Returns the 4 lower bytes of an 8-byte integer. */
+inline DWORD int64_low(int64_t n) noexcept
+{
+    return n & 0xffffffff;
+}
+
+template<
+    typename String,
+    typename = typename std::enable_if<
+        std::is_same<typename char_type<String>::type, char>::value
+    >::type
+> file_handle_type open_file_helper(const String& path, const access_mode mode)
+{
+    return ::CreateFileA(c_str(path),
+            mode == access_mode::read ? GENERIC_READ : GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            0,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            0);
+}
+
+template<typename String>
+typename std::enable_if<
+    std::is_same<typename char_type<String>::type, wchar_t>::value,
+    file_handle_type
+>::type open_file_helper(const String& path, const access_mode mode)
+{
+    return ::CreateFileW(c_str(path),
+            mode == access_mode::read ? GENERIC_READ : GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            0,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            0);
+}
+
+} // win
+#endif // _WIN32
+
+/**
+ * Returns the last platform specific system error (errno on POSIX and
+ * GetLastError on Win) as a `std::error_code`.
+ */
+inline std::error_code last_error() noexcept
+{
+    std::error_code error;
+#ifdef _WIN32
+    error.assign(GetLastError(), std::system_category());
+#else
+    error.assign(errno, std::system_category());
+#endif
+    return error;
+}
+
+template<typename String>
+file_handle_type open_file(const String& path, const access_mode mode,
+        std::error_code& error)
+{
+    error.clear();
+    if(detail::empty(path))
+    {
+        error = std::make_error_code(std::errc::invalid_argument);
+        return invalid_handle;
+    }
+#ifdef _WIN32
+    const auto handle = win::open_file_helper(path, mode);
+#else // POSIX
+    const auto handle = ::open(c_str(path),
+            mode == access_mode::read ? O_RDONLY : O_RDWR);
+#endif
+    if(handle == invalid_handle)
+    {
+        error = detail::last_error();
+    }
+    return handle;
+}
+
+inline size_t query_file_size(file_handle_type handle, std::error_code& error)
+{
+    error.clear();
+#ifdef _WIN32
+    LARGE_INTEGER file_size;
+    if(::GetFileSizeEx(handle, &file_size) == 0)
+    {
+        error = detail::last_error();
+        return 0;
+    }
+	return static_cast<int64_t>(file_size.QuadPart);
+#else // POSIX
+    struct stat sbuf;
+    if(::fstat(handle, &sbuf) == -1)
+    {
+        error = detail::last_error();
+        return 0;
+    }
+    return sbuf.st_size;
+#endif
+}
+
+struct mmap_context
+{
+    char* data;
+    int64_t length;
+    int64_t mapped_length;
+#ifdef _WIN32
+    file_handle_type file_mapping_handle;
+#endif
+};
+
+inline mmap_context memory_map(const file_handle_type file_handle, const int64_t offset,
+    const int64_t length, const access_mode mode, std::error_code& error)
+{
+    const int64_t aligned_offset = make_offset_page_aligned(offset);
+    const int64_t length_to_map = offset - aligned_offset + length;
+#ifdef _WIN32
+    const int64_t max_file_size = offset + length;
+    const auto file_mapping_handle = ::CreateFileMapping(
+            file_handle,
+            0,
+            mode == access_mode::read ? PAGE_READONLY : PAGE_READWRITE,
+            win::int64_high(max_file_size),
+            win::int64_low(max_file_size),
+            0);
+    if(file_mapping_handle == invalid_handle)
+    {
+        error = detail::last_error();
+        return {};
+    }
+    char* mapping_start = static_cast<char*>(::MapViewOfFile(
+            file_mapping_handle,
+            mode == access_mode::read ? FILE_MAP_READ : FILE_MAP_WRITE,
+            win::int64_high(aligned_offset),
+            win::int64_low(aligned_offset),
+            length_to_map));
+    if(mapping_start == nullptr)
+    {
+        // Close file handle if mapping it failed.
+        ::CloseHandle(file_mapping_handle);
+        error = detail::last_error();
+        return {};
+    }
+#else // POSIX
+    char* mapping_start = static_cast<char*>(::mmap(
+            0, // Don't give hint as to where to map.
+            length_to_map,
+            mode == access_mode::read ? PROT_READ : PROT_WRITE,
+            MAP_SHARED,
+            file_handle,
+            aligned_offset));
+    if(mapping_start == MAP_FAILED)
+    {
+        error = detail::last_error();
+        return {};
+    }
+#endif
+    mmap_context ctx;
+    ctx.data = mapping_start + offset - aligned_offset;
+    ctx.length = length;
+    ctx.mapped_length = length_to_map;
+#ifdef _WIN32
+    ctx.file_mapping_handle = file_mapping_handle;
+#endif
+    return ctx;
+}
+
+} // namespace detail
+
+// -- basic_mmap --
+
+template<access_mode AccessMode, typename ByteT>
+basic_mmap<AccessMode, ByteT>::~basic_mmap()
+{
+    conditional_sync();
+    unmap();
+}
+
+template<access_mode AccessMode, typename ByteT>
+basic_mmap<AccessMode, ByteT>::basic_mmap(basic_mmap&& other)
+    : data_(std::move(other.data_))
+    , length_(std::move(other.length_))
+    , mapped_length_(std::move(other.mapped_length_))
+    , file_handle_(std::move(other.file_handle_))
+#ifdef _WIN32
+    , file_mapping_handle_(std::move(other.file_mapping_handle_))
+#endif
+    , is_handle_internal_(std::move(other.is_handle_internal_))
+{
+    other.data_ = nullptr;
+    other.length_ = other.mapped_length_ = 0;
+    other.file_handle_ = invalid_handle;
+#ifdef _WIN32
+    other.file_mapping_handle_ = invalid_handle;
+#endif
+}
+
+template<access_mode AccessMode, typename ByteT>
+basic_mmap<AccessMode, ByteT>&
+basic_mmap<AccessMode, ByteT>::operator=(basic_mmap&& other)
+{
+    if(this != &other)
+    {
+        // First the existing mapping needs to be removed.
+        unmap();
+        data_ = std::move(other.data_);
+        length_ = std::move(other.length_);
+        mapped_length_ = std::move(other.mapped_length_);
+        file_handle_ = std::move(other.file_handle_);
+#ifdef _WIN32
+        file_mapping_handle_ = std::move(other.file_mapping_handle_);
+#endif
+        is_handle_internal_ = std::move(other.is_handle_internal_);
+
+        // The moved from basic_mmap's fields need to be reset, because
+        // otherwise other's destructor will unmap the same mapping that was
+        // just moved into this.
+        other.data_ = nullptr;
+        other.length_ = other.mapped_length_ = 0;
+        other.file_handle_ = invalid_handle;
+#ifdef _WIN32
+        other.file_mapping_handle_ = invalid_handle;
+#endif
+        other.is_handle_internal_ = false;
+    }
+    return *this;
+}
+
+template<access_mode AccessMode, typename ByteT>
+typename basic_mmap<AccessMode, ByteT>::handle_type
+basic_mmap<AccessMode, ByteT>::mapping_handle() const noexcept
+{
+#ifdef _WIN32
+    return file_mapping_handle_;
+#else
+    return file_handle_;
+#endif
+}
+
+template<access_mode AccessMode, typename ByteT>
+template<typename String>
+void basic_mmap<AccessMode, ByteT>::map(const String& path, const size_type offset,
+        const size_type length, std::error_code& error)
+{
+    error.clear();
+    if(detail::empty(path))
+    {
+        error = std::make_error_code(std::errc::invalid_argument);
+        return;
+    }
+    const auto handle = detail::open_file(path, AccessMode, error);
+    if(error)
+    {
+        return;
+    }
+
+    map(handle, offset, length, error);
+    // This MUST be after the call to map, as that sets this to true.
+    if(!error)
+    {
+        is_handle_internal_ = true;
+    }
+}
+
+template<access_mode AccessMode, typename ByteT>
+void basic_mmap<AccessMode, ByteT>::map(const handle_type handle,
+        const size_type offset, const size_type length, std::error_code& error)
+{
+    error.clear();
+    if(handle == invalid_handle)
+    {
+        error = std::make_error_code(std::errc::bad_file_descriptor);
+        return;
+    }
+
+    const auto file_size = detail::query_file_size(handle, error);
+    if(error)
+    {
+        return;
+    }
+
+    if(offset + length > file_size)
+    {
+        error = std::make_error_code(std::errc::invalid_argument);
+        return;
+    }
+
+    const auto ctx = detail::memory_map(handle, offset,
+            length == map_entire_file ? (file_size - offset) : length,
+            AccessMode, error);
+    if(!error)
+    {
+        // We must unmap the previous mapping that may have existed prior to this call.
+        // Note that this must only be invoked after a new mapping has been created in
+        // order to provide the strong guarantee that, should the new mapping fail, the
+        // `map` function leaves this instance in a state as though the function had
+        // never been invoked.
+        unmap();
+        file_handle_ = handle;
+        is_handle_internal_ = false;
+        data_ = reinterpret_cast<pointer>(ctx.data);
+        length_ = ctx.length;
+        mapped_length_ = ctx.mapped_length;
+#ifdef _WIN32
+        file_mapping_handle_ = ctx.file_mapping_handle;
+#endif
+    }
+}
+
+template<access_mode AccessMode, typename ByteT>
+template<access_mode A>
+typename std::enable_if<A == access_mode::write, void>::type
+basic_mmap<AccessMode, ByteT>::sync(std::error_code& error)
+{
+    error.clear();
+    if(!is_open())
+    {
+        error = std::make_error_code(std::errc::bad_file_descriptor);
+        return;
+    }
+
+    if(data())
+    {
+#ifdef _WIN32
+        if(::FlushViewOfFile(get_mapping_start(), mapped_length_) == 0
+           || ::FlushFileBuffers(file_handle_) == 0)
+#else // POSIX
+        if(::msync(get_mapping_start(), mapped_length_, MS_SYNC) != 0)
+#endif
+        {
+            error = detail::last_error();
+            return;
+        }
+    }
+#ifdef _WIN32
+    if(::FlushFileBuffers(file_handle_) == 0)
+    {
+        error = detail::last_error();
+    }
+#endif
+}
+
+template<access_mode AccessMode, typename ByteT>
+void basic_mmap<AccessMode, ByteT>::unmap()
+{
+    if(!is_open()) { return; }
+    // TODO do we care about errors here?
+#ifdef _WIN32
+    if(is_mapped())
+    {
+        ::UnmapViewOfFile(get_mapping_start());
+        ::CloseHandle(file_mapping_handle_);
+    }
+#else // POSIX
+    if(data_) { ::munmap(const_cast<pointer>(get_mapping_start()), mapped_length_); }
+#endif
+
+    // If `file_handle_` was obtained by our opening it (when map is called with
+    // a path, rather than an existing file handle), we need to close it,
+    // otherwise it must not be closed as it may still be used outside this
+    // instance.
+    if(is_handle_internal_)
+    {
+#ifdef _WIN32
+        ::CloseHandle(file_handle_);
+#else // POSIX
+        ::close(file_handle_);
+#endif
+    }
+
+    // Reset fields to their default values.
+    data_ = nullptr;
+    length_ = mapped_length_ = 0;
+    file_handle_ = invalid_handle;
+#ifdef _WIN32
+    file_mapping_handle_ = invalid_handle;
+#endif
+}
+
+template<access_mode AccessMode, typename ByteT>
+bool basic_mmap<AccessMode, ByteT>::is_mapped() const noexcept
+{
+#ifdef _WIN32
+    return file_mapping_handle_ != invalid_handle;
+#else // POSIX
+    return is_open();
+#endif
+}
+
+template<access_mode AccessMode, typename ByteT>
+void basic_mmap<AccessMode, ByteT>::swap(basic_mmap& other)
+{
+    if(this != &other)
+    {
+        using std::swap;
+        swap(data_, other.data_);
+        swap(file_handle_, other.file_handle_);
+#ifdef _WIN32
+        swap(file_mapping_handle_, other.file_mapping_handle_);
+#endif
+        swap(length_, other.length_);
+        swap(mapped_length_, other.mapped_length_);
+        swap(is_handle_internal_, other.is_handle_internal_);
+    }
+}
+
+template<access_mode AccessMode, typename ByteT>
+template<access_mode A>
+typename std::enable_if<A == access_mode::write, void>::type
+basic_mmap<AccessMode, ByteT>::conditional_sync()
+{
+    // This is invoked from the destructor, so not much we can do about
+    // failures here.
+    std::error_code ec;
+    sync(ec);
+}
+
+template<access_mode AccessMode, typename ByteT>
+template<access_mode A>
+typename std::enable_if<A == access_mode::read, void>::type
+basic_mmap<AccessMode, ByteT>::conditional_sync()
+{
+    // noop
+}
+
+template<access_mode AccessMode, typename ByteT>
+bool operator==(const basic_mmap<AccessMode, ByteT>& a,
+        const basic_mmap<AccessMode, ByteT>& b)
+{
+    return a.data() == b.data()
+        && a.size() == b.size();
+}
+
+template<access_mode AccessMode, typename ByteT>
+bool operator!=(const basic_mmap<AccessMode, ByteT>& a,
+        const basic_mmap<AccessMode, ByteT>& b)
+{
+    return !(a == b);
+}
+
+template<access_mode AccessMode, typename ByteT>
+bool operator<(const basic_mmap<AccessMode, ByteT>& a,
+        const basic_mmap<AccessMode, ByteT>& b)
+{
+    if(a.data() == b.data()) { return a.size() < b.size(); }
+    return a.data() < b.data();
+}
+
+template<access_mode AccessMode, typename ByteT>
+bool operator<=(const basic_mmap<AccessMode, ByteT>& a,
+        const basic_mmap<AccessMode, ByteT>& b)
+{
+    return !(a > b);
+}
+
+template<access_mode AccessMode, typename ByteT>
+bool operator>(const basic_mmap<AccessMode, ByteT>& a,
+        const basic_mmap<AccessMode, ByteT>& b)
+{
+    if(a.data() == b.data()) { return a.size() > b.size(); }
+    return a.data() > b.data();
+}
+
+template<access_mode AccessMode, typename ByteT>
+bool operator>=(const basic_mmap<AccessMode, ByteT>& a,
+        const basic_mmap<AccessMode, ByteT>& b)
+{
+    return !(a < b);
+}
+
+} // namespace mio
+
+#endif // MIO_BASIC_MMAP_IMPL
+
+
+#endif // MIO_MMAP_HEADER
+/* Copyright 2017 https://github.com/mandreyel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MIO_PAGE_HEADER
+#define MIO_PAGE_HEADER
+
+#ifdef _WIN32
+# include <windows.h>
+#else
+# include <unistd.h>
+#endif
+
+namespace mio {
+
+/**
+ * This is used by `basic_mmap` to determine whether to create a read-only or
+ * a read-write memory mapping.
+ */
+enum class access_mode
+{
+    read,
+    write
+};
+
+/**
+ * Determines the operating system's page allocation granularity.
+ *
+ * On the first call to this function, it invokes the operating system specific syscall
+ * to determine the page size, caches the value, and returns it. Any subsequent call to
+ * this function serves the cached value, so no further syscalls are made.
+ */
+inline size_t page_size()
+{
+    static const size_t page_size = []
+    {
+#ifdef _WIN32
+        SYSTEM_INFO SystemInfo;
+        GetSystemInfo(&SystemInfo);
+        return SystemInfo.dwAllocationGranularity;
+#else
+        return sysconf(_SC_PAGE_SIZE);
+#endif
+    }();
+    return page_size;
+}
+
+/**
+ * Alligns `offset` to the operating's system page size such that it subtracts the
+ * difference until the nearest page boundary before `offset`, or does nothing if
+ * `offset` is already page aligned.
+ */
+inline size_t make_offset_page_aligned(size_t offset) noexcept
+{
+    const size_t page_size_ = page_size();
+    // Use integer division to round down to the nearest page alignment.
+    return offset / page_size_ * page_size_;
+}
+
+} // namespace mio
+
+#endif // MIO_PAGE_HEADER
+/* Copyright 2017 https://github.com/mandreyel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MIO_SHARED_MMAP_HEADER
+#define MIO_SHARED_MMAP_HEADER
+
+// #include "mio/mmap.hpp"
+
+
+#include <system_error> // std::error_code
+#include <memory> // std::shared_ptr
+
+namespace mio {
+
+/**
+ * Exposes (nearly) the same interface as `basic_mmap`, but endowes it with
+ * `std::shared_ptr` semantics.
+ *
+ * This is not the default behaviour of `basic_mmap` to avoid allocating on the heap if
+ * shared semantics are not required.
+ */
+template<
+    access_mode AccessMode,
+    typename ByteT
+> class basic_shared_mmap
+{
+    using impl_type = basic_mmap<AccessMode, ByteT>;
+    std::shared_ptr<impl_type> pimpl_;
+
+public:
+    using value_type = typename impl_type::value_type;
+    using size_type = typename impl_type::size_type;
+    using reference = typename impl_type::reference;
+    using const_reference = typename impl_type::const_reference;
+    using pointer = typename impl_type::pointer;
+    using const_pointer = typename impl_type::const_pointer;
+    using difference_type = typename impl_type::difference_type;
+    using iterator = typename impl_type::iterator;
+    using const_iterator = typename impl_type::const_iterator;
+    using reverse_iterator = typename impl_type::reverse_iterator;
+    using const_reverse_iterator = typename impl_type::const_reverse_iterator;
+    using iterator_category = typename impl_type::iterator_category;
+    using handle_type = typename impl_type::handle_type;
+    using mmap_type = impl_type;
+
+    basic_shared_mmap() = default;
+    basic_shared_mmap(const basic_shared_mmap&) = default;
+    basic_shared_mmap& operator=(const basic_shared_mmap&) = default;
+    basic_shared_mmap(basic_shared_mmap&&) = default;
+    basic_shared_mmap& operator=(basic_shared_mmap&&) = default;
+
+    /** Takes ownership of an existing mmap object. */
+    basic_shared_mmap(mmap_type&& mmap)
+        : pimpl_(std::make_shared<mmap_type>(std::move(mmap)))
+    {}
+
+    /** Takes ownership of an existing mmap object. */
+    basic_shared_mmap& operator=(mmap_type&& mmap)
+    {
+        pimpl_ = std::make_shared<mmap_type>(std::move(mmap));
+        return *this;
+    }
+
+    /** Initializes this object with an already established shared mmap. */
+    basic_shared_mmap(std::shared_ptr<mmap_type> mmap) : pimpl_(std::move(mmap)) {}
+
+    /** Initializes this object with an already established shared mmap. */
+    basic_shared_mmap& operator=(std::shared_ptr<mmap_type> mmap)
+    {
+        pimpl_ = std::move(mmap);
+        return *this;
+    }
+
+#ifdef __cpp_exceptions
+    /**
+     * The same as invoking the `map` function, except any error that may occur
+     * while establishing the mapping is wrapped in a `std::system_error` and is
+     * thrown.
+     */
+    template<typename String>
+    basic_shared_mmap(const String& path, const size_type offset = 0, const size_type length = map_entire_file)
+    {
+        std::error_code error;
+        map(path, offset, length, error);
+        if(error) { throw std::system_error(error); }
+    }
+
+    /**
+     * The same as invoking the `map` function, except any error that may occur
+     * while establishing the mapping is wrapped in a `std::system_error` and is
+     * thrown.
+     */
+    basic_shared_mmap(const handle_type handle, const size_type offset = 0, const size_type length = map_entire_file)
+    {
+        std::error_code error;
+        map(handle, offset, length, error);
+        if(error) { throw std::system_error(error); }
+    }
+#endif // __cpp_exceptions
+
+    /**
+     * If this is a read-write mapping and the last reference to the mapping,
+     * the destructor invokes sync. Regardless of the access mode, unmap is
+     * invoked as a final step.
+     */
+    ~basic_shared_mmap() = default;
+
+    /** Returns the underlying `std::shared_ptr` instance that holds the mmap. */
+    std::shared_ptr<mmap_type> get_shared_ptr() { return pimpl_; }
+
+    /**
+     * On UNIX systems 'file_handle' and 'mapping_handle' are the same. On Windows,
+     * however, a mapped region of a file gets its own handle, which is returned by
+     * 'mapping_handle'.
+     */
+    handle_type file_handle() const noexcept
+    {
+        return pimpl_ ? pimpl_->file_handle() : invalid_handle;
+    }
+
+    handle_type mapping_handle() const noexcept
+    {
+        return pimpl_ ? pimpl_->mapping_handle() : invalid_handle;
+    }
+
+    /** Returns whether a valid memory mapping has been created. */
+    bool is_open() const noexcept { return pimpl_ && pimpl_->is_open(); }
+
+    /**
+     * Returns true if no mapping was established, that is, conceptually the
+     * same as though the length that was mapped was 0. This function is
+     * provided so that this class has Container semantics.
+     */
+    bool empty() const noexcept { return !pimpl_ || pimpl_->empty(); }
+
+    /**
+     * `size` and `length` both return the logical length, i.e. the number of bytes
+     * user requested to be mapped, while `mapped_length` returns the actual number of
+     * bytes that were mapped which is a multiple of the underlying operating system's
+     * page allocation granularity.
+     */
+    size_type size() const noexcept { return pimpl_ ? pimpl_->length() : 0; }
+    size_type length() const noexcept { return pimpl_ ? pimpl_->length() : 0; }
+    size_type mapped_length() const noexcept
+    {
+        return pimpl_ ? pimpl_->mapped_length() : 0;
+    }
+
+    /**
+     * Returns a pointer to the first requested byte, or `nullptr` if no memory mapping
+     * exists.
+     */
+    template<
+        access_mode A = AccessMode,
+        typename = typename std::enable_if<A == access_mode::write>::type
+    > pointer data() noexcept { return pimpl_->data(); }
+    const_pointer data() const noexcept { return pimpl_ ? pimpl_->data() : nullptr; }
+
+    /**
+     * Returns an iterator to the first requested byte, if a valid memory mapping
+     * exists, otherwise this function call is undefined behaviour.
+     */
+    iterator begin() noexcept { return pimpl_->begin(); }
+    const_iterator begin() const noexcept { return pimpl_->begin(); }
+    const_iterator cbegin() const noexcept { return pimpl_->cbegin(); }
+
+    /**
+     * Returns an iterator one past the last requested byte, if a valid memory mapping
+     * exists, otherwise this function call is undefined behaviour.
+     */
+    template<
+        access_mode A = AccessMode,
+        typename = typename std::enable_if<A == access_mode::write>::type
+    > iterator end() noexcept { return pimpl_->end(); }
+    const_iterator end() const noexcept { return pimpl_->end(); }
+    const_iterator cend() const noexcept { return pimpl_->cend(); }
+
+    /**
+     * Returns a reverse iterator to the last memory mapped byte, if a valid
+     * memory mapping exists, otherwise this function call is undefined
+     * behaviour.
+     */
+    template<
+        access_mode A = AccessMode,
+        typename = typename std::enable_if<A == access_mode::write>::type
+    > reverse_iterator rbegin() noexcept { return pimpl_->rbegin(); }
+    const_reverse_iterator rbegin() const noexcept { return pimpl_->rbegin(); }
+    const_reverse_iterator crbegin() const noexcept { return pimpl_->crbegin(); }
+
+    /**
+     * Returns a reverse iterator past the first mapped byte, if a valid memory
+     * mapping exists, otherwise this function call is undefined behaviour.
+     */
+    template<
+        access_mode A = AccessMode,
+        typename = typename std::enable_if<A == access_mode::write>::type
+    > reverse_iterator rend() noexcept { return pimpl_->rend(); }
+    const_reverse_iterator rend() const noexcept { return pimpl_->rend(); }
+    const_reverse_iterator crend() const noexcept { return pimpl_->crend(); }
+
+    /**
+     * Returns a reference to the `i`th byte from the first requested byte (as returned
+     * by `data`). If this is invoked when no valid memory mapping has been created
+     * prior to this call, undefined behaviour ensues.
+     */
+    reference operator[](const size_type i) noexcept { return (*pimpl_)[i]; }
+    const_reference operator[](const size_type i) const noexcept { return (*pimpl_)[i]; }
+
+    /**
+     * Establishes a memory mapping with AccessMode. If the mapping is unsuccesful, the
+     * reason is reported via `error` and the object remains in a state as if this
+     * function hadn't been called.
+     *
+     * `path`, which must be a path to an existing file, is used to retrieve a file
+     * handle (which is closed when the object destructs or `unmap` is called), which is
+     * then used to memory map the requested region. Upon failure, `error` is set to
+     * indicate the reason and the object remains in an unmapped state.
+     *
+     * `offset` is the number of bytes, relative to the start of the file, where the
+     * mapping should begin. When specifying it, there is no need to worry about
+     * providing a value that is aligned with the operating system's page allocation
+     * granularity. This is adjusted by the implementation such that the first requested
+     * byte (as returned by `data` or `begin`), so long as `offset` is valid, will be at
+     * `offset` from the start of the file.
+     *
+     * `length` is the number of bytes to map. It may be `map_entire_file`, in which
+     * case a mapping of the entire file is created.
+     */
+    template<typename String>
+    void map(const String& path, const size_type offset,
+        const size_type length, std::error_code& error)
+    {
+        map_impl(path, offset, length, error);
+    }
+
+    /**
+     * Establishes a memory mapping with AccessMode. If the mapping is unsuccesful, the
+     * reason is reported via `error` and the object remains in a state as if this
+     * function hadn't been called.
+     *
+     * `path`, which must be a path to an existing file, is used to retrieve a file
+     * handle (which is closed when the object destructs or `unmap` is called), which is
+     * then used to memory map the requested region. Upon failure, `error` is set to
+     * indicate the reason and the object remains in an unmapped state.
+     *
+     * The entire file is mapped.
+     */
+    template<typename String>
+    void map(const String& path, std::error_code& error)
+    {
+        map_impl(path, 0, map_entire_file, error);
+    }
+
+    /**
+     * Establishes a memory mapping with AccessMode. If the mapping is unsuccesful, the
+     * reason is reported via `error` and the object remains in a state as if this
+     * function hadn't been called.
+     *
+     * `handle`, which must be a valid file handle, which is used to memory map the
+     * requested region. Upon failure, `error` is set to indicate the reason and the
+     * object remains in an unmapped state.
+     *
+     * `offset` is the number of bytes, relative to the start of the file, where the
+     * mapping should begin. When specifying it, there is no need to worry about
+     * providing a value that is aligned with the operating system's page allocation
+     * granularity. This is adjusted by the implementation such that the first requested
+     * byte (as returned by `data` or `begin`), so long as `offset` is valid, will be at
+     * `offset` from the start of the file.
+     *
+     * `length` is the number of bytes to map. It may be `map_entire_file`, in which
+     * case a mapping of the entire file is created.
+     */
+    void map(const handle_type handle, const size_type offset,
+        const size_type length, std::error_code& error)
+    {
+        map_impl(handle, offset, length, error);
+    }
+
+    /**
+     * Establishes a memory mapping with AccessMode. If the mapping is unsuccesful, the
+     * reason is reported via `error` and the object remains in a state as if this
+     * function hadn't been called.
+     *
+     * `handle`, which must be a valid file handle, which is used to memory map the
+     * requested region. Upon failure, `error` is set to indicate the reason and the
+     * object remains in an unmapped state.
+     *
+     * The entire file is mapped.
+     */
+    void map(const handle_type handle, std::error_code& error)
+    {
+        map_impl(handle, 0, map_entire_file, error);
+    }
+
+    /**
+     * If a valid memory mapping has been created prior to this call, this call
+     * instructs the kernel to unmap the memory region and disassociate this object
+     * from the file.
+     *
+     * The file handle associated with the file that is mapped is only closed if the
+     * mapping was created using a file path. If, on the other hand, an existing
+     * file handle was used to create the mapping, the file handle is not closed.
+     */
+    void unmap() { if(pimpl_) pimpl_->unmap(); }
+
+    void swap(basic_shared_mmap& other) { pimpl_.swap(other.pimpl_); }
+
+    /** Flushes the memory mapped page to disk. Errors are reported via `error`. */
+    template<
+        access_mode A = AccessMode,
+        typename = typename std::enable_if<A == access_mode::write>::type
+    > void sync(std::error_code& error) { if(pimpl_) pimpl_->sync(error); }
+
+    /** All operators compare the underlying `basic_mmap`'s addresses. */
+
+    friend bool operator==(const basic_shared_mmap& a, const basic_shared_mmap& b)
+    {
+        return a.pimpl_ == b.pimpl_;
+    }
+
+    friend bool operator!=(const basic_shared_mmap& a, const basic_shared_mmap& b)
+    {
+        return !(a == b);
+    }
+
+    friend bool operator<(const basic_shared_mmap& a, const basic_shared_mmap& b)
+    {
+        return a.pimpl_ < b.pimpl_;
+    }
+
+    friend bool operator<=(const basic_shared_mmap& a, const basic_shared_mmap& b)
+    {
+        return a.pimpl_ <= b.pimpl_;
+    }
+
+    friend bool operator>(const basic_shared_mmap& a, const basic_shared_mmap& b)
+    {
+        return a.pimpl_ > b.pimpl_;
+    }
+
+    friend bool operator>=(const basic_shared_mmap& a, const basic_shared_mmap& b)
+    {
+        return a.pimpl_ >= b.pimpl_;
+    }
+
+private:
+    template<typename MappingToken>
+    void map_impl(const MappingToken& token, const size_type offset,
+        const size_type length, std::error_code& error)
+    {
+        if(!pimpl_)
+        {
+            mmap_type mmap = make_mmap<mmap_type>(token, offset, length, error);
+            if(error) { return; }
+            pimpl_ = std::make_shared<mmap_type>(std::move(mmap));
+        }
+        else
+        {
+            pimpl_->map(token, offset, length, error);
+        }
+    }
+};
+
+/**
+ * This is the basis for all read-only mmap objects and should be preferred over
+ * directly using basic_shared_mmap.
+ */
+template<typename ByteT>
+using basic_shared_mmap_source = basic_shared_mmap<access_mode::read, ByteT>;
+
+/**
+ * This is the basis for all read-write mmap objects and should be preferred over
+ * directly using basic_shared_mmap.
+ */
+template<typename ByteT>
+using basic_shared_mmap_sink = basic_shared_mmap<access_mode::write, ByteT>;
+
+/**
+ * These aliases cover the most common use cases, both representing a raw byte stream
+ * (either with a char or an unsigned char/uint8_t).
+ */
+using shared_mmap_source = basic_shared_mmap_source<char>;
+using shared_ummap_source = basic_shared_mmap_source<unsigned char>;
+
+using shared_mmap_sink = basic_shared_mmap_sink<char>;
+using shared_ummap_sink = basic_shared_mmap_sink<unsigned char>;
+
+} // namespace mio
+
+#endif // MIO_SHARED_MMAP_HEADER
+
+/** @file
+ *  @brief Contains the main CSV parsing algorithm and various utility functions
+ */
+
+#include <algorithm>
+#include <array>
+#include <condition_variable>
+#include <deque>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <thread>
+#include <vector>
+
+#include <memory>
+#include <unordered_map>
+#include <string>
+#include <vector>
+
+/** @file
+ *  A standalone header file containing shared code
+ */
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <deque>
+
+#if defined(_WIN32)
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <windows.h>
+# undef max
+# undef min
+#elif defined(__linux__)
+# include <unistd.h>
+#endif
+
+ /** Helper macro which should be #defined as "inline"
+  *  in the single header version
+  */
+#define CSV_INLINE inline
+
+#include <type_traits>
+
+// Copyright 2017-2019 by Martin Moene
+//
+// string-view lite, a C++17-like string_view for C++98 and later.
+// For more information see https://github.com/martinmoene/string-view-lite
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#ifndef NONSTD_SV_LITE_H_INCLUDED
+#define NONSTD_SV_LITE_H_INCLUDED
+
+#define string_view_lite_MAJOR  1
+#define string_view_lite_MINOR  1
+#define string_view_lite_PATCH  0
+
+#define string_view_lite_VERSION  nssv_STRINGIFY(string_view_lite_MAJOR) "." nssv_STRINGIFY(string_view_lite_MINOR) "." nssv_STRINGIFY(string_view_lite_PATCH)
+
+#define nssv_STRINGIFY(  x )  nssv_STRINGIFY_( x )
+#define nssv_STRINGIFY_( x )  #x
+
+// string-view lite configuration:
+
+#define nssv_STRING_VIEW_DEFAULT  0
+#define nssv_STRING_VIEW_NONSTD   1
+#define nssv_STRING_VIEW_STD      2
+
+#if !defined( nssv_CONFIG_SELECT_STRING_VIEW )
+# define nssv_CONFIG_SELECT_STRING_VIEW  ( nssv_HAVE_STD_STRING_VIEW ? nssv_STRING_VIEW_STD : nssv_STRING_VIEW_NONSTD )
+#endif
+
+#if defined( nssv_CONFIG_SELECT_STD_STRING_VIEW ) || defined( nssv_CONFIG_SELECT_NONSTD_STRING_VIEW )
+# error nssv_CONFIG_SELECT_STD_STRING_VIEW and nssv_CONFIG_SELECT_NONSTD_STRING_VIEW are deprecated and removed, please use nssv_CONFIG_SELECT_STRING_VIEW=nssv_STRING_VIEW_...
+#endif
+
+#ifndef  nssv_CONFIG_STD_SV_OPERATOR
+# define nssv_CONFIG_STD_SV_OPERATOR  0
+#endif
+
+#ifndef  nssv_CONFIG_USR_SV_OPERATOR
+# define nssv_CONFIG_USR_SV_OPERATOR  1
+#endif
+
+#ifdef   nssv_CONFIG_CONVERSION_STD_STRING
+# define nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS   nssv_CONFIG_CONVERSION_STD_STRING
+# define nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS  nssv_CONFIG_CONVERSION_STD_STRING
+#endif
+
+#ifndef  nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS
+# define nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS  1
+#endif
+
+#ifndef  nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+# define nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS  1
+#endif
+
+// Control presence of exception handling (try and auto discover):
+
+#ifndef nssv_CONFIG_NO_EXCEPTIONS
+# if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)
+#  define nssv_CONFIG_NO_EXCEPTIONS  0
+# else
+#  define nssv_CONFIG_NO_EXCEPTIONS  1
+# endif
+#endif
+
+// C++ language version detection (C++20 is speculative):
+// Note: VC14.0/1900 (VS2015) lacks too much from C++14.
+
+#ifndef   nssv_CPLUSPLUS
+# if defined(_MSVC_LANG ) && !defined(__clang__)
+#  define nssv_CPLUSPLUS  (_MSC_VER == 1900 ? 201103L : _MSVC_LANG )
+# else
+#  define nssv_CPLUSPLUS  __cplusplus
+# endif
+#endif
+
+#define nssv_CPP98_OR_GREATER  ( nssv_CPLUSPLUS >= 199711L )
+#define nssv_CPP11_OR_GREATER  ( nssv_CPLUSPLUS >= 201103L )
+#define nssv_CPP11_OR_GREATER_ ( nssv_CPLUSPLUS >= 201103L )
+#define nssv_CPP14_OR_GREATER  ( nssv_CPLUSPLUS >= 201402L )
+#define nssv_CPP17_OR_GREATER  ( nssv_CPLUSPLUS >= 201703L )
+#define nssv_CPP20_OR_GREATER  ( nssv_CPLUSPLUS >= 202000L )
+
+// use C++17 std::string_view if available and requested:
+
+#if nssv_CPP17_OR_GREATER && defined(__has_include )
+# if __has_include( <string_view> )
+#  define nssv_HAVE_STD_STRING_VIEW  1
+# else
+#  define nssv_HAVE_STD_STRING_VIEW  0
+# endif
+#else
+# define  nssv_HAVE_STD_STRING_VIEW  0
+#endif
+
+#define  nssv_USES_STD_STRING_VIEW  ( (nssv_CONFIG_SELECT_STRING_VIEW == nssv_STRING_VIEW_STD) || ((nssv_CONFIG_SELECT_STRING_VIEW == nssv_STRING_VIEW_DEFAULT) && nssv_HAVE_STD_STRING_VIEW) )
+
+#define nssv_HAVE_STARTS_WITH ( nssv_CPP20_OR_GREATER || !nssv_USES_STD_STRING_VIEW )
+#define nssv_HAVE_ENDS_WITH     nssv_HAVE_STARTS_WITH
+
+//
+// Use C++17 std::string_view:
+//
+
+#if nssv_USES_STD_STRING_VIEW
+
+#include <string_view>
+
+// Extensions for std::string:
+
+#if nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+
+namespace nonstd {
+
+template< class CharT, class Traits, class Allocator = std::allocator<CharT> >
+std::basic_string<CharT, Traits, Allocator>
+to_string( std::basic_string_view<CharT, Traits> v, Allocator const & a = Allocator() )
+{
+    return std::basic_string<CharT,Traits, Allocator>( v.begin(), v.end(), a );
+}
+
+template< class CharT, class Traits, class Allocator >
+std::basic_string_view<CharT, Traits>
+to_string_view( std::basic_string<CharT, Traits, Allocator> const & s )
+{
+    return std::basic_string_view<CharT, Traits>( s.data(), s.size() );
+}
+
+// Literal operators sv and _sv:
+
+#if nssv_CONFIG_STD_SV_OPERATOR
+
+using namespace std::literals::string_view_literals;
+
+#endif
+
+#if nssv_CONFIG_USR_SV_OPERATOR
+
+inline namespace literals {
+inline namespace string_view_literals {
+
+
+constexpr std::string_view operator ""_sv( const char* str, size_t len ) noexcept  // (1)
+{
+    return std::string_view{ str, len };
+}
+
+constexpr std::u16string_view operator ""_sv( const char16_t* str, size_t len ) noexcept  // (2)
+{
+    return std::u16string_view{ str, len };
+}
+
+constexpr std::u32string_view operator ""_sv( const char32_t* str, size_t len ) noexcept  // (3)
+{
+    return std::u32string_view{ str, len };
+}
+
+constexpr std::wstring_view operator ""_sv( const wchar_t* str, size_t len ) noexcept  // (4)
+{
+    return std::wstring_view{ str, len };
+}
+
+}} // namespace literals::string_view_literals
+
+#endif // nssv_CONFIG_USR_SV_OPERATOR
+
+} // namespace nonstd
+
+#endif // nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+
+namespace nonstd {
+
+using std::string_view;
+using std::wstring_view;
+using std::u16string_view;
+using std::u32string_view;
+using std::basic_string_view;
+
+// literal "sv" and "_sv", see above
+
+using std::operator==;
+using std::operator!=;
+using std::operator<;
+using std::operator<=;
+using std::operator>;
+using std::operator>=;
+
+using std::operator<<;
+
+} // namespace nonstd
+
+#else // nssv_HAVE_STD_STRING_VIEW
+
+//
+// Before C++17: use string_view lite:
+//
+
+// Compiler versions:
+//
+// MSVC++ 6.0  _MSC_VER == 1200 (Visual Studio 6.0)
+// MSVC++ 7.0  _MSC_VER == 1300 (Visual Studio .NET 2002)
+// MSVC++ 7.1  _MSC_VER == 1310 (Visual Studio .NET 2003)
+// MSVC++ 8.0  _MSC_VER == 1400 (Visual Studio 2005)
+// MSVC++ 9.0  _MSC_VER == 1500 (Visual Studio 2008)
+// MSVC++ 10.0 _MSC_VER == 1600 (Visual Studio 2010)
+// MSVC++ 11.0 _MSC_VER == 1700 (Visual Studio 2012)
+// MSVC++ 12.0 _MSC_VER == 1800 (Visual Studio 2013)
+// MSVC++ 14.0 _MSC_VER == 1900 (Visual Studio 2015)
+// MSVC++ 14.1 _MSC_VER >= 1910 (Visual Studio 2017)
+
+#if defined(_MSC_VER ) && !defined(__clang__)
+# define nssv_COMPILER_MSVC_VER      (_MSC_VER )
+# define nssv_COMPILER_MSVC_VERSION  (_MSC_VER / 10 - 10 * ( 5 + (_MSC_VER < 1900 ) ) )
+#else
+# define nssv_COMPILER_MSVC_VER      0
+# define nssv_COMPILER_MSVC_VERSION  0
+#endif
+
+#define nssv_COMPILER_VERSION( major, minor, patch )  (10 * ( 10 * major + minor) + patch)
+
+#if defined(__clang__)
+# define nssv_COMPILER_CLANG_VERSION  nssv_COMPILER_VERSION(__clang_major__, __clang_minor__, __clang_patchlevel__)
+#else
+# define nssv_COMPILER_CLANG_VERSION    0
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+# define nssv_COMPILER_GNUC_VERSION  nssv_COMPILER_VERSION(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+#else
+# define nssv_COMPILER_GNUC_VERSION    0
+#endif
+
+// half-open range [lo..hi):
+#define nssv_BETWEEN( v, lo, hi ) ( (lo) <= (v) && (v) < (hi) )
+
+// Presence of language and library features:
+
+#ifdef _HAS_CPP0X
+# define nssv_HAS_CPP0X  _HAS_CPP0X
+#else
+# define nssv_HAS_CPP0X  0
+#endif
+
+// Unless defined otherwise below, consider VC14 as C++11 for variant-lite:
+
+#if nssv_COMPILER_MSVC_VER >= 1900
+# undef  nssv_CPP11_OR_GREATER
+# define nssv_CPP11_OR_GREATER  1
+#endif
+
+#define nssv_CPP11_90   (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1500)
+#define nssv_CPP11_100  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1600)
+#define nssv_CPP11_110  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1700)
+#define nssv_CPP11_120  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1800)
+#define nssv_CPP11_140  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1900)
+#define nssv_CPP11_141  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1910)
+
+#define nssv_CPP14_000  (nssv_CPP14_OR_GREATER)
+#define nssv_CPP17_000  (nssv_CPP17_OR_GREATER)
+
+// Presence of C++11 language features:
+
+#define nssv_HAVE_CONSTEXPR_11          nssv_CPP11_140
+#define nssv_HAVE_EXPLICIT_CONVERSION   nssv_CPP11_140
+#define nssv_HAVE_INLINE_NAMESPACE      nssv_CPP11_140
+#define nssv_HAVE_NOEXCEPT              nssv_CPP11_140
+#define nssv_HAVE_NULLPTR               nssv_CPP11_100
+#define nssv_HAVE_REF_QUALIFIER         nssv_CPP11_140
+#define nssv_HAVE_UNICODE_LITERALS      nssv_CPP11_140
+#define nssv_HAVE_USER_DEFINED_LITERALS nssv_CPP11_140
+#define nssv_HAVE_WCHAR16_T             nssv_CPP11_100
+#define nssv_HAVE_WCHAR32_T             nssv_CPP11_100
+
+#if ! ( ( nssv_CPP11 && nssv_COMPILER_CLANG_VERSION ) || nssv_BETWEEN( nssv_COMPILER_CLANG_VERSION, 300, 400 ) )
+# define nssv_HAVE_STD_DEFINED_LITERALS  nssv_CPP11_140
+#endif
+
+// Presence of C++14 language features:
+
+#define nssv_HAVE_CONSTEXPR_14          nssv_CPP14_000
+
+// Presence of C++17 language features:
+
+#define nssv_HAVE_NODISCARD             nssv_CPP17_000
+
+// Presence of C++ library features:
+
+#define nssv_HAVE_STD_HASH              nssv_CPP11_120
+
+// C++ feature usage:
+
+#if nssv_HAVE_CONSTEXPR_11
+# define nssv_constexpr  constexpr
+#else
+# define nssv_constexpr  /*constexpr*/
+#endif
+
+#if  nssv_HAVE_CONSTEXPR_14
+# define nssv_constexpr14  constexpr
+#else
+# define nssv_constexpr14  /*constexpr*/
+#endif
+
+#if nssv_HAVE_EXPLICIT_CONVERSION
+# define nssv_explicit  explicit
+#else
+# define nssv_explicit  /*explicit*/
+#endif
+
+#if nssv_HAVE_INLINE_NAMESPACE
+# define nssv_inline_ns  inline
+#else
+# define nssv_inline_ns  /*inline*/
+#endif
+
+#if nssv_HAVE_NOEXCEPT
+# define nssv_noexcept  noexcept
+#else
+# define nssv_noexcept  /*noexcept*/
+#endif
+
+//#if nssv_HAVE_REF_QUALIFIER
+//# define nssv_ref_qual  &
+//# define nssv_refref_qual  &&
+//#else
+//# define nssv_ref_qual  /*&*/
+//# define nssv_refref_qual  /*&&*/
+//#endif
+
+#if nssv_HAVE_NULLPTR
+# define nssv_nullptr  nullptr
+#else
+# define nssv_nullptr  NULL
+#endif
+
+#if nssv_HAVE_NODISCARD
+# define nssv_nodiscard  [[nodiscard]]
+#else
+# define nssv_nodiscard  /*[[nodiscard]]*/
+#endif
+
+// Additional includes:
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <limits>
+#include <ostream>
+#include <string>   // std::char_traits<>
+
+#if ! nssv_CONFIG_NO_EXCEPTIONS
+# include <stdexcept>
+#endif
+
+#if nssv_CPP11_OR_GREATER
+# include <type_traits>
+#endif
+
+// Clang, GNUC, MSVC warning suppression macros:
+
+#if defined(__clang__)
+# pragma clang diagnostic ignored "-Wreserved-user-defined-literal"
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wuser-defined-literals"
+#elif defined(__GNUC__)
+# pragma  GCC  diagnostic push
+# pragma  GCC  diagnostic ignored "-Wliteral-suffix"
+#endif // __clang__
+
+#if nssv_COMPILER_MSVC_VERSION >= 140
+# define nssv_SUPPRESS_MSGSL_WARNING(expr)        [[gsl::suppress(expr)]]
+# define nssv_SUPPRESS_MSVC_WARNING(code, descr)  __pragma(warning(suppress: code) )
+# define nssv_DISABLE_MSVC_WARNINGS(codes)        __pragma(warning(push))  __pragma(warning(disable: codes))
+#else
+# define nssv_SUPPRESS_MSGSL_WARNING(expr)
+# define nssv_SUPPRESS_MSVC_WARNING(code, descr)
+# define nssv_DISABLE_MSVC_WARNINGS(codes)
+#endif
+
+#if defined(__clang__)
+# define nssv_RESTORE_WARNINGS()  _Pragma("clang diagnostic pop")
+#elif defined(__GNUC__)
+# define nssv_RESTORE_WARNINGS()  _Pragma("GCC diagnostic pop")
+#elif nssv_COMPILER_MSVC_VERSION >= 140
+# define nssv_RESTORE_WARNINGS()  __pragma(warning(pop ))
+#else
+# define nssv_RESTORE_WARNINGS()
+#endif
+
+// Suppress the following MSVC (GSL) warnings:
+// - C4455, non-gsl   : 'operator ""sv': literal suffix identifiers that do not
+//                      start with an underscore are reserved
+// - C26472, gsl::t.1 : don't use a static_cast for arithmetic conversions;
+//                      use brace initialization, gsl::narrow_cast or gsl::narow
+// - C26481: gsl::b.1 : don't use pointer arithmetic. Use span instead
+
+nssv_DISABLE_MSVC_WARNINGS( 4455 26481 26472 )
+//nssv_DISABLE_CLANG_WARNINGS( "-Wuser-defined-literals" )
+//nssv_DISABLE_GNUC_WARNINGS( -Wliteral-suffix )
+
+namespace nonstd { namespace sv_lite {
+
+template
+<
+    class CharT,
+    class Traits = std::char_traits<CharT>
+>
+class basic_string_view;
+
+//
+// basic_string_view:
+//
+
+template
+<
+    class CharT,
+    class Traits /* = std::char_traits<CharT> */
+>
+class basic_string_view
+{
+public:
+    // Member types:
+
+    typedef Traits traits_type;
+    typedef CharT  value_type;
+
+    typedef CharT       * pointer;
+    typedef CharT const * const_pointer;
+    typedef CharT       & reference;
+    typedef CharT const & const_reference;
+
+    typedef const_pointer iterator;
+    typedef const_pointer const_iterator;
+    typedef std::reverse_iterator< const_iterator > reverse_iterator;
+    typedef	std::reverse_iterator< const_iterator > const_reverse_iterator;
+
+    typedef std::size_t     size_type;
+    typedef std::ptrdiff_t  difference_type;
+
+    // 24.4.2.1 Construction and assignment:
+
+    nssv_constexpr basic_string_view() nssv_noexcept
+        : data_( nssv_nullptr )
+        , size_( 0 )
+    {}
+
+#if nssv_CPP11_OR_GREATER
+    nssv_constexpr basic_string_view( basic_string_view const & other ) nssv_noexcept = default;
+#else
+    nssv_constexpr basic_string_view( basic_string_view const & other ) nssv_noexcept
+        : data_( other.data_)
+        , size_( other.size_)
+    {}
+#endif
+
+    nssv_constexpr basic_string_view( CharT const * s, size_type count )
+        : data_( s )
+        , size_( count )
+    {}
+
+    nssv_constexpr basic_string_view( CharT const * s)
+        : data_( s )
+        , size_( Traits::length(s) )
+    {}
+
+    // Assignment:
+
+#if nssv_CPP11_OR_GREATER
+    nssv_constexpr14 basic_string_view & operator=( basic_string_view const & other ) nssv_noexcept = default;
+#else
+    nssv_constexpr14 basic_string_view & operator=( basic_string_view const & other ) nssv_noexcept
+    {
+        data_ = other.data_;
+        size_ = other.size_;
+        return *this;
+    }
+#endif
+
+    // 24.4.2.2 Iterator support:
+
+    nssv_constexpr const_iterator begin()  const nssv_noexcept { return data_;         }
+    nssv_constexpr const_iterator end()    const nssv_noexcept { return data_ + size_; }
+
+    nssv_constexpr const_iterator cbegin() const nssv_noexcept { return begin(); }
+    nssv_constexpr const_iterator cend()   const nssv_noexcept { return end();   }
+
+    nssv_constexpr const_reverse_iterator rbegin()  const nssv_noexcept { return const_reverse_iterator( end() );   }
+    nssv_constexpr const_reverse_iterator rend()    const nssv_noexcept { return const_reverse_iterator( begin() ); }
+
+    nssv_constexpr const_reverse_iterator crbegin() const nssv_noexcept { return rbegin(); }
+    nssv_constexpr const_reverse_iterator crend()   const nssv_noexcept { return rend();   }
+
+    // 24.4.2.3 Capacity:
+
+    nssv_constexpr size_type size()     const nssv_noexcept { return size_; }
+    nssv_constexpr size_type length()   const nssv_noexcept { return size_; }
+    nssv_constexpr size_type max_size() const nssv_noexcept { return (std::numeric_limits< size_type >::max)(); }
+
+    // since C++20
+    nssv_nodiscard nssv_constexpr bool empty() const nssv_noexcept
+    {
+        return 0 == size_;
+    }
+
+    // 24.4.2.4 Element access:
+
+    nssv_constexpr const_reference operator[]( size_type pos ) const
+    {
+        return data_at( pos );
+    }
+
+    nssv_constexpr14 const_reference at( size_type pos ) const
+    {
+#if nssv_CONFIG_NO_EXCEPTIONS
+        assert( pos < size() );
+#else
+        if ( pos >= size() )
+        {
+            throw std::out_of_range("nonst::string_view::at()");
+        }
+#endif
+        return data_at( pos );
+    }
+
+    nssv_constexpr const_reference front() const { return data_at( 0 );          }
+    nssv_constexpr const_reference back()  const { return data_at( size() - 1 ); }
+
+    nssv_constexpr const_pointer   data()  const nssv_noexcept { return data_; }
+
+    // 24.4.2.5 Modifiers:
+
+    nssv_constexpr14 void remove_prefix( size_type n )
+    {
+        assert( n <= size() );
+        data_ += n;
+        size_ -= n;
+    }
+
+    nssv_constexpr14 void remove_suffix( size_type n )
+    {
+        assert( n <= size() );
+        size_ -= n;
+    }
+
+    nssv_constexpr14 void swap( basic_string_view & other ) nssv_noexcept
+    {
+        using std::swap;
+        swap( data_, other.data_ );
+        swap( size_, other.size_ );
+    }
+
+    // 24.4.2.6 String operations:
+
+    size_type copy( CharT * dest, size_type n, size_type pos = 0 ) const
+    {
+#if nssv_CONFIG_NO_EXCEPTIONS
+        assert( pos <= size() );
+#else
+        if ( pos > size() )
+        {
+            throw std::out_of_range("nonst::string_view::copy()");
+        }
+#endif
+        const size_type rlen = (std::min)( n, size() - pos );
+
+        (void) Traits::copy( dest, data() + pos, rlen );
+
+        return rlen;
+    }
+
+    nssv_constexpr14 basic_string_view substr( size_type pos = 0, size_type n = npos ) const
+    {
+#if nssv_CONFIG_NO_EXCEPTIONS
+        assert( pos <= size() );
+#else
+        if ( pos > size() )
+        {
+            throw std::out_of_range("nonst::string_view::substr()");
+        }
+#endif
+        return basic_string_view( data() + pos, (std::min)( n, size() - pos ) );
+    }
+
+    // compare(), 6x:
+
+    nssv_constexpr14 int compare( basic_string_view other ) const nssv_noexcept // (1)
+    {
+        if ( const int result = Traits::compare( data(), other.data(), (std::min)( size(), other.size() ) ) )
+            return result;
+
+        return size() == other.size() ? 0 : size() < other.size() ? -1 : 1;
+    }
+
+    nssv_constexpr int compare( size_type pos1, size_type n1, basic_string_view other ) const // (2)
+    {
+        return substr( pos1, n1 ).compare( other );
+    }
+
+    nssv_constexpr int compare( size_type pos1, size_type n1, basic_string_view other, size_type pos2, size_type n2 ) const // (3)
+    {
+        return substr( pos1, n1 ).compare( other.substr( pos2, n2 ) );
+    }
+
+    nssv_constexpr int compare( CharT const * s ) const // (4)
+    {
+        return compare( basic_string_view( s ) );
+    }
+
+    nssv_constexpr int compare( size_type pos1, size_type n1, CharT const * s ) const // (5)
+    {
+        return substr( pos1, n1 ).compare( basic_string_view( s ) );
+    }
+
+    nssv_constexpr int compare( size_type pos1, size_type n1, CharT const * s, size_type n2 ) const // (6)
+    {
+        return substr( pos1, n1 ).compare( basic_string_view( s, n2 ) );
+    }
+
+    // 24.4.2.7 Searching:
+
+    // starts_with(), 3x, since C++20:
+
+    nssv_constexpr bool starts_with( basic_string_view v ) const nssv_noexcept  // (1)
+    {
+        return size() >= v.size() && compare( 0, v.size(), v ) == 0;
+    }
+
+    nssv_constexpr bool starts_with( CharT c ) const nssv_noexcept  // (2)
+    {
+        return starts_with( basic_string_view( &c, 1 ) );
+    }
+
+    nssv_constexpr bool starts_with( CharT const * s ) const  // (3)
+    {
+        return starts_with( basic_string_view( s ) );
+    }
+
+    // ends_with(), 3x, since C++20:
+
+    nssv_constexpr bool ends_with( basic_string_view v ) const nssv_noexcept  // (1)
+    {
+        return size() >= v.size() && compare( size() - v.size(), npos, v ) == 0;
+    }
+
+    nssv_constexpr bool ends_with( CharT c ) const nssv_noexcept  // (2)
+    {
+        return ends_with( basic_string_view( &c, 1 ) );
+    }
+
+    nssv_constexpr bool ends_with( CharT const * s ) const  // (3)
+    {
+        return ends_with( basic_string_view( s ) );
+    }
+
+    // find(), 4x:
+
+    nssv_constexpr14 size_type find( basic_string_view v, size_type pos = 0 ) const nssv_noexcept  // (1)
+    {
+        return assert( v.size() == 0 || v.data() != nssv_nullptr )
+            , pos >= size()
+            ? npos
+            : to_pos( std::search( cbegin() + pos, cend(), v.cbegin(), v.cend(), Traits::eq ) );
+    }
+
+    nssv_constexpr14 size_type find( CharT c, size_type pos = 0 ) const nssv_noexcept  // (2)
+    {
+        return find( basic_string_view( &c, 1 ), pos );
+    }
+
+    nssv_constexpr14 size_type find( CharT const * s, size_type pos, size_type n ) const  // (3)
+    {
+        return find( basic_string_view( s, n ), pos );
+    }
+
+    nssv_constexpr14 size_type find( CharT const * s, size_type pos = 0 ) const  // (4)
+    {
+        return find( basic_string_view( s ), pos );
+    }
+
+    // rfind(), 4x:
+
+    nssv_constexpr14 size_type rfind( basic_string_view v, size_type pos = npos ) const nssv_noexcept  // (1)
+    {
+        if ( size() < v.size() )
+            return npos;
+
+        if ( v.empty() )
+            return (std::min)( size(), pos );
+
+        const_iterator last   = cbegin() + (std::min)( size() - v.size(), pos ) + v.size();
+        const_iterator result = std::find_end( cbegin(), last, v.cbegin(), v.cend(), Traits::eq );
+
+        return result != last ? size_type( result - cbegin() ) : npos;
+    }
+
+    nssv_constexpr14 size_type rfind( CharT c, size_type pos = npos ) const nssv_noexcept  // (2)
+    {
+        return rfind( basic_string_view( &c, 1 ), pos );
+    }
+
+    nssv_constexpr14 size_type rfind( CharT const * s, size_type pos, size_type n ) const  // (3)
+    {
+        return rfind( basic_string_view( s, n ), pos );
+    }
+
+    nssv_constexpr14 size_type rfind( CharT const * s, size_type pos = npos ) const  // (4)
+    {
+        return rfind( basic_string_view( s ), pos );
+    }
+
+    // find_first_of(), 4x:
+
+    nssv_constexpr size_type find_first_of( basic_string_view v, size_type pos = 0 ) const nssv_noexcept  // (1)
+    {
+        return pos >= size()
+            ? npos
+            : to_pos( std::find_first_of( cbegin() + pos, cend(), v.cbegin(), v.cend(), Traits::eq ) );
+    }
+
+    nssv_constexpr size_type find_first_of( CharT c, size_type pos = 0 ) const nssv_noexcept  // (2)
+    {
+        return find_first_of( basic_string_view( &c, 1 ), pos );
+    }
+
+    nssv_constexpr size_type find_first_of( CharT const * s, size_type pos, size_type n ) const  // (3)
+    {
+        return find_first_of( basic_string_view( s, n ), pos );
+    }
+
+    nssv_constexpr size_type find_first_of(  CharT const * s, size_type pos = 0 ) const  // (4)
+    {
+        return find_first_of( basic_string_view( s ), pos );
+    }
+
+    // find_last_of(), 4x:
+
+    nssv_constexpr size_type find_last_of( basic_string_view v, size_type pos = npos ) const nssv_noexcept  // (1)
+    {
+        return empty()
+            ? npos
+            : pos >= size()
+            ? find_last_of( v, size() - 1 )
+            : to_pos( std::find_first_of( const_reverse_iterator( cbegin() + pos + 1 ), crend(), v.cbegin(), v.cend(), Traits::eq ) );
+    }
+
+    nssv_constexpr size_type find_last_of( CharT c, size_type pos = npos ) const nssv_noexcept  // (2)
+    {
+        return find_last_of( basic_string_view( &c, 1 ), pos );
+    }
+
+    nssv_constexpr size_type find_last_of( CharT const * s, size_type pos, size_type count ) const  // (3)
+    {
+        return find_last_of( basic_string_view( s, count ), pos );
+    }
+
+    nssv_constexpr size_type find_last_of( CharT const * s, size_type pos = npos ) const  // (4)
+    {
+        return find_last_of( basic_string_view( s ), pos );
+    }
+
+    // find_first_not_of(), 4x:
+
+    nssv_constexpr size_type find_first_not_of( basic_string_view v, size_type pos = 0 ) const nssv_noexcept  // (1)
+    {
+        return pos >= size()
+            ? npos
+            : to_pos( std::find_if( cbegin() + pos, cend(), not_in_view( v ) ) );
+    }
+
+    nssv_constexpr size_type find_first_not_of( CharT c, size_type pos = 0 ) const nssv_noexcept  // (2)
+    {
+        return find_first_not_of( basic_string_view( &c, 1 ), pos );
+    }
+
+    nssv_constexpr size_type find_first_not_of( CharT const * s, size_type pos, size_type count ) const  // (3)
+    {
+        return find_first_not_of( basic_string_view( s, count ), pos );
+    }
+
+    nssv_constexpr size_type find_first_not_of( CharT const * s, size_type pos = 0 ) const  // (4)
+    {
+        return find_first_not_of( basic_string_view( s ), pos );
+    }
+
+    // find_last_not_of(), 4x:
+
+    nssv_constexpr size_type find_last_not_of( basic_string_view v, size_type pos = npos ) const nssv_noexcept  // (1)
+    {
+        return empty()
+            ? npos
+            : pos >= size()
+            ? find_last_not_of( v, size() - 1 )
+            : to_pos( std::find_if( const_reverse_iterator( cbegin() + pos + 1 ), crend(), not_in_view( v ) ) );
+    }
+
+    nssv_constexpr size_type find_last_not_of( CharT c, size_type pos = npos ) const nssv_noexcept  // (2)
+    {
+        return find_last_not_of( basic_string_view( &c, 1 ), pos );
+    }
+
+    nssv_constexpr size_type find_last_not_of( CharT const * s, size_type pos, size_type count ) const  // (3)
+    {
+        return find_last_not_of( basic_string_view( s, count ), pos );
+    }
+
+    nssv_constexpr size_type find_last_not_of( CharT const * s, size_type pos = npos ) const  // (4)
+    {
+        return find_last_not_of( basic_string_view( s ), pos );
+    }
+
+    // Constants:
+
+#if nssv_CPP17_OR_GREATER
+    static nssv_constexpr size_type npos = size_type(-1);
+#elif nssv_CPP11_OR_GREATER
+    enum : size_type { npos = size_type(-1) };
+#else
+    enum { npos = size_type(-1) };
+#endif
+
+private:
+    struct not_in_view
+    {
+        const basic_string_view v;
+
+        nssv_constexpr not_in_view( basic_string_view v ) : v( v ) {}
+
+        nssv_constexpr bool operator()( CharT c ) const
+        {
+            return npos == v.find_first_of( c );
+        }
+    };
+
+    nssv_constexpr size_type to_pos( const_iterator it ) const
+    {
+        return it == cend() ? npos : size_type( it - cbegin() );
+    }
+
+    nssv_constexpr size_type to_pos( const_reverse_iterator it ) const
+    {
+        return it == crend() ? npos : size_type( crend() - it - 1 );
+    }
+
+    nssv_constexpr const_reference data_at( size_type pos ) const
+    {
+#if nssv_BETWEEN( nssv_COMPILER_GNUC_VERSION, 1, 500 )
+        return data_[pos];
+#else
+        return assert( pos < size() ), data_[pos];
+#endif
+    }
+
+private:
+    const_pointer data_;
+    size_type     size_;
+
+public:
+#if nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS
+
+    template< class Allocator >
+    basic_string_view( std::basic_string<CharT, Traits, Allocator> const & s ) nssv_noexcept
+        : data_( s.data() )
+        , size_( s.size() )
+    {}
+
+#if nssv_HAVE_EXPLICIT_CONVERSION
+
+    template< class Allocator >
+    explicit operator std::basic_string<CharT, Traits, Allocator>() const
+    {
+        return to_string( Allocator() );
+    }
+
+#endif // nssv_HAVE_EXPLICIT_CONVERSION
+
+#if nssv_CPP11_OR_GREATER
+
+    template< class Allocator = std::allocator<CharT> >
+    std::basic_string<CharT, Traits, Allocator>
+    to_string( Allocator const & a = Allocator() ) const
+    {
+        return std::basic_string<CharT, Traits, Allocator>( begin(), end(), a );
+    }
+
+#else
+
+    std::basic_string<CharT, Traits>
+    to_string() const
+    {
+        return std::basic_string<CharT, Traits>( begin(), end() );
+    }
+
+    template< class Allocator >
+    std::basic_string<CharT, Traits, Allocator>
+    to_string( Allocator const & a ) const
+    {
+        return std::basic_string<CharT, Traits, Allocator>( begin(), end(), a );
+    }
+
+#endif // nssv_CPP11_OR_GREATER
+
+#endif // nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS
+};
+
+//
+// Non-member functions:
+//
+
+// 24.4.3 Non-member comparison functions:
+// lexicographically compare two string views (function template):
+
+template< class CharT, class Traits >
+nssv_constexpr bool operator== (
+    basic_string_view <CharT, Traits> lhs,
+    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) == 0 ; }
+
+template< class CharT, class Traits >
+nssv_constexpr bool operator!= (
+    basic_string_view <CharT, Traits> lhs,
+    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) != 0 ; }
+
+template< class CharT, class Traits >
+nssv_constexpr bool operator< (
+    basic_string_view <CharT, Traits> lhs,
+    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) < 0 ; }
+
+template< class CharT, class Traits >
+nssv_constexpr bool operator<= (
+    basic_string_view <CharT, Traits> lhs,
+    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) <= 0 ; }
+
+template< class CharT, class Traits >
+nssv_constexpr bool operator> (
+    basic_string_view <CharT, Traits> lhs,
+    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) > 0 ; }
+
+template< class CharT, class Traits >
+nssv_constexpr bool operator>= (
+    basic_string_view <CharT, Traits> lhs,
+    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) >= 0 ; }
+
+// Let S be basic_string_view<CharT, Traits>, and sv be an instance of S.
+// Implementations shall provide sufficient additional overloads marked
+// constexpr and noexcept so that an object t with an implicit conversion
+// to S can be compared according to Table 67.
+
+#if nssv_CPP11_OR_GREATER && ! nssv_BETWEEN( nssv_COMPILER_MSVC_VERSION, 100, 141 )
+
+#define nssv_BASIC_STRING_VIEW_I(T,U)  typename std::decay< basic_string_view<T,U> >::type
+
+#if nssv_BETWEEN( nssv_COMPILER_MSVC_VERSION, 140, 150 )
+# define nssv_MSVC_ORDER(x)  , int=x
+#else
+# define nssv_MSVC_ORDER(x)  /*, int=x*/
+#endif
+
+// ==
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
+nssv_constexpr bool operator==(
+         basic_string_view  <CharT, Traits> lhs,
+    nssv_BASIC_STRING_VIEW_I(CharT, Traits) rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) == 0; }
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
+nssv_constexpr bool operator==(
+    nssv_BASIC_STRING_VIEW_I(CharT, Traits) lhs,
+         basic_string_view  <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.size() == rhs.size() && lhs.compare( rhs ) == 0; }
+
+// !=
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
+nssv_constexpr bool operator!= (
+         basic_string_view  < CharT, Traits > lhs,
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
+{ return lhs.size() != rhs.size() || lhs.compare( rhs ) != 0 ; }
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
+nssv_constexpr bool operator!= (
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
+         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) != 0 ; }
+
+// <
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
+nssv_constexpr bool operator< (
+         basic_string_view  < CharT, Traits > lhs,
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) < 0 ; }
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
+nssv_constexpr bool operator< (
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
+         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) < 0 ; }
+
+// <=
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
+nssv_constexpr bool operator<= (
+         basic_string_view  < CharT, Traits > lhs,
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) <= 0 ; }
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
+nssv_constexpr bool operator<= (
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
+         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) <= 0 ; }
+
+// >
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
+nssv_constexpr bool operator> (
+         basic_string_view  < CharT, Traits > lhs,
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) > 0 ; }
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
+nssv_constexpr bool operator> (
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
+         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) > 0 ; }
+
+// >=
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
+nssv_constexpr bool operator>= (
+         basic_string_view  < CharT, Traits > lhs,
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) >= 0 ; }
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
+nssv_constexpr bool operator>= (
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
+         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) >= 0 ; }
+
+#undef nssv_MSVC_ORDER
+#undef nssv_BASIC_STRING_VIEW_I
+
+#endif // nssv_CPP11_OR_GREATER
+
+// 24.4.4 Inserters and extractors:
+
+namespace detail {
+
+template< class Stream >
+void write_padding( Stream & os, std::streamsize n )
+{
+    for ( std::streamsize i = 0; i < n; ++i )
+        os.rdbuf()->sputc( os.fill() );
+}
+
+template< class Stream, class View >
+Stream & write_to_stream( Stream & os, View const & sv )
+{
+    typename Stream::sentry sentry( os );
+
+    if ( !os )
+        return os;
+
+    const std::streamsize length = static_cast<std::streamsize>( sv.length() );
+
+    // Whether, and how, to pad:
+    const bool      pad = ( length < os.width() );
+    const bool left_pad = pad && ( os.flags() & std::ios_base::adjustfield ) == std::ios_base::right;
+
+    if ( left_pad )
+        write_padding( os, os.width() - length );
+
+    // Write span characters:
+    os.rdbuf()->sputn( sv.begin(), length );
+
+    if ( pad && !left_pad )
+        write_padding( os, os.width() - length );
+
+    // Reset output stream width:
+    os.width( 0 );
+
+    return os;
+}
+
+} // namespace detail
+
+template< class CharT, class Traits >
+std::basic_ostream<CharT, Traits> &
+operator<<(
+    std::basic_ostream<CharT, Traits>& os,
+    basic_string_view <CharT, Traits> sv )
+{
+    return detail::write_to_stream( os, sv );
+}
+
+// Several typedefs for common character types are provided:
+
+typedef basic_string_view<char>      string_view;
+typedef basic_string_view<wchar_t>   wstring_view;
+#if nssv_HAVE_WCHAR16_T
+typedef basic_string_view<char16_t>  u16string_view;
+typedef basic_string_view<char32_t>  u32string_view;
+#endif
+
+}} // namespace nonstd::sv_lite
+
+//
+// 24.4.6 Suffix for basic_string_view literals:
+//
+
+#if nssv_HAVE_USER_DEFINED_LITERALS
+
+namespace nonstd {
+nssv_inline_ns namespace literals {
+nssv_inline_ns namespace string_view_literals {
+
+#if nssv_CONFIG_STD_SV_OPERATOR && nssv_HAVE_STD_DEFINED_LITERALS
+
+nssv_constexpr nonstd::sv_lite::string_view operator "" sv( const char* str, size_t len ) nssv_noexcept  // (1)
+{
+    return nonstd::sv_lite::string_view{ str, len };
+}
+
+nssv_constexpr nonstd::sv_lite::u16string_view operator "" sv( const char16_t* str, size_t len ) nssv_noexcept  // (2)
+{
+    return nonstd::sv_lite::u16string_view{ str, len };
+}
+
+nssv_constexpr nonstd::sv_lite::u32string_view operator "" sv( const char32_t* str, size_t len ) nssv_noexcept  // (3)
+{
+    return nonstd::sv_lite::u32string_view{ str, len };
+}
+
+nssv_constexpr nonstd::sv_lite::wstring_view operator "" sv( const wchar_t* str, size_t len ) nssv_noexcept  // (4)
+{
+    return nonstd::sv_lite::wstring_view{ str, len };
+}
+
+#endif // nssv_CONFIG_STD_SV_OPERATOR && nssv_HAVE_STD_DEFINED_LITERALS
+
+#if nssv_CONFIG_USR_SV_OPERATOR
+
+nssv_constexpr nonstd::sv_lite::string_view operator "" _sv( const char* str, size_t len ) nssv_noexcept  // (1)
+{
+    return nonstd::sv_lite::string_view{ str, len };
+}
+
+nssv_constexpr nonstd::sv_lite::u16string_view operator "" _sv( const char16_t* str, size_t len ) nssv_noexcept  // (2)
+{
+    return nonstd::sv_lite::u16string_view{ str, len };
+}
+
+nssv_constexpr nonstd::sv_lite::u32string_view operator "" _sv( const char32_t* str, size_t len ) nssv_noexcept  // (3)
+{
+    return nonstd::sv_lite::u32string_view{ str, len };
+}
+
+nssv_constexpr nonstd::sv_lite::wstring_view operator "" _sv( const wchar_t* str, size_t len ) nssv_noexcept  // (4)
+{
+    return nonstd::sv_lite::wstring_view{ str, len };
+}
+
+#endif // nssv_CONFIG_USR_SV_OPERATOR
+
+}}} // namespace nonstd::literals::string_view_literals
+
+#endif
+
+//
+// Extensions for std::string:
+//
+
+#if nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+
+namespace nonstd {
+namespace sv_lite {
+
+// Exclude MSVC 14 (19.00): it yields ambiguous to_string():
+
+#if nssv_CPP11_OR_GREATER && nssv_COMPILER_MSVC_VERSION != 140
+
+template< class CharT, class Traits, class Allocator = std::allocator<CharT> >
+std::basic_string<CharT, Traits, Allocator>
+to_string( basic_string_view<CharT, Traits> v, Allocator const & a = Allocator() )
+{
+    return std::basic_string<CharT,Traits, Allocator>( v.begin(), v.end(), a );
+}
+
+#else
+
+template< class CharT, class Traits >
+std::basic_string<CharT, Traits>
+to_string( basic_string_view<CharT, Traits> v )
+{
+    return std::basic_string<CharT, Traits>( v.begin(), v.end() );
+}
+
+template< class CharT, class Traits, class Allocator >
+std::basic_string<CharT, Traits, Allocator>
+to_string( basic_string_view<CharT, Traits> v, Allocator const & a )
+{
+    return std::basic_string<CharT, Traits, Allocator>( v.begin(), v.end(), a );
+}
+
+#endif // nssv_CPP11_OR_GREATER
+
+template< class CharT, class Traits, class Allocator >
+basic_string_view<CharT, Traits>
+to_string_view( std::basic_string<CharT, Traits, Allocator> const & s )
+{
+    return basic_string_view<CharT, Traits>( s.data(), s.size() );
+}
+
+}} // namespace nonstd::sv_lite
+
+#endif // nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+
+//
+// make types and algorithms available in namespace nonstd:
+//
+
+namespace nonstd {
+
+using sv_lite::basic_string_view;
+using sv_lite::string_view;
+using sv_lite::wstring_view;
+
+#if nssv_HAVE_WCHAR16_T
+using sv_lite::u16string_view;
+#endif
+#if nssv_HAVE_WCHAR32_T
+using sv_lite::u32string_view;
+#endif
+
+// literal "sv"
+
+using sv_lite::operator==;
+using sv_lite::operator!=;
+using sv_lite::operator<;
+using sv_lite::operator<=;
+using sv_lite::operator>;
+using sv_lite::operator>=;
+
+using sv_lite::operator<<;
+
+#if nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+using sv_lite::to_string;
+using sv_lite::to_string_view;
+#endif
+
+} // namespace nonstd
+
+// 24.4.5 Hash support (C++11):
+
+// Note: The hash value of a string view object is equal to the hash value of
+// the corresponding string object.
+
+#if nssv_HAVE_STD_HASH
+
+#include <functional>
+
+namespace std {
+
+template<>
+struct hash< nonstd::string_view >
+{
+public:
+    std::size_t operator()( nonstd::string_view v ) const nssv_noexcept
+    {
+        return std::hash<std::string>()( std::string( v.data(), v.size() ) );
+    }
+};
+
+template<>
+struct hash< nonstd::wstring_view >
+{
+public:
+    std::size_t operator()( nonstd::wstring_view v ) const nssv_noexcept
+    {
+        return std::hash<std::wstring>()( std::wstring( v.data(), v.size() ) );
+    }
+};
+
+template<>
+struct hash< nonstd::u16string_view >
+{
+public:
+    std::size_t operator()( nonstd::u16string_view v ) const nssv_noexcept
+    {
+        return std::hash<std::u16string>()( std::u16string( v.data(), v.size() ) );
+    }
+};
+
+template<>
+struct hash< nonstd::u32string_view >
+{
+public:
+    std::size_t operator()( nonstd::u32string_view v ) const nssv_noexcept
+    {
+        return std::hash<std::u32string>()( std::u32string( v.data(), v.size() ) );
+    }
+};
+
+} // namespace std
+
+#endif // nssv_HAVE_STD_HASH
+
+nssv_RESTORE_WARNINGS()
+
+#endif // nssv_HAVE_STD_STRING_VIEW
+#endif // NONSTD_SV_LITE_H_INCLUDED
+
+
+  // If there is another version of Hedley, then the newer one 
+  // takes precedence.
+  // See: https://github.com/nemequ/hedley
+/* Hedley - https://nemequ.github.io/hedley
+ * Created by Evan Nemerson <evan@nemerson.com>
+ *
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this software to
+ * the public domain worldwide. This software is distributed without
+ * any warranty.
+ *
+ * For details, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#if !defined(HEDLEY_VERSION) || (HEDLEY_VERSION < 9)
+#if defined(HEDLEY_VERSION)
+#  undef HEDLEY_VERSION
+#endif
+#define HEDLEY_VERSION 9
+
+#if defined(HEDLEY_STRINGIFY_EX)
+#  undef HEDLEY_STRINGIFY_EX
+#endif
+#define HEDLEY_STRINGIFY_EX(x) #x
+
+#if defined(HEDLEY_STRINGIFY)
+#  undef HEDLEY_STRINGIFY
+#endif
+#define HEDLEY_STRINGIFY(x) HEDLEY_STRINGIFY_EX(x)
+
+#if defined(HEDLEY_CONCAT_EX)
+#  undef HEDLEY_CONCAT_EX
+#endif
+#define HEDLEY_CONCAT_EX(a,b) a##b
+
+#if defined(HEDLEY_CONCAT)
+#  undef HEDLEY_CONCAT
+#endif
+#define HEDLEY_CONCAT(a,b) HEDLEY_CONCAT_EX(a,b)
+
+#if defined(HEDLEY_VERSION_ENCODE)
+#  undef HEDLEY_VERSION_ENCODE
+#endif
+#define HEDLEY_VERSION_ENCODE(major,minor,revision) (((major) * 1000000) + ((minor) * 1000) + (revision))
+
+#if defined(HEDLEY_VERSION_DECODE_MAJOR)
+#  undef HEDLEY_VERSION_DECODE_MAJOR
+#endif
+#define HEDLEY_VERSION_DECODE_MAJOR(version) ((version) / 1000000)
+
+#if defined(HEDLEY_VERSION_DECODE_MINOR)
+#  undef HEDLEY_VERSION_DECODE_MINOR
+#endif
+#define HEDLEY_VERSION_DECODE_MINOR(version) (((version) % 1000000) / 1000)
+
+#if defined(HEDLEY_VERSION_DECODE_REVISION)
+#  undef HEDLEY_VERSION_DECODE_REVISION
+#endif
+#define HEDLEY_VERSION_DECODE_REVISION(version) ((version) % 1000)
+
+#if defined(HEDLEY_GNUC_VERSION)
+#  undef HEDLEY_GNUC_VERSION
+#endif
+#if defined(__GNUC__) && defined(__GNUC_PATCHLEVEL__)
+#  define HEDLEY_GNUC_VERSION HEDLEY_VERSION_ENCODE(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+#elif defined(__GNUC__)
+#  define HEDLEY_GNUC_VERSION HEDLEY_VERSION_ENCODE(__GNUC__, __GNUC_MINOR__, 0)
+#endif
+
+#if defined(HEDLEY_GNUC_VERSION_CHECK)
+#  undef HEDLEY_GNUC_VERSION_CHECK
+#endif
+#if defined(HEDLEY_GNUC_VERSION)
+#  define HEDLEY_GNUC_VERSION_CHECK(major,minor,patch) (HEDLEY_GNUC_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_GNUC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_MSVC_VERSION)
+#  undef HEDLEY_MSVC_VERSION
+#endif
+#if defined(_MSC_FULL_VER) && (_MSC_FULL_VER >= 140000000)
+#  define HEDLEY_MSVC_VERSION HEDLEY_VERSION_ENCODE(_MSC_FULL_VER / 10000000, (_MSC_FULL_VER % 10000000) / 100000, (_MSC_FULL_VER % 100000) / 100)
+#elif defined(_MSC_FULL_VER)
+#  define HEDLEY_MSVC_VERSION HEDLEY_VERSION_ENCODE(_MSC_FULL_VER / 1000000, (_MSC_FULL_VER % 1000000) / 10000, (_MSC_FULL_VER % 10000) / 10)
+#elif defined(_MSC_VER)
+#  define HEDLEY_MSVC_VERSION HEDLEY_VERSION_ENCODE(_MSC_VER / 100, _MSC_VER % 100, 0)
+#endif
+
+#if defined(HEDLEY_MSVC_VERSION_CHECK)
+#  undef HEDLEY_MSVC_VERSION_CHECK
+#endif
+#if !defined(_MSC_VER)
+#  define HEDLEY_MSVC_VERSION_CHECK(major,minor,patch) (0)
+#elif defined(_MSC_VER) && (_MSC_VER >= 1400)
+#  define HEDLEY_MSVC_VERSION_CHECK(major,minor,patch) (_MSC_FULL_VER >= ((major * 10000000) + (minor * 100000) + (patch)))
+#elif defined(_MSC_VER) && (_MSC_VER >= 1200)
+#  define HEDLEY_MSVC_VERSION_CHECK(major,minor,patch) (_MSC_FULL_VER >= ((major * 1000000) + (minor * 10000) + (patch)))
+#else
+#  define HEDLEY_MSVC_VERSION_CHECK(major,minor,patch) (_MSC_VER >= ((major * 100) + (minor)))
+#endif
+
+#if defined(HEDLEY_INTEL_VERSION)
+#  undef HEDLEY_INTEL_VERSION
+#endif
+#if defined(__INTEL_COMPILER) && defined(__INTEL_COMPILER_UPDATE)
+#  define HEDLEY_INTEL_VERSION HEDLEY_VERSION_ENCODE(__INTEL_COMPILER / 100, __INTEL_COMPILER % 100, __INTEL_COMPILER_UPDATE)
+#elif defined(__INTEL_COMPILER)
+#  define HEDLEY_INTEL_VERSION HEDLEY_VERSION_ENCODE(__INTEL_COMPILER / 100, __INTEL_COMPILER % 100, 0)
+#endif
+
+#if defined(HEDLEY_INTEL_VERSION_CHECK)
+#  undef HEDLEY_INTEL_VERSION_CHECK
+#endif
+#if defined(HEDLEY_INTEL_VERSION)
+#  define HEDLEY_INTEL_VERSION_CHECK(major,minor,patch) (HEDLEY_INTEL_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_INTEL_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_PGI_VERSION)
+#  undef HEDLEY_PGI_VERSION
+#endif
+#if defined(__PGI) && defined(__PGIC__) && defined(__PGIC_MINOR__) && defined(__PGIC_PATCHLEVEL__)
+#  define HEDLEY_PGI_VERSION HEDLEY_VERSION_ENCODE(__PGIC__, __PGIC_MINOR__, __PGIC_PATCHLEVEL__)
+#endif
+
+#if defined(HEDLEY_PGI_VERSION_CHECK)
+#  undef HEDLEY_PGI_VERSION_CHECK
+#endif
+#if defined(HEDLEY_PGI_VERSION)
+#  define HEDLEY_PGI_VERSION_CHECK(major,minor,patch) (HEDLEY_PGI_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_PGI_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_SUNPRO_VERSION)
+#  undef HEDLEY_SUNPRO_VERSION
+#endif
+#if defined(__SUNPRO_C) && (__SUNPRO_C > 0x1000)
+#  define HEDLEY_SUNPRO_VERSION HEDLEY_VERSION_ENCODE((((__SUNPRO_C >> 16) & 0xf) * 10) + ((__SUNPRO_C >> 12) & 0xf), (((__SUNPRO_C >> 8) & 0xf) * 10) + ((__SUNPRO_C >> 4) & 0xf), (__SUNPRO_C & 0xf) * 10)
+#elif defined(__SUNPRO_C)
+#  define HEDLEY_SUNPRO_VERSION HEDLEY_VERSION_ENCODE((__SUNPRO_C >> 8) & 0xf, (__SUNPRO_C >> 4) & 0xf, (__SUNPRO_C) & 0xf)
+#elif defined(__SUNPRO_CC) && (__SUNPRO_CC > 0x1000)
+#  define HEDLEY_SUNPRO_VERSION HEDLEY_VERSION_ENCODE((((__SUNPRO_CC >> 16) & 0xf) * 10) + ((__SUNPRO_CC >> 12) & 0xf), (((__SUNPRO_CC >> 8) & 0xf) * 10) + ((__SUNPRO_CC >> 4) & 0xf), (__SUNPRO_CC & 0xf) * 10)
+#elif defined(__SUNPRO_CC)
+#  define HEDLEY_SUNPRO_VERSION HEDLEY_VERSION_ENCODE((__SUNPRO_CC >> 8) & 0xf, (__SUNPRO_CC >> 4) & 0xf, (__SUNPRO_CC) & 0xf)
+#endif
+
+#if defined(HEDLEY_SUNPRO_VERSION_CHECK)
+#  undef HEDLEY_SUNPRO_VERSION_CHECK
+#endif
+#if defined(HEDLEY_SUNPRO_VERSION)
+#  define HEDLEY_SUNPRO_VERSION_CHECK(major,minor,patch) (HEDLEY_SUNPRO_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_SUNPRO_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_EMSCRIPTEN_VERSION)
+#  undef HEDLEY_EMSCRIPTEN_VERSION
+#endif
+#if defined(__EMSCRIPTEN__)
+#  define HEDLEY_EMSCRIPTEN_VERSION HEDLEY_VERSION_ENCODE(__EMSCRIPTEN_major__, __EMSCRIPTEN_minor__, __EMSCRIPTEN_tiny__)
+#endif
+
+#if defined(HEDLEY_EMSCRIPTEN_VERSION_CHECK)
+#  undef HEDLEY_EMSCRIPTEN_VERSION_CHECK
+#endif
+#if defined(HEDLEY_EMSCRIPTEN_VERSION)
+#  define HEDLEY_EMSCRIPTEN_VERSION_CHECK(major,minor,patch) (HEDLEY_EMSCRIPTEN_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_EMSCRIPTEN_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_ARM_VERSION)
+#  undef HEDLEY_ARM_VERSION
+#endif
+#if defined(__CC_ARM) && defined(__ARMCOMPILER_VERSION)
+#  define HEDLEY_ARM_VERSION HEDLEY_VERSION_ENCODE(__ARMCOMPILER_VERSION / 1000000, (__ARMCOMPILER_VERSION % 1000000) / 10000, (__ARMCOMPILER_VERSION % 10000) / 100)
+#elif defined(__CC_ARM) && defined(__ARMCC_VERSION)
+#  define HEDLEY_ARM_VERSION HEDLEY_VERSION_ENCODE(__ARMCC_VERSION / 1000000, (__ARMCC_VERSION % 1000000) / 10000, (__ARMCC_VERSION % 10000) / 100)
+#endif
+
+#if defined(HEDLEY_ARM_VERSION_CHECK)
+#  undef HEDLEY_ARM_VERSION_CHECK
+#endif
+#if defined(HEDLEY_ARM_VERSION)
+#  define HEDLEY_ARM_VERSION_CHECK(major,minor,patch) (HEDLEY_ARM_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_ARM_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_IBM_VERSION)
+#  undef HEDLEY_IBM_VERSION
+#endif
+#if defined(__ibmxl__)
+#  define HEDLEY_IBM_VERSION HEDLEY_VERSION_ENCODE(__ibmxl_version__, __ibmxl_release__, __ibmxl_modification__)
+#elif defined(__xlC__) && defined(__xlC_ver__)
+#  define HEDLEY_IBM_VERSION HEDLEY_VERSION_ENCODE(__xlC__ >> 8, __xlC__ & 0xff, (__xlC_ver__ >> 8) & 0xff)
+#elif defined(__xlC__)
+#  define HEDLEY_IBM_VERSION HEDLEY_VERSION_ENCODE(__xlC__ >> 8, __xlC__ & 0xff, 0)
+#endif
+
+#if defined(HEDLEY_IBM_VERSION_CHECK)
+#  undef HEDLEY_IBM_VERSION_CHECK
+#endif
+#if defined(HEDLEY_IBM_VERSION)
+#  define HEDLEY_IBM_VERSION_CHECK(major,minor,patch) (HEDLEY_IBM_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_IBM_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_TI_VERSION)
+#  undef HEDLEY_TI_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__)
+#  define HEDLEY_TI_VERSION HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(HEDLEY_TI_VERSION_CHECK)
+#  undef HEDLEY_TI_VERSION_CHECK
+#endif
+#if defined(HEDLEY_TI_VERSION)
+#  define HEDLEY_TI_VERSION_CHECK(major,minor,patch) (HEDLEY_TI_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_TI_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_CRAY_VERSION)
+#  undef HEDLEY_CRAY_VERSION
+#endif
+#if defined(_CRAYC)
+#  if defined(_RELEASE_PATCHLEVEL)
+#    define HEDLEY_CRAY_VERSION HEDLEY_VERSION_ENCODE(_RELEASE_MAJOR, _RELEASE_MINOR, _RELEASE_PATCHLEVEL)
+#  else
+#    define HEDLEY_CRAY_VERSION HEDLEY_VERSION_ENCODE(_RELEASE_MAJOR, _RELEASE_MINOR, 0)
+#  endif
+#endif
+
+#if defined(HEDLEY_CRAY_VERSION_CHECK)
+#  undef HEDLEY_CRAY_VERSION_CHECK
+#endif
+#if defined(HEDLEY_CRAY_VERSION)
+#  define HEDLEY_CRAY_VERSION_CHECK(major,minor,patch) (HEDLEY_CRAY_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_CRAY_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_IAR_VERSION)
+#  undef HEDLEY_IAR_VERSION
+#endif
+#if defined(__IAR_SYSTEMS_ICC__)
+#  if __VER__ > 1000
+#    define HEDLEY_IAR_VERSION HEDLEY_VERSION_ENCODE((__VER__ / 1000000), ((__VER__ / 1000) % 1000), (__VER__ % 1000))
+#  else
+#    define HEDLEY_IAR_VERSION HEDLEY_VERSION_ENCODE(VER / 100, __VER__ % 100, 0)
+#  endif
+#endif
+
+#if defined(HEDLEY_IAR_VERSION_CHECK)
+#  undef HEDLEY_IAR_VERSION_CHECK
+#endif
+#if defined(HEDLEY_IAR_VERSION)
+#  define HEDLEY_IAR_VERSION_CHECK(major,minor,patch) (HEDLEY_IAR_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_IAR_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_TINYC_VERSION)
+#  undef HEDLEY_TINYC_VERSION
+#endif
+#if defined(__TINYC__)
+#  define HEDLEY_TINYC_VERSION HEDLEY_VERSION_ENCODE(__TINYC__ / 1000, (__TINYC__ / 100) % 10, __TINYC__ % 100)
+#endif
+
+#if defined(HEDLEY_TINYC_VERSION_CHECK)
+#  undef HEDLEY_TINYC_VERSION_CHECK
+#endif
+#if defined(HEDLEY_TINYC_VERSION)
+#  define HEDLEY_TINYC_VERSION_CHECK(major,minor,patch) (HEDLEY_TINYC_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_TINYC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_DMC_VERSION)
+#  undef HEDLEY_DMC_VERSION
+#endif
+#if defined(__DMC__)
+#  define HEDLEY_DMC_VERSION HEDLEY_VERSION_ENCODE(__DMC__ >> 8, (__DMC__ >> 4) & 0xf, __DMC__ & 0xf)
+#endif
+
+#if defined(HEDLEY_DMC_VERSION_CHECK)
+#  undef HEDLEY_DMC_VERSION_CHECK
+#endif
+#if defined(HEDLEY_DMC_VERSION)
+#  define HEDLEY_DMC_VERSION_CHECK(major,minor,patch) (HEDLEY_DMC_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_DMC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_COMPCERT_VERSION)
+#  undef HEDLEY_COMPCERT_VERSION
+#endif
+#if defined(__COMPCERT_VERSION__)
+#  define HEDLEY_COMPCERT_VERSION HEDLEY_VERSION_ENCODE(__COMPCERT_VERSION__ / 10000, (__COMPCERT_VERSION__ / 100) % 100, __COMPCERT_VERSION__ % 100)
+#endif
+
+#if defined(HEDLEY_COMPCERT_VERSION_CHECK)
+#  undef HEDLEY_COMPCERT_VERSION_CHECK
+#endif
+#if defined(HEDLEY_COMPCERT_VERSION)
+#  define HEDLEY_COMPCERT_VERSION_CHECK(major,minor,patch) (HEDLEY_COMPCERT_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_COMPCERT_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_PELLES_VERSION)
+#  undef HEDLEY_PELLES_VERSION
+#endif
+#if defined(__POCC__)
+#  define HEDLEY_PELLES_VERSION HEDLEY_VERSION_ENCODE(__POCC__ / 100, __POCC__ % 100, 0)
+#endif
+
+#if defined(HEDLEY_PELLES_VERSION_CHECK)
+#  undef HEDLEY_PELLES_VERSION_CHECK
+#endif
+#if defined(HEDLEY_PELLES_VERSION)
+#  define HEDLEY_PELLES_VERSION_CHECK(major,minor,patch) (HEDLEY_PELLES_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_PELLES_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_GCC_VERSION)
+#  undef HEDLEY_GCC_VERSION
+#endif
+#if \
+  defined(HEDLEY_GNUC_VERSION) && \
+  !defined(__clang__) && \
+  !defined(HEDLEY_INTEL_VERSION) && \
+  !defined(HEDLEY_PGI_VERSION) && \
+  !defined(HEDLEY_ARM_VERSION) && \
+  !defined(HEDLEY_TI_VERSION) && \
+  !defined(__COMPCERT__)
+#  define HEDLEY_GCC_VERSION HEDLEY_GNUC_VERSION
+#endif
+
+#if defined(HEDLEY_GCC_VERSION_CHECK)
+#  undef HEDLEY_GCC_VERSION_CHECK
+#endif
+#if defined(HEDLEY_GCC_VERSION)
+#  define HEDLEY_GCC_VERSION_CHECK(major,minor,patch) (HEDLEY_GCC_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_GCC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_HAS_ATTRIBUTE)
+#  undef HEDLEY_HAS_ATTRIBUTE
+#endif
+#if defined(__has_attribute)
+#  define HEDLEY_HAS_ATTRIBUTE(attribute) __has_attribute(attribute)
+#else
+#  define HEDLEY_HAS_ATTRIBUTE(attribute) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_ATTRIBUTE)
+#  undef HEDLEY_GNUC_HAS_ATTRIBUTE
+#endif
+#if defined(__has_attribute)
+#  define HEDLEY_GNUC_HAS_ATTRIBUTE(attribute,major,minor,patch) __has_attribute(attribute)
+#else
+#  define HEDLEY_GNUC_HAS_ATTRIBUTE(attribute,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_ATTRIBUTE)
+#  undef HEDLEY_GCC_HAS_ATTRIBUTE
+#endif
+#if defined(__has_attribute)
+#  define HEDLEY_GCC_HAS_ATTRIBUTE(attribute,major,minor,patch) __has_attribute(attribute)
+#else
+#  define HEDLEY_GCC_HAS_ATTRIBUTE(attribute,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_HAS_CPP_ATTRIBUTE)
+#  undef HEDLEY_HAS_CPP_ATTRIBUTE
+#endif
+#if defined(__has_cpp_attribute) && defined(__cplusplus)
+#  define HEDLEY_HAS_CPP_ATTRIBUTE(attribute) __has_cpp_attribute(attribute)
+#else
+#  define HEDLEY_HAS_CPP_ATTRIBUTE(attribute) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_CPP_ATTRIBUTE)
+#  undef HEDLEY_GNUC_HAS_CPP_ATTRIBUTE
+#endif
+#if defined(__has_cpp_attribute) && defined(__cplusplus)
+#  define HEDLEY_GNUC_HAS_CPP_ATTRIBUTE(attribute,major,minor,patch) __has_cpp_attribute(attribute)
+#else
+#  define HEDLEY_GNUC_HAS_CPP_ATTRIBUTE(attribute,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_CPP_ATTRIBUTE)
+#  undef HEDLEY_GCC_HAS_CPP_ATTRIBUTE
+#endif
+#if defined(__has_cpp_attribute) && defined(__cplusplus)
+#  define HEDLEY_GCC_HAS_CPP_ATTRIBUTE(attribute,major,minor,patch) __has_cpp_attribute(attribute)
+#else
+#  define HEDLEY_GCC_HAS_CPP_ATTRIBUTE(attribute,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_HAS_BUILTIN)
+#  undef HEDLEY_HAS_BUILTIN
+#endif
+#if defined(__has_builtin)
+#  define HEDLEY_HAS_BUILTIN(builtin) __has_builtin(builtin)
+#else
+#  define HEDLEY_HAS_BUILTIN(builtin) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_BUILTIN)
+#  undef HEDLEY_GNUC_HAS_BUILTIN
+#endif
+#if defined(__has_builtin)
+#  define HEDLEY_GNUC_HAS_BUILTIN(builtin,major,minor,patch) __has_builtin(builtin)
+#else
+#  define HEDLEY_GNUC_HAS_BUILTIN(builtin,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_BUILTIN)
+#  undef HEDLEY_GCC_HAS_BUILTIN
+#endif
+#if defined(__has_builtin)
+#  define HEDLEY_GCC_HAS_BUILTIN(builtin,major,minor,patch) __has_builtin(builtin)
+#else
+#  define HEDLEY_GCC_HAS_BUILTIN(builtin,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_HAS_FEATURE)
+#  undef HEDLEY_HAS_FEATURE
+#endif
+#if defined(__has_feature)
+#  define HEDLEY_HAS_FEATURE(feature) __has_feature(feature)
+#else
+#  define HEDLEY_HAS_FEATURE(feature) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_FEATURE)
+#  undef HEDLEY_GNUC_HAS_FEATURE
+#endif
+#if defined(__has_feature)
+#  define HEDLEY_GNUC_HAS_FEATURE(feature,major,minor,patch) __has_feature(feature)
+#else
+#  define HEDLEY_GNUC_HAS_FEATURE(feature,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_FEATURE)
+#  undef HEDLEY_GCC_HAS_FEATURE
+#endif
+#if defined(__has_feature)
+#  define HEDLEY_GCC_HAS_FEATURE(feature,major,minor,patch) __has_feature(feature)
+#else
+#  define HEDLEY_GCC_HAS_FEATURE(feature,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_HAS_EXTENSION)
+#  undef HEDLEY_HAS_EXTENSION
+#endif
+#if defined(__has_extension)
+#  define HEDLEY_HAS_EXTENSION(extension) __has_extension(extension)
+#else
+#  define HEDLEY_HAS_EXTENSION(extension) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_EXTENSION)
+#  undef HEDLEY_GNUC_HAS_EXTENSION
+#endif
+#if defined(__has_extension)
+#  define HEDLEY_GNUC_HAS_EXTENSION(extension,major,minor,patch) __has_extension(extension)
+#else
+#  define HEDLEY_GNUC_HAS_EXTENSION(extension,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_EXTENSION)
+#  undef HEDLEY_GCC_HAS_EXTENSION
+#endif
+#if defined(__has_extension)
+#  define HEDLEY_GCC_HAS_EXTENSION(extension,major,minor,patch) __has_extension(extension)
+#else
+#  define HEDLEY_GCC_HAS_EXTENSION(extension,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_HAS_DECLSPEC_ATTRIBUTE)
+#  undef HEDLEY_HAS_DECLSPEC_ATTRIBUTE
+#endif
+#if defined(__has_declspec_attribute)
+#  define HEDLEY_HAS_DECLSPEC_ATTRIBUTE(attribute) __has_declspec_attribute(attribute)
+#else
+#  define HEDLEY_HAS_DECLSPEC_ATTRIBUTE(attribute) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE)
+#  undef HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE
+#endif
+#if defined(__has_declspec_attribute)
+#  define HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE(attribute,major,minor,patch) __has_declspec_attribute(attribute)
+#else
+#  define HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE(attribute,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE)
+#  undef HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE
+#endif
+#if defined(__has_declspec_attribute)
+#  define HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE(attribute,major,minor,patch) __has_declspec_attribute(attribute)
+#else
+#  define HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE(attribute,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_HAS_WARNING)
+#  undef HEDLEY_HAS_WARNING
+#endif
+#if defined(__has_warning)
+#  define HEDLEY_HAS_WARNING(warning) __has_warning(warning)
+#else
+#  define HEDLEY_HAS_WARNING(warning) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_WARNING)
+#  undef HEDLEY_GNUC_HAS_WARNING
+#endif
+#if defined(__has_warning)
+#  define HEDLEY_GNUC_HAS_WARNING(warning,major,minor,patch) __has_warning(warning)
+#else
+#  define HEDLEY_GNUC_HAS_WARNING(warning,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_WARNING)
+#  undef HEDLEY_GCC_HAS_WARNING
+#endif
+#if defined(__has_warning)
+#  define HEDLEY_GCC_HAS_WARNING(warning,major,minor,patch) __has_warning(warning)
+#else
+#  define HEDLEY_GCC_HAS_WARNING(warning,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if \
+  (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)) || \
+  defined(__clang__) || \
+  HEDLEY_GCC_VERSION_CHECK(3,0,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_IAR_VERSION_CHECK(8,0,0) || \
+  HEDLEY_PGI_VERSION_CHECK(18,4,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(6,0,0) || \
+  HEDLEY_CRAY_VERSION_CHECK(5,0,0) || \
+  HEDLEY_TINYC_VERSION_CHECK(0,9,17) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(8,0,0) || \
+  (HEDLEY_IBM_VERSION_CHECK(10,1,0) && defined(__C99_PRAGMA_OPERATOR))
+#  define HEDLEY_PRAGMA(value) _Pragma(#value)
+#elif HEDLEY_MSVC_VERSION_CHECK(15,0,0)
+#  define HEDLEY_PRAGMA(value) __pragma(value)
+#else
+#  define HEDLEY_PRAGMA(value)
+#endif
+
+#if defined(HEDLEY_DIAGNOSTIC_PUSH)
+#  undef HEDLEY_DIAGNOSTIC_PUSH
+#endif
+#if defined(HEDLEY_DIAGNOSTIC_POP)
+#  undef HEDLEY_DIAGNOSTIC_POP
+#endif
+#if defined(__clang__)
+#  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("clang diagnostic push")
+#  define HEDLEY_DIAGNOSTIC_POP _Pragma("clang diagnostic pop")
+#elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("warning(push)")
+#  define HEDLEY_DIAGNOSTIC_POP _Pragma("warning(pop)")
+#elif HEDLEY_GCC_VERSION_CHECK(4,6,0)
+#  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("GCC diagnostic push")
+#  define HEDLEY_DIAGNOSTIC_POP _Pragma("GCC diagnostic pop")
+#elif HEDLEY_MSVC_VERSION_CHECK(15,0,0)
+#  define HEDLEY_DIAGNOSTIC_PUSH __pragma(warning(push))
+#  define HEDLEY_DIAGNOSTIC_POP __pragma(warning(pop))
+#elif HEDLEY_ARM_VERSION_CHECK(5,6,0)
+#  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("push")
+#  define HEDLEY_DIAGNOSTIC_POP _Pragma("pop")
+#elif HEDLEY_TI_VERSION_CHECK(8,1,0)
+#  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("diag_push")
+#  define HEDLEY_DIAGNOSTIC_POP _Pragma("diag_pop")
+#elif HEDLEY_PELLES_VERSION_CHECK(2,90,0)
+#  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("warning(push)")
+#  define HEDLEY_DIAGNOSTIC_POP _Pragma("warning(pop)")
+#else
+#  define HEDLEY_DIAGNOSTIC_PUSH
+#  define HEDLEY_DIAGNOSTIC_POP
+#endif
+
+#if defined(HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED)
+#  undef HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED
+#endif
+#if HEDLEY_HAS_WARNING("-Wdeprecated-declarations")
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("warning(disable:1478 1786)")
+#elif HEDLEY_PGI_VERSION_CHECK(17,10,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress 1215,1444")
+#elif HEDLEY_GCC_VERSION_CHECK(4,3,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif HEDLEY_MSVC_VERSION_CHECK(15,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED __pragma(warning(disable:4996))
+#elif HEDLEY_TI_VERSION_CHECK(8,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress 1291,1718")
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,13,0) && !defined(__cplusplus)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("error_messages(off,E_DEPRECATED_ATT,E_DEPRECATED_ATT_MESS)")
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,13,0) && defined(__cplusplus)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("error_messages(off,symdeprecated,symdeprecated2)")
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress=Pe1444,Pe1215")
+#elif HEDLEY_PELLES_VERSION_CHECK(2,90,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("warn(disable:2241)")
+#else
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED
+#endif
+
+#if defined(HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS)
+#  undef HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS
+#endif
+#if HEDLEY_HAS_WARNING("-Wunknown-pragmas")
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("clang diagnostic ignored \"-Wunknown-pragmas\"")
+#elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("warning(disable:161)")
+#elif HEDLEY_PGI_VERSION_CHECK(17,10,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress 1675")
+#elif HEDLEY_GCC_VERSION_CHECK(4,3,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")
+#elif HEDLEY_MSVC_VERSION_CHECK(15,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS __pragma(warning(disable:4068))
+#elif HEDLEY_TI_VERSION_CHECK(8,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress 163")
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress=Pe161")
+#else
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS
+#endif
+
+#if defined(HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL)
+#  undef HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL
+#endif
+#if HEDLEY_HAS_WARNING("-Wcast-qual")
+#  define HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL _Pragma("clang diagnostic ignored \"-Wcast-qual\"")
+#elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL _Pragma("warning(disable:2203 2331)")
+#elif HEDLEY_GCC_VERSION_CHECK(3,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL _Pragma("GCC diagnostic ignored \"-Wcast-qual\"")
+#else
+#  define HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL
+#endif
+
+#if defined(HEDLEY_DEPRECATED)
+#  undef HEDLEY_DEPRECATED
+#endif
+#if defined(HEDLEY_DEPRECATED_FOR)
+#  undef HEDLEY_DEPRECATED_FOR
+#endif
+#if defined(__cplusplus) && (__cplusplus >= 201402L)
+#  define HEDLEY_DEPRECATED(since) [[deprecated("Since " #since)]]
+#  define HEDLEY_DEPRECATED_FOR(since, replacement) [[deprecated("Since " #since "; use " #replacement)]]
+#elif \
+  HEDLEY_HAS_EXTENSION(attribute_deprecated_with_message) || \
+  HEDLEY_GCC_VERSION_CHECK(4,5,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_ARM_VERSION_CHECK(5,6,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,13,0) || \
+  HEDLEY_PGI_VERSION_CHECK(17,10,0) || \
+  HEDLEY_TI_VERSION_CHECK(8,3,0)
+#  define HEDLEY_DEPRECATED(since) __attribute__((__deprecated__("Since " #since)))
+#  define HEDLEY_DEPRECATED_FOR(since, replacement) __attribute__((__deprecated__("Since " #since "; use " #replacement)))
+#elif \
+  HEDLEY_HAS_ATTRIBUTE(deprecated) || \
+  HEDLEY_GCC_VERSION_CHECK(3,1,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(8,0,0) || \
+  (HEDLEY_TI_VERSION_CHECK(7,3,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__))
+#  define HEDLEY_DEPRECATED(since) __attribute__((__deprecated__))
+#  define HEDLEY_DEPRECATED_FOR(since, replacement) __attribute__((__deprecated__))
+#elif HEDLEY_MSVC_VERSION_CHECK(14,0,0)
+#  define HEDLEY_DEPRECATED(since) __declspec(deprecated("Since " # since))
+#  define HEDLEY_DEPRECATED_FOR(since, replacement) __declspec(deprecated("Since " #since "; use " #replacement))
+#elif \
+  HEDLEY_MSVC_VERSION_CHECK(13,10,0) || \
+  HEDLEY_PELLES_VERSION_CHECK(6,50,0)
+#  define HEDLEY_DEPRECATED(since) _declspec(deprecated)
+#  define HEDLEY_DEPRECATED_FOR(since, replacement) __declspec(deprecated)
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_DEPRECATED(since) _Pragma("deprecated")
+#  define HEDLEY_DEPRECATED_FOR(since, replacement) _Pragma("deprecated")
+#else
+#  define HEDLEY_DEPRECATED(since)
+#  define HEDLEY_DEPRECATED_FOR(since, replacement)
+#endif
+
+#if defined(HEDLEY_UNAVAILABLE)
+#  undef HEDLEY_UNAVAILABLE
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(warning) || \
+  HEDLEY_GCC_VERSION_CHECK(4,3,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_UNAVAILABLE(available_since) __attribute__((__warning__("Not available until " #available_since)))
+#else
+#  define HEDLEY_UNAVAILABLE(available_since)
+#endif
+
+#if defined(HEDLEY_WARN_UNUSED_RESULT)
+#  undef HEDLEY_WARN_UNUSED_RESULT
+#endif
+#if defined(__cplusplus) && (__cplusplus >= 201703L)
+#  define HEDLEY_WARN_UNUSED_RESULT [[nodiscard]]
+#elif \
+  HEDLEY_HAS_ATTRIBUTE(warn_unused_result) || \
+  HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_TI_VERSION_CHECK(8,0,0) || \
+  (HEDLEY_TI_VERSION_CHECK(7,3,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  (HEDLEY_SUNPRO_VERSION_CHECK(5,15,0) && defined(__cplusplus)) || \
+  HEDLEY_PGI_VERSION_CHECK(17,10,0)
+#  define HEDLEY_WARN_UNUSED_RESULT __attribute__((__warn_unused_result__))
+#elif defined(_Check_return_) /* SAL */
+#  define HEDLEY_WARN_UNUSED_RESULT _Check_return_
+#else
+#  define HEDLEY_WARN_UNUSED_RESULT
+#endif
+
+#if defined(HEDLEY_SENTINEL)
+#  undef HEDLEY_SENTINEL
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(sentinel) || \
+  HEDLEY_GCC_VERSION_CHECK(4,0,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_ARM_VERSION_CHECK(5,4,0)
+#  define HEDLEY_SENTINEL(position) __attribute__((__sentinel__(position)))
+#else
+#  define HEDLEY_SENTINEL(position)
+#endif
+
+#if defined(HEDLEY_NO_RETURN)
+#  undef HEDLEY_NO_RETURN
+#endif
+#if HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_NO_RETURN __noreturn
+#elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_NO_RETURN __attribute__((__noreturn__))
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#  define HEDLEY_NO_RETURN _Noreturn
+#elif defined(__cplusplus) && (__cplusplus >= 201103L)
+#  define HEDLEY_NO_RETURN [[noreturn]]
+#elif \
+  HEDLEY_HAS_ATTRIBUTE(noreturn) || \
+  HEDLEY_GCC_VERSION_CHECK(3,2,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(18,0,0) || \
+  (HEDLEY_TI_VERSION_CHECK(17,3,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__))
+#  define HEDLEY_NO_RETURN __attribute__((__noreturn__))
+#elif HEDLEY_MSVC_VERSION_CHECK(13,10,0)
+#  define HEDLEY_NO_RETURN __declspec(noreturn)
+#elif HEDLEY_TI_VERSION_CHECK(6,0,0) && defined(__cplusplus)
+#  define HEDLEY_NO_RETURN _Pragma("FUNC_NEVER_RETURNS;")
+#elif HEDLEY_COMPCERT_VERSION_CHECK(3,2,0)
+#  define HEDLEY_NO_RETURN __attribute((noreturn))
+#elif HEDLEY_PELLES_VERSION_CHECK(9,0,0)
+#  define HEDLEY_NO_RETURN __declspec(noreturn)
+#else
+#  define HEDLEY_NO_RETURN
+#endif
+
+#if defined(HEDLEY_UNREACHABLE)
+#  undef HEDLEY_UNREACHABLE
+#endif
+#if defined(HEDLEY_UNREACHABLE_RETURN)
+#  undef HEDLEY_UNREACHABLE_RETURN
+#endif
+#if \
+  (HEDLEY_HAS_BUILTIN(__builtin_unreachable) && (!defined(HEDLEY_ARM_VERSION))) || \
+  HEDLEY_GCC_VERSION_CHECK(4,5,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_IBM_VERSION_CHECK(13,1,5)
+#  define HEDLEY_UNREACHABLE() __builtin_unreachable()
+#elif HEDLEY_MSVC_VERSION_CHECK(13,10,0)
+#  define HEDLEY_UNREACHABLE() __assume(0)
+#elif HEDLEY_TI_VERSION_CHECK(6,0,0)
+#  if defined(__cplusplus)
+#    define HEDLEY_UNREACHABLE() std::_nassert(0)
+#  else
+#    define HEDLEY_UNREACHABLE() _nassert(0)
+#  endif
+#  define HEDLEY_UNREACHABLE_RETURN(value) return value
+#elif defined(EXIT_FAILURE)
+#  define HEDLEY_UNREACHABLE() abort()
+#else
+#  define HEDLEY_UNREACHABLE()
+#  define HEDLEY_UNREACHABLE_RETURN(value) return value
+#endif
+#if !defined(HEDLEY_UNREACHABLE_RETURN)
+#  define HEDLEY_UNREACHABLE_RETURN(value) HEDLEY_UNREACHABLE()
+#endif
+
+#if defined(HEDLEY_ASSUME)
+#  undef HEDLEY_ASSUME
+#endif
+#if \
+  HEDLEY_MSVC_VERSION_CHECK(13,10,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_ASSUME(expr) __assume(expr)
+#elif HEDLEY_HAS_BUILTIN(__builtin_assume)
+#  define HEDLEY_ASSUME(expr) __builtin_assume(expr)
+#elif HEDLEY_TI_VERSION_CHECK(6,0,0)
+#  if defined(__cplusplus)
+#    define HEDLEY_ASSUME(expr) std::_nassert(expr)
+#  else
+#    define HEDLEY_ASSUME(expr) _nassert(expr)
+#  endif
+#elif \
+  (HEDLEY_HAS_BUILTIN(__builtin_unreachable) && !defined(HEDLEY_ARM_VERSION)) || \
+  HEDLEY_GCC_VERSION_CHECK(4,5,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_IBM_VERSION_CHECK(13,1,5)
+#  define HEDLEY_ASSUME(expr) ((void) ((expr) ? 1 : (__builtin_unreachable(), 1)))
+#else
+#  define HEDLEY_ASSUME(expr) ((void) (expr))
+#endif
+
+
+HEDLEY_DIAGNOSTIC_PUSH
+#if \
+  HEDLEY_HAS_WARNING("-Wvariadic-macros") || \
+  HEDLEY_GCC_VERSION_CHECK(4,0,0)
+#  if defined(__clang__)
+#    pragma clang diagnostic ignored "-Wvariadic-macros"
+#  elif defined(HEDLEY_GCC_VERSION)
+#    pragma GCC diagnostic ignored "-Wvariadic-macros"
+#  endif
+#endif
+#if defined(HEDLEY_NON_NULL)
+#  undef HEDLEY_NON_NULL
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(nonnull) || \
+  HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0)
+#  define HEDLEY_NON_NULL(...) __attribute__((__nonnull__(__VA_ARGS__)))
+#else
+#  define HEDLEY_NON_NULL(...)
+#endif
+HEDLEY_DIAGNOSTIC_POP
+
+#if defined(HEDLEY_PRINTF_FORMAT)
+#  undef HEDLEY_PRINTF_FORMAT
+#endif
+#if defined(__MINGW32__) && HEDLEY_GCC_HAS_ATTRIBUTE(format,4,4,0) && !defined(__USE_MINGW_ANSI_STDIO)
+#  define HEDLEY_PRINTF_FORMAT(string_idx,first_to_check) __attribute__((__format__(ms_printf, string_idx, first_to_check)))
+#elif defined(__MINGW32__) && HEDLEY_GCC_HAS_ATTRIBUTE(format,4,4,0) && defined(__USE_MINGW_ANSI_STDIO)
+#  define HEDLEY_PRINTF_FORMAT(string_idx,first_to_check) __attribute__((__format__(gnu_printf, string_idx, first_to_check)))
+#elif \
+  HEDLEY_HAS_ATTRIBUTE(format) || \
+  HEDLEY_GCC_VERSION_CHECK(3,1,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_ARM_VERSION_CHECK(5,6,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(8,0,0) || \
+  (HEDLEY_TI_VERSION_CHECK(7,3,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__))
+#  define HEDLEY_PRINTF_FORMAT(string_idx,first_to_check) __attribute__((__format__(__printf__, string_idx, first_to_check)))
+#elif HEDLEY_PELLES_VERSION_CHECK(6,0,0)
+#  define HEDLEY_PRINTF_FORMAT(string_idx,first_to_check) __declspec(vaformat(printf,string_idx,first_to_check))
+#else
+#  define HEDLEY_PRINTF_FORMAT(string_idx,first_to_check)
+#endif
+
+#if defined(HEDLEY_CONSTEXPR)
+#  undef HEDLEY_CONSTEXPR
+#endif
+#if defined(__cplusplus)
+#  if __cplusplus >= 201103L
+#    define HEDLEY_CONSTEXPR constexpr
+#  endif
+#endif
+#if !defined(HEDLEY_CONSTEXPR)
+#  define HEDLEY_CONSTEXPR
+#endif
+
+#if defined(HEDLEY_PREDICT)
+#  undef HEDLEY_PREDICT
+#endif
+#if defined(HEDLEY_LIKELY)
+#  undef HEDLEY_LIKELY
+#endif
+#if defined(HEDLEY_UNLIKELY)
+#  undef HEDLEY_UNLIKELY
+#endif
+#if defined(HEDLEY_UNPREDICTABLE)
+#  undef HEDLEY_UNPREDICTABLE
+#endif
+#if HEDLEY_HAS_BUILTIN(__builtin_unpredictable)
+#  define HEDLEY_UNPREDICTABLE(expr) __builtin_unpredictable(!!(expr))
+#endif
+#if \
+  HEDLEY_HAS_BUILTIN(__builtin_expect_with_probability) || \
+  HEDLEY_GCC_VERSION_CHECK(9,0,0)
+#  define HEDLEY_PREDICT(expr, value, probability) __builtin_expect_with_probability(expr, value, probability)
+#  define HEDLEY_PREDICT_TRUE(expr, probability) __builtin_expect_with_probability(!!(expr), 1, probability)
+#  define HEDLEY_PREDICT_FALSE(expr, probability) __builtin_expect_with_probability(!!(expr), 0, probability)
+#  define HEDLEY_LIKELY(expr) __builtin_expect(!!(expr), 1)
+#  define HEDLEY_UNLIKELY(expr) __builtin_expect(!!(expr), 0)
+#  if !defined(HEDLEY_BUILTIN_UNPREDICTABLE)
+#    define HEDLEY_BUILTIN_UNPREDICTABLE(expr) __builtin_expect_with_probability(!!(expr), 1, 0.5)
+#  endif
+#elif \
+  HEDLEY_HAS_BUILTIN(__builtin_expect) || \
+  HEDLEY_GCC_VERSION_CHECK(3,0,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  (HEDLEY_SUNPRO_VERSION_CHECK(5,15,0) && defined(__cplusplus)) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(6,1,0) || \
+  HEDLEY_TINYC_VERSION_CHECK(0,9,27)
+#  define HEDLEY_PREDICT(expr, expected, probability) \
+  (((probability) >= 0.9) ? __builtin_expect(!!(expr), (expected)) : (((void) (expected)), !!(expr)))
+#  define HEDLEY_PREDICT_TRUE(expr, probability) \
+     (__extension__ ({ \
+       HEDLEY_CONSTEXPR double hedley_probability_ = (probability); \
+       ((hedley_probability_ >= 0.9) ? __builtin_expect(!!(expr), 1) : ((hedley_probability_ <= 0.1) ? __builtin_expect(!!(expr), 0) : !!(expr))); \
+     }))
+#  define HEDLEY_PREDICT_FALSE(expr, probability) \
+     (__extension__ ({ \
+       HEDLEY_CONSTEXPR double hedley_probability_ = (probability); \
+       ((hedley_probability_ >= 0.9) ? __builtin_expect(!!(expr), 0) : ((hedley_probability_ <= 0.1) ? __builtin_expect(!!(expr), 1) : !!(expr))); \
+     }))
+#  define HEDLEY_LIKELY(expr)   __builtin_expect(!!(expr), 1)
+#  define HEDLEY_UNLIKELY(expr) __builtin_expect(!!(expr), 0)
+#else
+#  define HEDLEY_PREDICT(expr, expected, probability) (((void) (expected)), !!(expr))
+#  define HEDLEY_PREDICT_TRUE(expr, probability) (!!(expr))
+#  define HEDLEY_PREDICT_FALSE(expr, probability) (!!(expr))
+#  define HEDLEY_LIKELY(expr) (!!(expr))
+#  define HEDLEY_UNLIKELY(expr) (!!(expr))
+#endif
+#if !defined(HEDLEY_UNPREDICTABLE)
+#  define HEDLEY_UNPREDICTABLE(expr) HEDLEY_PREDICT(expr, 1, 0.5)
+#endif
+
+#if defined(HEDLEY_MALLOC)
+#  undef HEDLEY_MALLOC
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(malloc) || \
+  HEDLEY_GCC_VERSION_CHECK(3,1,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(12,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(8,0,0) || \
+  (HEDLEY_TI_VERSION_CHECK(7,3,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__))
+#  define HEDLEY_MALLOC __attribute__((__malloc__))
+#elif HEDLEY_MSVC_VERSION_CHECK(14, 0, 0)
+#  define HEDLEY_MALLOC __declspec(restrict)
+#else
+#  define HEDLEY_MALLOC
+#endif
+
+#if defined(HEDLEY_PURE)
+#  undef HEDLEY_PURE
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(pure) || \
+  HEDLEY_GCC_VERSION_CHECK(2,96,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(8,0,0) || \
+  (HEDLEY_TI_VERSION_CHECK(7,3,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_PGI_VERSION_CHECK(17,10,0)
+#  define HEDLEY_PURE __attribute__((__pure__))
+#elif HEDLEY_TI_VERSION_CHECK(6,0,0) && defined(__cplusplus)
+#  define HEDLEY_PURE _Pragma("FUNC_IS_PURE;")
+#else
+#  define HEDLEY_PURE
+#endif
+
+#if defined(HEDLEY_CONST)
+#  undef HEDLEY_CONST
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(const) || \
+  HEDLEY_GCC_VERSION_CHECK(2,5,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(8,0,0) || \
+  (HEDLEY_TI_VERSION_CHECK(7,3,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_PGI_VERSION_CHECK(17,10,0)
+#  define HEDLEY_CONST __attribute__((__const__))
+#else
+#  define HEDLEY_CONST HEDLEY_PURE
+#endif
+
+#if defined(HEDLEY_RESTRICT)
+#  undef HEDLEY_RESTRICT
+#endif
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && !defined(__cplusplus)
+#  define HEDLEY_RESTRICT restrict
+#elif \
+  HEDLEY_GCC_VERSION_CHECK(3,1,0) || \
+  HEDLEY_MSVC_VERSION_CHECK(14,0,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_PGI_VERSION_CHECK(17,10,0) || \
+  HEDLEY_TI_VERSION_CHECK(8,0,0) || \
+  (HEDLEY_SUNPRO_VERSION_CHECK(5,14,0) && defined(__cplusplus)) || \
+  HEDLEY_IAR_VERSION_CHECK(8,0,0) || \
+  defined(__clang__)
+#  define HEDLEY_RESTRICT __restrict
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,3,0) && !defined(__cplusplus)
+#  define HEDLEY_RESTRICT _Restrict
+#else
+#  define HEDLEY_RESTRICT
+#endif
+
+#if defined(HEDLEY_INLINE)
+#  undef HEDLEY_INLINE
+#endif
+#if \
+  (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)) || \
+  (defined(__cplusplus) && (__cplusplus >= 199711L))
+#  define HEDLEY_INLINE inline
+#elif \
+  defined(HEDLEY_GCC_VERSION) || \
+  HEDLEY_ARM_VERSION_CHECK(6,2,0)
+#  define HEDLEY_INLINE __inline__
+#elif \
+  HEDLEY_MSVC_VERSION_CHECK(12,0,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(8,0,0)
+#  define HEDLEY_INLINE __inline
+#else
+#  define HEDLEY_INLINE
+#endif
+
+#if defined(HEDLEY_ALWAYS_INLINE)
+#  undef HEDLEY_ALWAYS_INLINE
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(always_inline) || \
+  HEDLEY_GCC_VERSION_CHECK(4,0,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(8,0,0) || \
+  (HEDLEY_TI_VERSION_CHECK(7,3,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__))
+#  define HEDLEY_ALWAYS_INLINE __attribute__((__always_inline__)) HEDLEY_INLINE
+#elif HEDLEY_MSVC_VERSION_CHECK(12,0,0)
+#  define HEDLEY_ALWAYS_INLINE __forceinline
+#elif HEDLEY_TI_VERSION_CHECK(7,0,0) && defined(__cplusplus)
+#  define HEDLEY_ALWAYS_INLINE _Pragma("FUNC_ALWAYS_INLINE;")
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_ALWAYS_INLINE _Pragma("inline=forced")
+#else
+#  define HEDLEY_ALWAYS_INLINE HEDLEY_INLINE
+#endif
+
+#if defined(HEDLEY_NEVER_INLINE)
+#  undef HEDLEY_NEVER_INLINE
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(noinline) || \
+  HEDLEY_GCC_VERSION_CHECK(4,0,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(8,0,0) || \
+  (HEDLEY_TI_VERSION_CHECK(7,3,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__))
+#  define HEDLEY_NEVER_INLINE __attribute__((__noinline__))
+#elif HEDLEY_MSVC_VERSION_CHECK(13,10,0)
+#  define HEDLEY_NEVER_INLINE __declspec(noinline)
+#elif HEDLEY_PGI_VERSION_CHECK(10,2,0)
+#  define HEDLEY_NEVER_INLINE _Pragma("noinline")
+#elif HEDLEY_TI_VERSION_CHECK(6,0,0) && defined(__cplusplus)
+#  define HEDLEY_NEVER_INLINE _Pragma("FUNC_CANNOT_INLINE;")
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_NEVER_INLINE _Pragma("inline=never")
+#elif HEDLEY_COMPCERT_VERSION_CHECK(3,2,0)
+#  define HEDLEY_NEVER_INLINE __attribute((noinline))
+#elif HEDLEY_PELLES_VERSION_CHECK(9,0,0)
+#  define HEDLEY_NEVER_INLINE __declspec(noinline)
+#else
+#  define HEDLEY_NEVER_INLINE
+#endif
+
+#if defined(HEDLEY_PRIVATE)
+#  undef HEDLEY_PRIVATE
+#endif
+#if defined(HEDLEY_PUBLIC)
+#  undef HEDLEY_PUBLIC
+#endif
+#if defined(HEDLEY_IMPORT)
+#  undef HEDLEY_IMPORT
+#endif
+#if defined(_WIN32) || defined(__CYGWIN__)
+#  define HEDLEY_PRIVATE
+#  define HEDLEY_PUBLIC   __declspec(dllexport)
+#  define HEDLEY_IMPORT   __declspec(dllimport)
+#else
+#  if \
+    HEDLEY_HAS_ATTRIBUTE(visibility) || \
+    HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+    HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+    HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    HEDLEY_IBM_VERSION_CHECK(13,1,0) || \
+    HEDLEY_TI_VERSION_CHECK(8,0,0) || \
+    (HEDLEY_TI_VERSION_CHECK(7,3,0) && defined(__TI_EABI__) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__))
+#    define HEDLEY_PRIVATE __attribute__((__visibility__("hidden")))
+#    define HEDLEY_PUBLIC  __attribute__((__visibility__("default")))
+#  else
+#    define HEDLEY_PRIVATE
+#    define HEDLEY_PUBLIC
+#  endif
+#  define HEDLEY_IMPORT    extern
+#endif
+
+#if defined(HEDLEY_NO_THROW)
+#  undef HEDLEY_NO_THROW
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(nothrow) || \
+  HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_NO_THROW __attribute__((__nothrow__))
+#elif \
+  HEDLEY_MSVC_VERSION_CHECK(13,1,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0)
+#  define HEDLEY_NO_THROW __declspec(nothrow)
+#else
+#  define HEDLEY_NO_THROW
+#endif
+
+#if defined(HEDLEY_FALL_THROUGH)
+#  undef HEDLEY_FALL_THROUGH
+#endif
+#if \
+     defined(__cplusplus) && \
+     (!defined(HEDLEY_SUNPRO_VERSION) || HEDLEY_SUNPRO_VERSION_CHECK(5,15,0)) && \
+     !defined(HEDLEY_PGI_VERSION)
+#  if \
+     (__cplusplus >= 201703L) || \
+     ((__cplusplus >= 201103L) && HEDLEY_HAS_CPP_ATTRIBUTE(fallthrough))
+#    define HEDLEY_FALL_THROUGH [[fallthrough]]
+#  elif (__cplusplus >= 201103L) && HEDLEY_HAS_CPP_ATTRIBUTE(clang::fallthrough)
+#    define HEDLEY_FALL_THROUGH [[clang::fallthrough]]
+#  elif (__cplusplus >= 201103L) && HEDLEY_GCC_VERSION_CHECK(7,0,0)
+#    define HEDLEY_FALL_THROUGH [[gnu::fallthrough]]
+#  endif
+#endif
+#if !defined(HEDLEY_FALL_THROUGH)
+#  if HEDLEY_GNUC_HAS_ATTRIBUTE(fallthrough,7,0,0) && !defined(HEDLEY_PGI_VERSION)
+#    define HEDLEY_FALL_THROUGH __attribute__((__fallthrough__))
+#  elif defined(__fallthrough) /* SAL */
+#    define HEDLEY_FALL_THROUGH __fallthrough
+#  else
+#    define HEDLEY_FALL_THROUGH
+#  endif
+#endif
+
+#if defined(HEDLEY_RETURNS_NON_NULL)
+#  undef HEDLEY_RETURNS_NON_NULL
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(returns_nonnull) || \
+  HEDLEY_GCC_VERSION_CHECK(4,9,0)
+#  define HEDLEY_RETURNS_NON_NULL __attribute__((__returns_nonnull__))
+#elif defined(_Ret_notnull_) /* SAL */
+#  define HEDLEY_RETURNS_NON_NULL _Ret_notnull_
+#else
+#  define HEDLEY_RETURNS_NON_NULL
+#endif
+
+#if defined(HEDLEY_ARRAY_PARAM)
+#  undef HEDLEY_ARRAY_PARAM
+#endif
+#if \
+  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
+  !defined(__STDC_NO_VLA__) && \
+  !defined(__cplusplus) && \
+  !defined(HEDLEY_PGI_VERSION) && \
+  !defined(HEDLEY_TINYC_VERSION)
+#  define HEDLEY_ARRAY_PARAM(name) (name)
+#else
+#  define HEDLEY_ARRAY_PARAM(name)
+#endif
+
+#if defined(HEDLEY_IS_CONSTANT)
+#  undef HEDLEY_IS_CONSTANT
+#endif
+#if defined(HEDLEY_REQUIRE_CONSTEXPR)
+#  undef HEDLEY_REQUIRE_CONSTEXPR
+#endif
+/* Note the double-underscore. For internal use only; no API
+ * guarantees! */
+#if defined(HEDLEY__IS_CONSTEXPR)
+#  undef HEDLEY__IS_CONSTEXPR
+#endif
+
+#if \
+  HEDLEY_HAS_BUILTIN(__builtin_constant_p) || \
+  HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_TINYC_VERSION_CHECK(0,9,19) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(13,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(6,1,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,10,0) || \
+  HEDLEY_CRAY_VERSION_CHECK(8,1,0)
+#  define HEDLEY_IS_CONSTANT(expr) __builtin_constant_p(expr)
+#endif
+#if !defined(__cplusplus)
+#  if \
+       HEDLEY_HAS_BUILTIN(__builtin_types_compatible_p) || \
+       HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+       HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+       HEDLEY_IBM_VERSION_CHECK(13,1,0) || \
+       HEDLEY_CRAY_VERSION_CHECK(8,1,0) || \
+       HEDLEY_ARM_VERSION_CHECK(5,4,0) || \
+       HEDLEY_TINYC_VERSION_CHECK(0,9,24)
+#    if defined(__INTPTR_TYPE__)
+#      define HEDLEY__IS_CONSTEXPR(expr) __builtin_types_compatible_p(__typeof__((1 ? (void*) ((__INTPTR_TYPE__) ((expr) * 0)) : (int*) 0)), int*)
+#    else
+#      include <stdint.h>
+#      define HEDLEY__IS_CONSTEXPR(expr) __builtin_types_compatible_p(__typeof__((1 ? (void*) ((intptr_t) ((expr) * 0)) : (int*) 0)), int*)
+#    endif
+#  elif \
+       (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && !defined(HEDLEY_SUNPRO_VERSION) && !defined(HEDLEY_PGI_VERSION)) || \
+       HEDLEY_HAS_EXTENSION(c_generic_selections) || \
+       HEDLEY_GCC_VERSION_CHECK(4,9,0) || \
+       HEDLEY_INTEL_VERSION_CHECK(17,0,0) || \
+       HEDLEY_IBM_VERSION_CHECK(12,1,0) || \
+       HEDLEY_ARM_VERSION_CHECK(5,3,0)
+#    if defined(__INTPTR_TYPE__)
+#      define HEDLEY__IS_CONSTEXPR(expr) _Generic((1 ? (void*) ((__INTPTR_TYPE__) ((expr) * 0)) : (int*) 0), int*: 1, void*: 0)
+#    else
+#      include <stdint.h>
+#      define HEDLEY__IS_CONSTEXPR(expr) _Generic((1 ? (void*) ((intptr_t) * 0) : (int*) 0), int*: 1, void*: 0)
+#    endif
+#  elif \
+       defined(HEDLEY_GCC_VERSION) || \
+       defined(HEDLEY_INTEL_VERSION) || \
+       defined(HEDLEY_TINYC_VERSION) || \
+       defined(HEDLEY_TI_VERSION) || \
+       defined(__clang__)
+#    define HEDLEY__IS_CONSTEXPR(expr) ( \
+         sizeof(void) != \
+         sizeof(*( \
+           1 ? \
+             ((void*) ((expr) * 0L) ) : \
+             ((struct { char v[sizeof(void) * 2]; } *) 1) \
+           ) \
+         ) \
+       )
+#  endif
+#endif
+#if defined(HEDLEY__IS_CONSTEXPR)
+#  if !defined(HEDLEY_IS_CONSTANT)
+#    define HEDLEY_IS_CONSTANT(expr) HEDLEY__IS_CONSTEXPR(expr)
+#  endif
+#  define HEDLEY_REQUIRE_CONSTEXPR(expr) (HEDLEY__IS_CONSTEXPR(expr) ? (expr) : (-1))
+#else
+#  if !defined(HEDLEY_IS_CONSTANT)
+#    define HEDLEY_IS_CONSTANT(expr) (0)
+#  endif
+#  define HEDLEY_REQUIRE_CONSTEXPR(expr) (expr)
+#endif
+
+#if defined(HEDLEY_BEGIN_C_DECLS)
+#  undef HEDLEY_BEGIN_C_DECLS
+#endif
+#if defined(HEDLEY_END_C_DECLS)
+#  undef HEDLEY_END_C_DECLS
+#endif
+#if defined(HEDLEY_C_DECL)
+#  undef HEDLEY_C_DECL
+#endif
+#if defined(__cplusplus)
+#  define HEDLEY_BEGIN_C_DECLS extern "C" {
+#  define HEDLEY_END_C_DECLS }
+#  define HEDLEY_C_DECL extern "C"
+#else
+#  define HEDLEY_BEGIN_C_DECLS
+#  define HEDLEY_END_C_DECLS
+#  define HEDLEY_C_DECL
+#endif
+
+#if defined(HEDLEY_STATIC_ASSERT)
+#  undef HEDLEY_STATIC_ASSERT
+#endif
+#if \
+  !defined(__cplusplus) && ( \
+      (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)) || \
+      HEDLEY_HAS_FEATURE(c_static_assert) || \
+      HEDLEY_GCC_VERSION_CHECK(6,0,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      defined(_Static_assert) \
+    )
+#  define HEDLEY_STATIC_ASSERT(expr, message) _Static_assert(expr, message)
+#elif \
+  (defined(__cplusplus) && (__cplusplus >= 201703L)) || \
+  HEDLEY_MSVC_VERSION_CHECK(16,0,0) || \
+  (defined(__cplusplus) && HEDLEY_TI_VERSION_CHECK(8,3,0))
+#  define HEDLEY_STATIC_ASSERT(expr, message) static_assert(expr, message)
+#elif defined(__cplusplus) && (__cplusplus >= 201103L)
+#  define HEDLEY_STATIC_ASSERT(expr, message) static_assert(expr)
+#else
+#  define HEDLEY_STATIC_ASSERT(expr, message)
+#endif
+
+#if defined(HEDLEY_CONST_CAST)
+#  undef HEDLEY_CONST_CAST
+#endif
+#if defined(__cplusplus)
+#  define HEDLEY_CONST_CAST(T, expr) (const_cast<T>(expr))
+#elif \
+  HEDLEY_HAS_WARNING("-Wcast-qual") || \
+  HEDLEY_GCC_VERSION_CHECK(4,6,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_CONST_CAST(T, expr) (__extension__ ({ \
+      HEDLEY_DIAGNOSTIC_PUSH \
+      HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL \
+      ((T) (expr)); \
+      HEDLEY_DIAGNOSTIC_POP \
+    }))
+#else
+#  define HEDLEY_CONST_CAST(T, expr) ((T) (expr))
+#endif
+
+#if defined(HEDLEY_REINTERPRET_CAST)
+#  undef HEDLEY_REINTERPRET_CAST
+#endif
+#if defined(__cplusplus)
+#  define HEDLEY_REINTERPRET_CAST(T, expr) (reinterpret_cast<T>(expr))
+#else
+#  define HEDLEY_REINTERPRET_CAST(T, expr) (*((T*) &(expr)))
+#endif
+
+#if defined(HEDLEY_STATIC_CAST)
+#  undef HEDLEY_STATIC_CAST
+#endif
+#if defined(__cplusplus)
+#  define HEDLEY_STATIC_CAST(T, expr) (static_cast<T>(expr))
+#else
+#  define HEDLEY_STATIC_CAST(T, expr) ((T) (expr))
+#endif
+
+#if defined(HEDLEY_CPP_CAST)
+#  undef HEDLEY_CPP_CAST
+#endif
+#if defined(__cplusplus)
+#  define HEDLEY_CPP_CAST(T, expr) static_cast<T>(expr)
+#else
+#  define HEDLEY_CPP_CAST(T, expr) (expr)
+#endif
+
+#if defined(HEDLEY_MESSAGE)
+#  undef HEDLEY_MESSAGE
+#endif
+#if HEDLEY_HAS_WARNING("-Wunknown-pragmas")
+#  define HEDLEY_MESSAGE(msg) \
+  HEDLEY_DIAGNOSTIC_PUSH \
+  HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS \
+  HEDLEY_PRAGMA(message msg) \
+  HEDLEY_DIAGNOSTIC_POP
+#elif \
+  HEDLEY_GCC_VERSION_CHECK(4,4,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_MESSAGE(msg) HEDLEY_PRAGMA(message msg)
+#elif HEDLEY_CRAY_VERSION_CHECK(5,0,0)
+#  define HEDLEY_MESSAGE(msg) HEDLEY_PRAGMA(_CRI message msg)
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_MESSAGE(msg) HEDLEY_PRAGMA(message(msg))
+#elif HEDLEY_PELLES_VERSION_CHECK(2,0,0)
+#  define HEDLEY_MESSAGE(msg) HEDLEY_PRAGMA(message(msg))
+#else
+#  define HEDLEY_MESSAGE(msg)
+#endif
+
+#if defined(HEDLEY_WARNING)
+#  undef HEDLEY_WARNING
+#endif
+#if HEDLEY_HAS_WARNING("-Wunknown-pragmas")
+#  define HEDLEY_WARNING(msg) \
+  HEDLEY_DIAGNOSTIC_PUSH \
+  HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS \
+  HEDLEY_PRAGMA(clang warning msg) \
+  HEDLEY_DIAGNOSTIC_POP
+#elif \
+  HEDLEY_GCC_VERSION_CHECK(4,8,0) || \
+  HEDLEY_PGI_VERSION_CHECK(18,4,0)
+#  define HEDLEY_WARNING(msg) HEDLEY_PRAGMA(GCC warning msg)
+#elif HEDLEY_MSVC_VERSION_CHECK(15,0,0)
+#  define HEDLEY_WARNING(msg) HEDLEY_PRAGMA(message(msg))
+#else
+#  define HEDLEY_WARNING(msg) HEDLEY_MESSAGE(msg)
+#endif
+
+#if defined(HEDLEY_REQUIRE_MSG)
+#  undef HEDLEY_REQUIRE_MSG
+#endif
+#if HEDLEY_HAS_ATTRIBUTE(diagnose_if)
+#  if HEDLEY_HAS_WARNING("-Wgcc-compat")
+#    define HEDLEY_REQUIRE_MSG(expr, msg) \
+  HEDLEY_DIAGNOSTIC_PUSH \
+  _Pragma("clang diagnostic ignored \"-Wgcc-compat\"") \
+  __attribute__((__diagnose_if__(!(expr), msg, "error"))) \
+  HEDLEY_DIAGNOSTIC_POP
+#  else
+#    define HEDLEY_REQUIRE_MSG(expr, msg) __attribute__((__diagnose_if__(!(expr), msg, "error")))
+#  endif
+#else
+#  define HEDLEY_REQUIRE_MSG(expr, msg)
+#endif
+
+#if defined(HEDLEY_REQUIRE)
+#  undef HEDLEY_REQUIRE
+#endif
+#define HEDLEY_REQUIRE(expr) HEDLEY_REQUIRE_MSG(expr, #expr)
+
+#if defined(HEDLEY_FLAGS)
+#  undef HEDLEY_FLAGS
+#endif
+#if HEDLEY_HAS_ATTRIBUTE(flag_enum)
+#  define HEDLEY_FLAGS __attribute__((__flag_enum__))
+#endif
+
+#if defined(HEDLEY_FLAGS_CAST)
+#  undef HEDLEY_FLAGS_CAST
+#endif
+#if HEDLEY_INTEL_VERSION_CHECK(19,0,0)
+#  define HEDLEY_FLAGS_CAST(T, expr) (__extension__ ({ \
+  HEDLEY_DIAGNOSTIC_PUSH \
+      _Pragma("warning(disable:188)") \
+      ((T) (expr)); \
+      HEDLEY_DIAGNOSTIC_POP \
+    }))
+#else
+#  define HEDLEY_FLAGS_CAST(T, expr) HEDLEY_STATIC_CAST(T, expr)
+#endif
+
+/* Remaining macros are deprecated. */
+
+#if defined(HEDLEY_GCC_NOT_CLANG_VERSION_CHECK)
+#  undef HEDLEY_GCC_NOT_CLANG_VERSION_CHECK
+#endif
+#if defined(__clang__)
+#  define HEDLEY_GCC_NOT_CLANG_VERSION_CHECK(major,minor,patch) (0)
+#else
+#  define HEDLEY_GCC_NOT_CLANG_VERSION_CHECK(major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_CLANG_HAS_ATTRIBUTE)
+#  undef HEDLEY_CLANG_HAS_ATTRIBUTE
+#endif
+#define HEDLEY_CLANG_HAS_ATTRIBUTE(attribute) HEDLEY_HAS_ATTRIBUTE(attribute)
+
+#if defined(HEDLEY_CLANG_HAS_CPP_ATTRIBUTE)
+#  undef HEDLEY_CLANG_HAS_CPP_ATTRIBUTE
+#endif
+#define HEDLEY_CLANG_HAS_CPP_ATTRIBUTE(attribute) HEDLEY_HAS_CPP_ATTRIBUTE(attribute)
+
+#if defined(HEDLEY_CLANG_HAS_BUILTIN)
+#  undef HEDLEY_CLANG_HAS_BUILTIN
+#endif
+#define HEDLEY_CLANG_HAS_BUILTIN(builtin) HEDLEY_HAS_BUILTIN(builtin)
+
+#if defined(HEDLEY_CLANG_HAS_FEATURE)
+#  undef HEDLEY_CLANG_HAS_FEATURE
+#endif
+#define HEDLEY_CLANG_HAS_FEATURE(feature) HEDLEY_HAS_FEATURE(feature)
+
+#if defined(HEDLEY_CLANG_HAS_EXTENSION)
+#  undef HEDLEY_CLANG_HAS_EXTENSION
+#endif
+#define HEDLEY_CLANG_HAS_EXTENSION(extension) HEDLEY_HAS_EXTENSION(extension)
+
+#if defined(HEDLEY_CLANG_HAS_DECLSPEC_DECLSPEC_ATTRIBUTE)
+#  undef HEDLEY_CLANG_HAS_DECLSPEC_DECLSPEC_ATTRIBUTE
+#endif
+#define HEDLEY_CLANG_HAS_DECLSPEC_ATTRIBUTE(attribute) HEDLEY_HAS_DECLSPEC_ATTRIBUTE(attribute)
+
+#if defined(HEDLEY_CLANG_HAS_WARNING)
+#  undef HEDLEY_CLANG_HAS_WARNING
+#endif
+#define HEDLEY_CLANG_HAS_WARNING(warning) HEDLEY_HAS_WARNING(warning)
+
+#endif /* !defined(HEDLEY_VERSION) || (HEDLEY_VERSION < X) */
+
+
+namespace csv {
+#ifdef _MSC_VER
+#pragma region Compatibility Macros
+#endif
+    /**
+     *  @def IF_CONSTEXPR
+     *  Expands to `if constexpr` in C++17 and `if` otherwise
+     *
+     *  @def CONSTEXPR_VALUE
+     *  Expands to `constexpr` in C++17 and `const` otherwise.
+     *  Mainly used for global variables.
+     *
+     *  @def CONSTEXPR
+     *  Expands to `constexpr` in decent compilers and `inline` otherwise.
+     *  Intended for functions and methods.
+     */
+
+#define STATIC_ASSERT(x) static_assert(x, "Assertion failed")
+
+#if (defined(CMAKE_CXX_STANDARD) && CMAKE_CXX_STANDARD == 17) || __cplusplus >= 201703L
+#define CSV_HAS_CXX17
+#endif
+
+#if (defined(CMAKE_CXX_STANDARD) && CMAKE_CXX_STANDARD >= 14) || __cplusplus >= 201402L
+#define CSV_HAS_CXX14
+#endif
+
+#ifdef CSV_HAS_CXX17
+#include <string_view>
+     /** @typedef string_view
+      *  The string_view class used by this library.
+      */
+    using string_view = std::string_view;
+#else
+     /** @typedef string_view
+      *  The string_view class used by this library.
+      */
+    using string_view = nonstd::string_view;
+#endif
+
+#ifdef CSV_HAS_CXX17
+    #define IF_CONSTEXPR if constexpr
+    #define CONSTEXPR_VALUE constexpr
+
+    #define CONSTEXPR_17 constexpr
+#else
+    #define IF_CONSTEXPR if
+    #define CONSTEXPR_VALUE const
+
+    #define CONSTEXPR_17 inline
+#endif
+
+#ifdef CSV_HAS_CXX14
+    template<bool B, class T = void>
+    using enable_if_t = std::enable_if_t<B, T>;
+
+    #define CONSTEXPR_14 constexpr
+    #define CONSTEXPR_VALUE_14 constexpr
+#else
+    template<bool B, class T = void>
+    using enable_if_t = typename std::enable_if<B, T>::type;
+
+    #define CONSTEXPR_14 inline
+    #define CONSTEXPR_VALUE_14 const
+#endif
+
+    // Resolves g++ bug with regard to constexpr methods
+    // See: https://stackoverflow.com/questions/36489369/constexpr-non-static-member-function-with-non-constexpr-constructor-gcc-clang-d
+#if defined __GNUC__ && !defined __clang__
+    #if (__GNUC__ >= 7 &&__GNUC_MINOR__ >= 2) || (__GNUC__ >= 8)
+        #define CONSTEXPR constexpr
+    #endif
+    #else
+        #ifdef CSV_HAS_CXX17
+        #define CONSTEXPR constexpr
+    #endif
+#endif
+
+#ifndef CONSTEXPR
+#define CONSTEXPR inline
+#endif
+
+#ifdef _MSC_VER
+#pragma endregion
+#endif
+
+    namespace internals {
+        // PAGE_SIZE macro could be already defined by the host system.
+#if defined(PAGE_SIZE)
+#undef PAGE_SIZE
+#endif
+
+// Get operating system specific details
+#if defined(_WIN32)
+        inline int getpagesize() {
+            _SYSTEM_INFO sys_info = {};
+            GetSystemInfo(&sys_info);
+            return std::max(sys_info.dwPageSize, sys_info.dwAllocationGranularity);
+        }
+
+        const int PAGE_SIZE = getpagesize();
+#elif defined(__linux__) 
+        const int PAGE_SIZE = getpagesize();
+#else
+        /** Size of a memory page in bytes. Used by
+         *  csv::internals::CSVFieldArray when allocating blocks.
+         */
+        const int PAGE_SIZE = 4096;
+#endif
+
+        /** For functions that lazy load a large CSV, this determines how
+         *  many bytes are read at a time
+         */
+        constexpr size_t ITERATION_CHUNK_SIZE = 10000000; // 10MB
+
+        template<typename T>
+        inline bool is_equal(T a, T b, T epsilon = 0.001) {
+            /** Returns true if two floating point values are about the same */
+            static_assert(std::is_floating_point<T>::value, "T must be a floating point type.");
+            return std::abs(a - b) < epsilon;
+        }
+
+        /**  @typedef ParseFlags
+         *   An enum used for describing the significance of each character
+         *   with respect to CSV parsing
+         *
+         *   @see quote_escape_flag
+         */
+        enum class ParseFlags {
+            QUOTE_ESCAPE_QUOTE = 0, /**< A quote inside or terminating a quote_escaped field */
+            QUOTE = 2 | 1,          /**< Characters which may signify a quote escape */
+            NOT_SPECIAL = 4,        /**< Characters with no special meaning or escaped delimiters and newlines */
+            DELIMITER = 4 | 2,      /**< Characters which signify a new field */
+            NEWLINE = 4 | 2 | 1     /**< Characters which signify a new row */
+        };
+
+        /** Transform the ParseFlags given the context of whether or not the current
+         *  field is quote escaped */
+        constexpr ParseFlags quote_escape_flag(ParseFlags flag, bool quote_escape) noexcept {
+            return (ParseFlags)((int)flag & ~((int)ParseFlags::QUOTE * quote_escape));
+        }
+
+        // Assumed to be true by parsing functions: allows for testing
+        // if an item is DELIMITER or NEWLINE with a >= statement
+        STATIC_ASSERT(ParseFlags::DELIMITER < ParseFlags::NEWLINE);
+
+        /** Optimizations for reducing branching in parsing loop
+         *
+         *  Idea: The meaning of all non-quote characters changes depending
+         *  on whether or not the parser is in a quote-escaped mode (0 or 1)
+         */
+        STATIC_ASSERT(quote_escape_flag(ParseFlags::NOT_SPECIAL, false) == ParseFlags::NOT_SPECIAL);
+        STATIC_ASSERT(quote_escape_flag(ParseFlags::QUOTE, false) == ParseFlags::QUOTE);
+        STATIC_ASSERT(quote_escape_flag(ParseFlags::DELIMITER, false) == ParseFlags::DELIMITER);
+        STATIC_ASSERT(quote_escape_flag(ParseFlags::NEWLINE, false) == ParseFlags::NEWLINE);
+
+        STATIC_ASSERT(quote_escape_flag(ParseFlags::NOT_SPECIAL, true) == ParseFlags::NOT_SPECIAL);
+        STATIC_ASSERT(quote_escape_flag(ParseFlags::QUOTE, true) == ParseFlags::QUOTE_ESCAPE_QUOTE);
+        STATIC_ASSERT(quote_escape_flag(ParseFlags::DELIMITER, true) == ParseFlags::NOT_SPECIAL);
+        STATIC_ASSERT(quote_escape_flag(ParseFlags::NEWLINE, true) == ParseFlags::NOT_SPECIAL);
+
+        /** An array which maps ASCII chars to a parsing flag */
+        using ParseFlagMap = std::array<ParseFlags, 256>;
+
+        /** An array which maps ASCII chars to a flag indicating if it is whitespace */
+        using WhitespaceMap = std::array<bool, 256>;
+    }
+
+    /** Integer indicating a requested column wasn't found. */
+    constexpr int CSV_NOT_FOUND = -1;
+}
+
+
+namespace csv {
+    namespace internals {
+        struct ColNames;
+        using ColNamesPtr = std::shared_ptr<ColNames>;
+
+        /** @struct ColNames
+             *  A data structure for handling column name information.
+             *
+             *  These are created by CSVReader and passed (via smart pointer)
+             *  to CSVRow objects it creates, thus
+             *  allowing for indexing by column name.
+             */
+        struct ColNames {
+        public:
+            ColNames() = default;
+            ColNames(const std::vector<std::string>& names) {
+                set_col_names(names);
+            }
+
+            std::vector<std::string> get_col_names() const;
+            void set_col_names(const std::vector<std::string>&);
+            int index_of(csv::string_view) const;
+
+            bool empty() const noexcept { return this->col_names.empty(); }
+            size_t size() const noexcept;
+
+        private:
+            std::vector<std::string> col_names;
+            std::unordered_map<std::string, size_t> col_pos;
+        };
+    }
+}
+/** @file
+ *  Defines an object used to store CSV format settings
+ */
+
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+
+namespace csv {
+    namespace internals {
+        class IBasicCSVParser;
+    }
+
+    class CSVReader;
+
+    /** Determines how to handle rows that are shorter or longer than the majority */
+    enum class VariableColumnPolicy {
+        THROW = -1,
+        IGNORE_ROW = 0,
+        KEEP   = 1
+    };
+
+    /** Stores the inferred format of a CSV file. */
+    struct CSVGuessResult {
+        char delim;
+        int header_row;
+    };
+
+    /** Stores information about how to parse a CSV file.
+     *  Can be used to construct a csv::CSVReader. 
+     */
+    class CSVFormat {
+    public:
+        /** Settings for parsing a RFC 4180 CSV file */
+        CSVFormat() = default;
+
+        /** Sets the delimiter of the CSV file
+         *
+         *  @throws `std::runtime_error` thrown if trim, quote, or possible delimiting characters overlap
+         */
+        CSVFormat& delimiter(char delim);
+
+        /** Sets a list of potential delimiters
+         *  
+         *  @throws `std::runtime_error` thrown if trim, quote, or possible delimiting characters overlap
+         *  @param[in] delim An array of possible delimiters to try parsing the CSV with
+         */
+        CSVFormat& delimiter(const std::vector<char> & delim);
+
+        /** Sets the whitespace characters to be trimmed
+         *
+         *  @throws `std::runtime_error` thrown if trim, quote, or possible delimiting characters overlap
+         *  @param[in] ws An array of whitespace characters that should be trimmed
+         */
+        CSVFormat& trim(const std::vector<char> & ws);
+
+        /** Sets the quote character
+         *
+         *  @throws `std::runtime_error` thrown if trim, quote, or possible delimiting characters overlap
+         */
+        CSVFormat& quote(char quote);
+
+        /** Sets the column names.
+         *
+         *  @note Unsets any values set by header_row()
+         */
+        CSVFormat& column_names(const std::vector<std::string>& names);
+
+        /** Sets the header row
+         *
+         *  @note Unsets any values set by column_names()
+         */
+        CSVFormat& header_row(int row);
+
+        /** Tells the parser that this CSV has no header row
+         *
+         *  @note Equivalent to `header_row(-1)`
+         *
+         */
+        CSVFormat& no_header() {
+            this->header_row(-1);
+            return *this;
+        }
+
+        /** Turn quoting on or off */
+        CSVFormat& quote(bool use_quote) {
+            this->no_quote = !use_quote;
+            return *this;
+        }
+
+        /** Tells the parser how to handle columns of a different length than the others */
+        CONSTEXPR_14 CSVFormat& variable_columns(VariableColumnPolicy policy = VariableColumnPolicy::IGNORE_ROW) {
+            this->variable_column_policy = policy;
+            return *this;
+        }
+
+        /** Tells the parser how to handle columns of a different length than the others */
+        CONSTEXPR_14 CSVFormat& variable_columns(bool policy) {
+            this->variable_column_policy = (VariableColumnPolicy)policy;
+            return *this;
+        }
+
+        #ifndef DOXYGEN_SHOULD_SKIP_THIS
+        char get_delim() const {
+            // This error should never be received by end users.
+            if (this->possible_delimiters.size() > 1) {
+                throw std::runtime_error("There is more than one possible delimiter.");
+            }
+
+            return this->possible_delimiters.at(0);
+        }
+
+        CONSTEXPR bool is_quoting_enabled() const { return !this->no_quote; }
+        CONSTEXPR char get_quote_char() const { return this->quote_char; }
+        CONSTEXPR int get_header() const { return this->header; }
+        std::vector<char> get_possible_delims() const { return this->possible_delimiters; }
+        std::vector<char> get_trim_chars() const { return this->trim_chars; }
+        CONSTEXPR VariableColumnPolicy get_variable_column_policy() const { return this->variable_column_policy; }
+        #endif
+        
+        /** CSVFormat for guessing the delimiter */
+        CSV_INLINE static CSVFormat guess_csv() {
+            CSVFormat format;
+            format.delimiter({ ',', '|', '\t', ';', '^' })
+                .quote('"')
+                .header_row(0);
+
+            return format;
+        }
+
+        bool guess_delim() {
+            return this->possible_delimiters.size() > 1;
+        }
+
+        friend CSVReader;
+        friend internals::IBasicCSVParser;
+        
+    private:
+        /**< Throws an error if delimiters and trim characters overlap */
+        void assert_no_char_overlap();
+
+        /**< Set of possible delimiters */
+        std::vector<char> possible_delimiters = { ',' };
+
+        /**< Set of whitespace characters to trim */
+        std::vector<char> trim_chars = {};
+
+        /**< Row number with columns (ignored if col_names is non-empty) */
+        int header = 0;
+
+        /**< Whether or not to use quoting */
+        bool no_quote = false;
+
+        /**< Quote character */
+        char quote_char = '"';
+
+        /**< Should be left empty unless file doesn't include header */
+        std::vector<std::string> col_names = {};
+
+        /**< Allow variable length columns? */
+        VariableColumnPolicy variable_column_policy = VariableColumnPolicy::IGNORE_ROW;
+    };
+}
+/** @file
+ *  Defines the data type used for storing information about a CSV row
+ */
+
+#include <cmath>
+#include <deque>
+#include <iterator>
+#include <memory> // For CSVField
+#include <limits> // For CSVField
+#include <unordered_map>
+#include <unordered_set>
+#include <string>
+#include <sstream>
+#include <vector>
+
+/** @file
+ *  @brief Implements data type parsing functionality
+ */
+
+#include <cmath>
+#include <cctype>
+#include <string>
+#include <cassert>
+
+
+namespace csv {
+    /** Enumerates the different CSV field types that are
+     *  recognized by this library
+     *
+     *  @note Overflowing integers will be stored and classified as doubles.
+     *  @note Unlike previous releases, integer enums here are platform agnostic.
+     */
+    enum class DataType {
+        UNKNOWN = -1,
+        CSV_NULL,   /**< Empty string */
+        CSV_STRING, /**< Non-numeric string */
+        CSV_INT8,   /**< 8-bit integer */
+        CSV_INT16,  /**< 16-bit integer (short on MSVC/GCC) */
+        CSV_INT32,  /**< 32-bit integer (int on MSVC/GCC) */
+        CSV_INT64,  /**< 64-bit integer (long long on MSVC/GCC) */
+        CSV_BIGINT, /**< Value too big to fit in a 64-bit in */
+        CSV_DOUBLE  /**< Floating point value */
+    };
+
+    static_assert(DataType::CSV_STRING < DataType::CSV_INT8, "String type should come before numeric types.");
+    static_assert(DataType::CSV_INT8 < DataType::CSV_INT64, "Smaller integer types should come before larger integer types.");
+    static_assert(DataType::CSV_INT64 < DataType::CSV_DOUBLE, "Integer types should come before floating point value types.");
+
+    namespace internals {
+        /** Compute 10 to the power of n */
+        template<typename T>
+        HEDLEY_CONST CONSTEXPR_14
+        long double pow10(const T& n) noexcept {
+            long double multiplicand = n > 0 ? 10 : 0.1,
+                ret = 1;
+
+            // Make all numbers positive
+            T iterations = n > 0 ? n : -n;
+            
+            for (T i = 0; i < iterations; i++) {
+                ret *= multiplicand;
+            }
+
+            return ret;
+        }
+
+        /** Compute 10 to the power of n */
+        template<>
+        HEDLEY_CONST CONSTEXPR_14
+        long double pow10(const unsigned& n) noexcept {
+            long double multiplicand = n > 0 ? 10 : 0.1,
+                ret = 1;
+
+            for (unsigned i = 0; i < n; i++) {
+                ret *= multiplicand;
+            }
+
+            return ret;
+        }
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+        /** Private site-indexed array mapping byte sizes to an integer size enum */
+        constexpr DataType int_type_arr[8] = {
+            DataType::CSV_INT8,  // 1
+            DataType::CSV_INT16, // 2
+            DataType::UNKNOWN,
+            DataType::CSV_INT32, // 4
+            DataType::UNKNOWN,
+            DataType::UNKNOWN,
+            DataType::UNKNOWN,
+            DataType::CSV_INT64  // 8
+        };
+
+        template<typename T>
+        inline DataType type_num() {
+            static_assert(std::is_integral<T>::value, "T should be an integral type.");
+            static_assert(sizeof(T) <= 8, "Byte size must be no greater than 8.");
+            return int_type_arr[sizeof(T) - 1];
+        }
+
+        template<> inline DataType type_num<float>() { return DataType::CSV_DOUBLE; }
+        template<> inline DataType type_num<double>() { return DataType::CSV_DOUBLE; }
+        template<> inline DataType type_num<long double>() { return DataType::CSV_DOUBLE; }
+        template<> inline DataType type_num<std::nullptr_t>() { return DataType::CSV_NULL; }
+        template<> inline DataType type_num<std::string>() { return DataType::CSV_STRING; }
+
+        CONSTEXPR_14 DataType data_type(csv::string_view in, long double* const out = nullptr, 
+            const char decimalsymbol = '.');
+#endif
+
+        /** Given a byte size, return the largest number than can be stored in
+         *  an integer of that size
+         *
+         *  Note: Provides a platform-agnostic way of mapping names like "long int" to
+         *  byte sizes
+         */
+        template<size_t Bytes>
+        CONSTEXPR_14 long double get_int_max() {
+            static_assert(Bytes == 1 || Bytes == 2 || Bytes == 4 || Bytes == 8,
+                "Bytes must be a power of 2 below 8.");
+
+            IF_CONSTEXPR (sizeof(signed char) == Bytes) {
+                return (long double)std::numeric_limits<signed char>::max();
+            }
+
+            IF_CONSTEXPR (sizeof(short) == Bytes) {
+                return (long double)std::numeric_limits<short>::max();
+            }
+
+            IF_CONSTEXPR (sizeof(int) == Bytes) {
+                return (long double)std::numeric_limits<int>::max();
+            }
+
+            IF_CONSTEXPR (sizeof(long int) == Bytes) {
+                return (long double)std::numeric_limits<long int>::max();
+            }
+
+            IF_CONSTEXPR (sizeof(long long int) == Bytes) {
+                return (long double)std::numeric_limits<long long int>::max();
+            }
+
+            HEDLEY_UNREACHABLE();
+        }
+
+        /** Given a byte size, return the largest number than can be stored in
+         *  an unsigned integer of that size
+         */
+        template<size_t Bytes>
+        CONSTEXPR_14 long double get_uint_max() {
+            static_assert(Bytes == 1 || Bytes == 2 || Bytes == 4 || Bytes == 8,
+                "Bytes must be a power of 2 below 8.");
+
+            IF_CONSTEXPR(sizeof(unsigned char) == Bytes) {
+                return (long double)std::numeric_limits<unsigned char>::max();
+            }
+
+            IF_CONSTEXPR(sizeof(unsigned short) == Bytes) {
+                return (long double)std::numeric_limits<unsigned short>::max();
+            }
+
+            IF_CONSTEXPR(sizeof(unsigned int) == Bytes) {
+                return (long double)std::numeric_limits<unsigned int>::max();
+            }
+
+            IF_CONSTEXPR(sizeof(unsigned long int) == Bytes) {
+                return (long double)std::numeric_limits<unsigned long int>::max();
+            }
+
+            IF_CONSTEXPR(sizeof(unsigned long long int) == Bytes) {
+                return (long double)std::numeric_limits<unsigned long long int>::max();
+            }
+
+            HEDLEY_UNREACHABLE();
+        }
+
+        /** Largest number that can be stored in a 8-bit integer */
+        CONSTEXPR_VALUE_14 long double CSV_INT8_MAX = get_int_max<1>();
+
+        /** Largest number that can be stored in a 16-bit integer */
+        CONSTEXPR_VALUE_14 long double CSV_INT16_MAX = get_int_max<2>();
+
+        /** Largest number that can be stored in a 32-bit integer */
+        CONSTEXPR_VALUE_14 long double CSV_INT32_MAX = get_int_max<4>();
+
+        /** Largest number that can be stored in a 64-bit integer */
+        CONSTEXPR_VALUE_14 long double CSV_INT64_MAX = get_int_max<8>();
+
+        /** Largest number that can be stored in a 8-bit ungisned integer */
+        CONSTEXPR_VALUE_14 long double CSV_UINT8_MAX = get_uint_max<1>();
+
+        /** Largest number that can be stored in a 16-bit unsigned integer */
+        CONSTEXPR_VALUE_14 long double CSV_UINT16_MAX = get_uint_max<2>();
+
+        /** Largest number that can be stored in a 32-bit unsigned integer */
+        CONSTEXPR_VALUE_14 long double CSV_UINT32_MAX = get_uint_max<4>();
+
+        /** Largest number that can be stored in a 64-bit unsigned integer */
+        CONSTEXPR_VALUE_14 long double CSV_UINT64_MAX = get_uint_max<8>();
+
+        /** Given a pointer to the start of what is start of
+         *  the exponential part of a number written (possibly) in scientific notation
+         *  parse the exponent
+         */
+        HEDLEY_PRIVATE CONSTEXPR_14
+        DataType _process_potential_exponential(
+            csv::string_view exponential_part,
+            const long double& coeff,
+            long double * const out) {
+            long double exponent = 0;
+            auto result = data_type(exponential_part, &exponent);
+
+            // Exponents in scientific notation should not be decimal numbers
+            if (result >= DataType::CSV_INT8 && result < DataType::CSV_DOUBLE) {
+                if (out) *out = coeff * pow10(exponent);
+                return DataType::CSV_DOUBLE;
+            }
+
+            return DataType::CSV_STRING;
+        }
+
+        /** Given the absolute value of an integer, determine what numeric type
+         *  it fits in
+         */
+        HEDLEY_PRIVATE HEDLEY_PURE CONSTEXPR_14
+        DataType _determine_integral_type(const long double& number) noexcept {
+            // We can assume number is always non-negative
+            assert(number >= 0);
+
+            if (number <= internals::CSV_INT8_MAX)
+                return DataType::CSV_INT8;
+            else if (number <= internals::CSV_INT16_MAX)
+                return DataType::CSV_INT16;
+            else if (number <= internals::CSV_INT32_MAX)
+                return DataType::CSV_INT32;
+            else if (number <= internals::CSV_INT64_MAX)
+                return DataType::CSV_INT64;
+            else // Conversion to long long will cause an overflow
+                return DataType::CSV_BIGINT;
+        }
+
+        /** Distinguishes numeric from other text values. Used by various
+         *  type casting functions, like csv_parser::CSVReader::read_row()
+         *
+         *  #### Rules
+         *   - Leading and trailing whitespace ("padding") ignored
+         *   - A string of just whitespace is NULL
+         *
+         *  @param[in]  in  String value to be examined
+         *  @param[out] out Pointer to long double where results of numeric parsing
+         *                  get stored
+         *  @param[in]  decimalSymbol  the character separating integral and decimal part,
+         *                             defaults to '.' if omitted
+         */
+        CONSTEXPR_14
+        DataType data_type(csv::string_view in, long double* const out, const char decimalSymbol) {
+            // Empty string --> NULL
+            if (in.size() == 0)
+                return DataType::CSV_NULL;
+
+            bool ws_allowed = true,
+                dot_allowed = true,
+                digit_allowed = true,
+                is_negative = false,
+                has_digit = false,
+                prob_float = false;
+
+            unsigned places_after_decimal = 0;
+            long double integral_part = 0,
+                decimal_part = 0;
+
+            for (size_t i = 0, ilen = in.size(); i < ilen; i++) {
+                const char& current = in[i];
+
+                switch (current) {
+                case ' ':
+                    if (!ws_allowed) {
+                        if (isdigit(in[i - 1])) {
+                            digit_allowed = false;
+                            ws_allowed = true;
+                        }
+                        else {
+                            // Ex: '510 123 4567'
+                            return DataType::CSV_STRING;
+                        }
+                    }
+                    break;
+                case '+':
+                    if (!ws_allowed) {
+                        return DataType::CSV_STRING;
+                    }
+
+                    break;
+                case '-':
+                    if (!ws_allowed) {
+                        // Ex: '510-123-4567'
+                        return DataType::CSV_STRING;
+                    }
+
+                    is_negative = true;
+                    break;
+                // case decimalSymbol: not allowed because decimalSymbol is not a literal,
+                // it is handled in the default block
+                case 'e':
+                case 'E':
+                    // Process scientific notation
+                    if (prob_float || (i && i + 1 < ilen && isdigit(in[i - 1]))) {
+                        size_t exponent_start_idx = i + 1;
+                        prob_float = true;
+
+                        // Strip out plus sign
+                        if (in[i + 1] == '+') {
+                            exponent_start_idx++;
+                        }
+
+                        return _process_potential_exponential(
+                            in.substr(exponent_start_idx),
+                            is_negative ? -(integral_part + decimal_part) : integral_part + decimal_part,
+                            out
+                        );
+                    }
+
+                    return DataType::CSV_STRING;
+                    break;
+                default:
+                    short digit = static_cast<short>(current - '0');
+                    if (digit >= 0 && digit <= 9) {
+                        // Process digit
+                        has_digit = true;
+
+                        if (!digit_allowed)
+                            return DataType::CSV_STRING;
+                        else if (ws_allowed) // Ex: '510 456'
+                            ws_allowed = false;
+
+                        // Build current number
+                        if (prob_float)
+                            decimal_part += digit / pow10(++places_after_decimal);
+                        else
+                            integral_part = (integral_part * 10) + digit;
+                    }
+                    // case decimalSymbol: not allowed because decimalSymbol is not a literal. 
+                    else if (dot_allowed && current == decimalSymbol) {
+                        dot_allowed = false;
+                        prob_float = true;
+                    }
+                    else {
+                        return DataType::CSV_STRING;
+                    }
+                }
+            }
+
+            // No non-numeric/non-whitespace characters found
+            if (has_digit) {
+                long double number = integral_part + decimal_part;
+                if (out) {
+                    *out = is_negative ? -number : number;
+                }
+
+                return prob_float ? DataType::CSV_DOUBLE : _determine_integral_type(number);
+            }
+
+            // Just whitespace
+            return DataType::CSV_NULL;
+        }
+    }
+}
+
+namespace csv {
+    namespace internals {
+        class IBasicCSVParser;
+
+        static const std::string ERROR_NAN = "Not a number.";
+        static const std::string ERROR_OVERFLOW = "Overflow error.";
+        static const std::string ERROR_FLOAT_TO_INT =
+            "Attempted to convert a floating point value to an integral type.";
+        static const std::string ERROR_NEG_TO_UNSIGNED = "Negative numbers cannot be converted to unsigned types.";
+    
+        std::string json_escape_string(csv::string_view s) noexcept;
+
+        /** A barebones class used for describing CSV fields */
+        struct RawCSVField {
+            RawCSVField() = default;
+            RawCSVField(size_t _start, size_t _length, bool _double_quote = false) {
+                start = _start;
+                length = _length;
+                has_double_quote = _double_quote;
+            }
+
+            /** The start of the field, relative to the beginning of the row */
+            size_t start;
+
+            /** The length of the row, ignoring quote escape characters */
+            size_t length; 
+
+            /** Whether or not the field contains an escaped quote */
+            bool has_double_quote;
+        };
+
+        /** A class used for efficiently storing RawCSVField objects and expanding as necessary
+         *
+         *  @par Implementation
+         *  This data structure stores RawCSVField in continguous blocks. When more capacity
+         *  is needed, a new block is allocated, but previous data stays put.
+         *
+         *  @par Thread Safety
+         *  This class may be safely read from multiple threads and written to from one,
+         *  as long as the writing thread does not actively touch fields which are being
+         *  read.
+         */
+        class CSVFieldList {
+        public:
+            /** Construct a CSVFieldList which allocates blocks of a certain size */
+            CSVFieldList(size_t single_buffer_capacity = (size_t)(internals::PAGE_SIZE / sizeof(RawCSVField))) :
+                _single_buffer_capacity(single_buffer_capacity) {
+                this->allocate();
+            }
+
+            // No copy constructor
+            CSVFieldList(const CSVFieldList& other) = delete;
+
+            // CSVFieldArrays may be moved
+            CSVFieldList(CSVFieldList&& other) :
+                _single_buffer_capacity(other._single_buffer_capacity) {
+
+                for (auto&& buffer : other.buffers) {
+                    this->buffers.emplace_back(std::move(buffer));
+                }
+
+                _current_buffer_size = other._current_buffer_size;
+                _back = other._back;
+            }
+
+            template <class... Args>
+            void emplace_back(Args&&... args) {
+                if (this->_current_buffer_size == this->_single_buffer_capacity) {
+                    this->allocate();
+                }
+
+                *(_back++) = RawCSVField(std::forward<Args>(args)...);
+                _current_buffer_size++;
+            }
+
+            size_t size() const noexcept {
+                return this->_current_buffer_size + ((this->buffers.size() - 1) * this->_single_buffer_capacity);
+            }
+
+            RawCSVField& operator[](size_t n) const;
+
+        private:
+            const size_t _single_buffer_capacity;
+
+            /**
+             * Prefer std::deque over std::vector because it does not
+             * reallocate upon expansion, allowing pointers to its members
+             * to remain valid & avoiding potential race conditions when 
+             * CSVFieldList is accesssed simulatenously by a reading thread and
+             * a writing thread
+             */
+            std::deque<std::unique_ptr<RawCSVField[]>> buffers = {};
+
+            /** Number of items in the current buffer */
+            size_t _current_buffer_size = 0;
+
+            /** Pointer to the current empty field */
+            RawCSVField* _back = nullptr;
+
+            /** Allocate a new page of memory */
+            void allocate();
+        };
+
+        /** A class for storing raw CSV data and associated metadata */
+        struct RawCSVData {
+            std::shared_ptr<void> _data = nullptr;
+            csv::string_view data = "";
+
+            internals::CSVFieldList fields;
+
+            std::unordered_set<size_t> has_double_quotes = {};
+
+            // TODO: Consider replacing with a more thread-safe structure
+            std::unordered_map<size_t, std::string> double_quote_fields = {};
+
+            internals::ColNamesPtr col_names = nullptr;
+            internals::ParseFlagMap parse_flags;
+            internals::WhitespaceMap ws_flags;
+        };
+
+        using RawCSVDataPtr = std::shared_ptr<RawCSVData>;
+    }
+
+    /**
+    * @class CSVField
+    * @brief Data type representing individual CSV values.
+    *        CSVFields can be obtained by using CSVRow::operator[]
+    */
+    class CSVField {
+    public:
+        /** Constructs a CSVField from a string_view */
+        constexpr explicit CSVField(csv::string_view _sv) noexcept : sv(_sv) { };
+
+        operator std::string() const {
+            return std::string("<CSVField> ") + std::string(this->sv);
+        }
+
+        /** Returns the value casted to the requested type, performing type checking before.
+        *
+        *  \par Valid options for T
+        *   - std::string or csv::string_view
+        *   - signed integral types (signed char, short, int, long int, long long int)
+        *   - floating point types (float, double, long double)
+        *   - unsigned integers are not supported at this time, but may be in a later release
+        *
+        *  \par Invalid conversions
+        *   - Converting non-numeric values to any numeric type
+        *   - Converting floating point values to integers
+        *   - Converting a large integer to a smaller type that will not hold it
+        *
+        *  @note    This method is capable of parsing scientific E-notation.
+        *           See [this page](md_docs_source_scientific_notation.html)
+        *           for more details.
+        *
+        *  @throws  std::runtime_error Thrown if an invalid conversion is performed.
+        *
+        *  @warning Currently, conversions to floating point types are not
+        *           checked for loss of precision
+        *
+        *  @warning Any string_views returned are only guaranteed to be valid
+        *           if the parent CSVRow is still alive. If you are concerned
+        *           about object lifetimes, then grab a std::string or a
+        *           numeric value.
+        *
+        */
+        template<typename T = std::string> T get() {
+            IF_CONSTEXPR(std::is_arithmetic<T>::value) {
+                // Note: this->type() also converts the CSV value to float
+                if (this->type() <= DataType::CSV_STRING) {
+                    throw std::runtime_error(internals::ERROR_NAN);
+                }
+            }
+
+            IF_CONSTEXPR(std::is_integral<T>::value) {
+                // Note: this->is_float() also converts the CSV value to float
+                if (this->is_float()) {
+                    throw std::runtime_error(internals::ERROR_FLOAT_TO_INT);
+                }
+
+                IF_CONSTEXPR(std::is_unsigned<T>::value) {
+                    if (this->value < 0) {
+                        throw std::runtime_error(internals::ERROR_NEG_TO_UNSIGNED);
+                    }
+                }
+            }
+
+            // Allow fallthrough from previous if branch
+            IF_CONSTEXPR(!std::is_floating_point<T>::value) {
+                IF_CONSTEXPR(std::is_unsigned<T>::value) {
+                    // Quick hack to perform correct unsigned integer boundary checks
+                    if (this->value > internals::get_uint_max<sizeof(T)>()) {
+                        throw std::runtime_error(internals::ERROR_OVERFLOW);
+                    }
+                }
+                else if (internals::type_num<T>() < this->_type) {
+                    throw std::runtime_error(internals::ERROR_OVERFLOW);
+                }
+            }
+
+            return static_cast<T>(this->value);
+        }
+
+        /** Parse a hexadecimal value, returning false if the value is not hex. */
+        bool try_parse_hex(int& parsedValue);
+
+        /** Attempts to parse a decimal (or integer) value using the given symbol,
+         *  returning `true` if the value is numeric.
+         *
+         *  @note This method also updates this field's type
+         *
+         */
+        bool try_parse_decimal(long double& dVal, const char decimalSymbol = '.');
+
+        /** Compares the contents of this field to a numeric value. If this
+         *  field does not contain a numeric value, then all comparisons return
+         *  false.
+         *
+         *  @note    Floating point values are considered equal if they are within
+         *           `0.000001` of each other.
+         *
+         *  @warning Multiple numeric comparisons involving the same field can
+         *           be done more efficiently by calling the CSVField::get<>() method.
+         *
+         *  @sa      csv::CSVField::operator==(const char * other)
+         *  @sa      csv::CSVField::operator==(csv::string_view other)
+         */
+        template<typename T>
+        CONSTEXPR_14 bool operator==(T other) const noexcept
+        {
+            static_assert(std::is_arithmetic<T>::value,
+                "T should be a numeric value.");
+
+            if (this->_type != DataType::UNKNOWN) {
+                if (this->_type == DataType::CSV_STRING) {
+                    return false;
+                }
+
+                return internals::is_equal(value, static_cast<long double>(other), 0.000001L);
+            }
+
+            long double out = 0;
+            if (internals::data_type(this->sv, &out) == DataType::CSV_STRING) {
+                return false;
+            }
+
+            return internals::is_equal(out, static_cast<long double>(other), 0.000001L);
+        }
+
+        /** Return a string view over the field's contents */
+        CONSTEXPR csv::string_view get_sv() const noexcept { return this->sv; }
+
+        /** Returns true if field is an empty string or string of whitespace characters */
+        CONSTEXPR_14 bool is_null() noexcept { return type() == DataType::CSV_NULL; }
+
+        /** Returns true if field is a non-numeric, non-empty string */
+        CONSTEXPR_14 bool is_str() noexcept { return type() == DataType::CSV_STRING; }
+
+        /** Returns true if field is an integer or float */
+        CONSTEXPR_14 bool is_num() noexcept { return type() >= DataType::CSV_INT8; }
+
+        /** Returns true if field is an integer */
+        CONSTEXPR_14 bool is_int() noexcept {
+            return (type() >= DataType::CSV_INT8) && (type() <= DataType::CSV_INT64);
+        }
+
+        /** Returns true if field is a floating point value */
+        CONSTEXPR_14 bool is_float() noexcept { return type() == DataType::CSV_DOUBLE; };
+
+        /** Return the type of the underlying CSV data */
+        CONSTEXPR_14 DataType type() noexcept {
+            this->get_value();
+            return _type;
+        }
+
+    private:
+        long double value = 0;    /**< Cached numeric value */
+        csv::string_view sv = ""; /**< A pointer to this field's text */
+        DataType _type = DataType::UNKNOWN; /**< Cached data type value */
+        CONSTEXPR_14 void get_value() noexcept {
+            /* Check to see if value has been cached previously, if not
+             * evaluate it
+             */
+            if ((int)_type < 0) {
+                this->_type = internals::data_type(this->sv, &this->value);
+            }
+        }
+    };
+
+    /** Data structure for representing CSV rows */
+    class CSVRow {
+    public:
+        friend internals::IBasicCSVParser;
+
+        CSVRow() = default;
+        
+        /** Construct a CSVRow from a RawCSVDataPtr */
+        CSVRow(internals::RawCSVDataPtr _data) : data(_data) {}
+        CSVRow(internals::RawCSVDataPtr _data, size_t _data_start, size_t _field_bounds)
+            : data(_data), data_start(_data_start), fields_start(_field_bounds) {}
+
+        /** Indicates whether row is empty or not */
+        CONSTEXPR bool empty() const noexcept { return this->size() == 0; }
+
+        /** Return the number of fields in this row */
+        CONSTEXPR size_t size() const noexcept { return row_length; }
+
+        /** @name Value Retrieval */
+        ///@{
+        CSVField operator[](size_t n) const;
+        CSVField operator[](const std::string&) const;
+        std::string to_json(const std::vector<std::string>& subset = {}) const;
+        std::string to_json_array(const std::vector<std::string>& subset = {}) const;
+
+        /** Retrieve this row's associated column names */
+        std::vector<std::string> get_col_names() const {
+            return this->data->col_names->get_col_names();
+        }
+
+        /** Convert this CSVRow into a vector of strings.
+         *  **Note**: This is a less efficient method of
+         *  accessing data than using the [] operator.
+         */
+        operator std::vector<std::string>() const;
+        ///@}
+
+        /** A random access iterator over the contents of a CSV row.
+         *  Each iterator points to a CSVField.
+         */
+        class iterator {
+        public:
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+            using value_type = CSVField;
+            using difference_type = int;
+            using pointer = std::shared_ptr<CSVField>;
+            using reference = CSVField & ;
+            using iterator_category = std::random_access_iterator_tag;
+#endif
+            iterator(const CSVRow*, int i);
+
+            reference operator*() const;
+            pointer operator->() const;
+
+            iterator operator++(int);
+            iterator& operator++();
+            iterator operator--(int);
+            iterator& operator--();
+            iterator operator+(difference_type n) const;
+            iterator operator-(difference_type n) const;
+
+            /** Two iterators are equal if they point to the same field */
+            CONSTEXPR bool operator==(const iterator& other) const noexcept {
+                return this->i == other.i;
+            };
+
+            CONSTEXPR bool operator!=(const iterator& other) const noexcept { return !operator==(other); }
+
+#ifndef NDEBUG
+            friend CSVRow;
+#endif
+
+        private:
+            const CSVRow * daddy = nullptr;            // Pointer to parent
+            std::shared_ptr<CSVField> field = nullptr; // Current field pointed at
+            int i = 0;                                 // Index of current field
+        };
+
+        /** A reverse iterator over the contents of a CSVRow. */
+        using reverse_iterator = std::reverse_iterator<iterator>;
+
+        /** @name Iterators
+         *  @brief Each iterator points to a CSVField object.
+         */
+         ///@{
+        iterator begin() const;
+        iterator end() const noexcept;
+        reverse_iterator rbegin() const noexcept;
+        reverse_iterator rend() const;
+        ///@}
+
+    private:
+        /** Retrieve a string view corresponding to the specified index */
+        csv::string_view get_field(size_t index) const;
+
+        internals::RawCSVDataPtr data;
+
+        /** Where in RawCSVData.data we start */
+        size_t data_start = 0;
+
+        /** Where in the RawCSVDataPtr.fields array we start */
+        size_t fields_start = 0;
+
+        /** How many columns this row spans */
+        size_t row_length = 0;
+    };
+
+#ifdef _MSC_VER
+#pragma region CSVField::get Specializations
+#endif
+    /** Retrieve this field's original string */
+    template<>
+    inline std::string CSVField::get<std::string>() {
+        return std::string(this->sv);
+    }
+
+    /** Retrieve a view over this field's string
+     *
+     *  @warning This string_view is only guaranteed to be valid as long as this
+     *           CSVRow is still alive.
+     */
+    template<>
+    CONSTEXPR_14 csv::string_view CSVField::get<csv::string_view>() {
+        return this->sv;
+    }
+
+    /** Retrieve this field's value as a long double */
+    template<>
+    CONSTEXPR_14 long double CSVField::get<long double>() {
+        if (!is_num())
+            throw std::runtime_error(internals::ERROR_NAN);
+
+        return this->value;
+    }
+#ifdef _MSC_VER
+#pragma endregion CSVField::get Specializations
+#endif
+
+    /** Compares the contents of this field to a string */
+    template<>
+    CONSTEXPR bool CSVField::operator==(const char * other) const noexcept
+    {
+        return this->sv == other;
+    }
+
+    /** Compares the contents of this field to a string */
+    template<>
+    CONSTEXPR bool CSVField::operator==(csv::string_view other) const noexcept
+    {
+        return this->sv == other;
+    }
+}
+
+inline std::ostream& operator << (std::ostream& os, csv::CSVField const& value) {
+    os << std::string(value);
+    return os;
+}
+
+
+namespace csv {
+    namespace internals {
+        /** Create a vector v where each index i corresponds to the
+         *  ASCII number for a character and, v[i + 128] labels it according to
+         *  the CSVReader::ParseFlags enum
+         */
+        HEDLEY_CONST CONSTEXPR_17 ParseFlagMap make_parse_flags(char delimiter) {
+            std::array<ParseFlags, 256> ret = {};
+            for (int i = -128; i < 128; i++) {
+                const int arr_idx = i + 128;
+                char ch = char(i);
+
+                if (ch == delimiter)
+                    ret[arr_idx] = ParseFlags::DELIMITER;
+                else if (ch == '\r' || ch == '\n')
+                    ret[arr_idx] = ParseFlags::NEWLINE;
+                else
+                    ret[arr_idx] = ParseFlags::NOT_SPECIAL;
+            }
+
+            return ret;
+        }
+
+        /** Create a vector v where each index i corresponds to the
+         *  ASCII number for a character and, v[i + 128] labels it according to
+         *  the CSVReader::ParseFlags enum
+         */
+        HEDLEY_CONST CONSTEXPR_17 ParseFlagMap make_parse_flags(char delimiter, char quote_char) {
+            std::array<ParseFlags, 256> ret = make_parse_flags(delimiter);
+            ret[(size_t)quote_char + 128] = ParseFlags::QUOTE;
+            return ret;
+        }
+
+        /** Create a vector v where each index i corresponds to the
+         *  ASCII number for a character c and, v[i + 128] is true if
+         *  c is a whitespace character
+         */
+        HEDLEY_CONST CONSTEXPR_17 WhitespaceMap make_ws_flags(const char* ws_chars, size_t n_chars) {
+            std::array<bool, 256> ret = {};
+            for (int i = -128; i < 128; i++) {
+                const int arr_idx = i + 128;
+                char ch = char(i);
+                ret[arr_idx] = false;
+
+                for (size_t j = 0; j < n_chars; j++) {
+                    if (ws_chars[j] == ch) {
+                        ret[arr_idx] = true;
+                    }
+                }
+            }
+
+            return ret;
+        }
+
+        inline WhitespaceMap make_ws_flags(const std::vector<char>& flags) {
+            return make_ws_flags(flags.data(), flags.size());
+        }
+
+        CSV_INLINE size_t get_file_size(csv::string_view filename);
+
+        CSV_INLINE std::string get_csv_head(csv::string_view filename);
+
+        template<typename TStream,
+            csv::enable_if_t<std::is_base_of<std::istream, TStream>::value, int>  = 0>
+        std::string get_csv_head(TStream &source) {
+            auto tellg = source.tellg();
+            std::string head;
+            std::getline(source, head);
+            source.seekg(tellg);
+            return head;
+        }
+
+        /** Read the first 500KB of a CSV file */
+        CSV_INLINE std::string get_csv_head(csv::string_view filename, size_t file_size);
+
+        /** A std::deque wrapper which allows multiple read and write threads to concurrently
+         *  access it along with providing read threads the ability to wait for the deque
+         *  to become populated
+         */
+        template<typename T>
+        class ThreadSafeDeque {
+        public:
+            ThreadSafeDeque(size_t notify_size = 100) : _notify_size(notify_size) {};
+            ThreadSafeDeque(const ThreadSafeDeque& other) {
+                this->data = other.data;
+                this->_notify_size = other._notify_size;
+            }
+
+            ThreadSafeDeque(const std::deque<T>& source) : ThreadSafeDeque() {
+                this->data = source;
+            }
+
+            void clear() noexcept { this->data.clear(); }
+
+            bool empty() const noexcept {
+                return this->data.empty();
+            }
+
+            T& front() noexcept {
+                return this->data.front();
+            }
+
+            T& operator[](size_t n) {
+                return this->data[n];
+            }
+
+            void push_back(T&& item) {
+                std::lock_guard<std::mutex> lock{ this->_lock };
+                this->data.push_back(std::move(item));
+
+                if (this->size() >= _notify_size) {
+                    this->_cond.notify_all();
+                }
+            }
+
+            T pop_front() noexcept {
+                std::lock_guard<std::mutex> lock{ this->_lock };
+                T item = std::move(data.front());
+                data.pop_front();
+                return item;
+            }
+
+            size_t size() const noexcept { return this->data.size(); }
+
+            /** Returns true if a thread is actively pushing items to this deque */
+            constexpr bool is_waitable() const noexcept { return this->_is_waitable; }
+
+            /** Wait for an item to become available */
+            void wait() {
+                if (!is_waitable()) {
+                    return;
+                }
+
+                std::unique_lock<std::mutex> lock{ this->_lock };
+                this->_cond.wait(lock, [this] { return this->size() >= _notify_size || !this->is_waitable(); });
+                lock.unlock();
+            }
+
+            typename std::deque<T>::iterator begin() noexcept {
+                return this->data.begin();
+            }
+
+            typename std::deque<T>::iterator end() noexcept {
+                return this->data.end();
+            }
+
+            /** Tell listeners that this deque is actively being pushed to */
+            void notify_all() {
+                std::unique_lock<std::mutex> lock{ this->_lock };
+                this->_is_waitable = true;
+                this->_cond.notify_all();
+            }
+
+            /** Tell all listeners to stop */
+            void kill_all() {
+                std::unique_lock<std::mutex> lock{ this->_lock };
+                this->_is_waitable = false;
+                this->_cond.notify_all();
+            }
+
+        private:
+            bool _is_waitable = false;
+            size_t _notify_size;
+            std::mutex _lock;
+            std::condition_variable _cond;
+            std::deque<T> data;
+        };
+
+        constexpr const int UNINITIALIZED_FIELD = -1;
+    }
+
+    /** Standard type for storing collection of rows */
+    using RowCollection = internals::ThreadSafeDeque<CSVRow>;
+
+    namespace internals {
+        /** Abstract base class which provides CSV parsing logic.
+         *
+         *  Concrete implementations may customize this logic across
+         *  different input sources, such as memory mapped files, stringstreams,
+         *  etc...
+         */
+        class IBasicCSVParser {
+        public:
+            IBasicCSVParser() = default;
+            IBasicCSVParser(const CSVFormat&, const ColNamesPtr&);
+            IBasicCSVParser(const ParseFlagMap& parse_flags, const WhitespaceMap& ws_flags
+            ) : _parse_flags(parse_flags), _ws_flags(ws_flags) {};
+
+            virtual ~IBasicCSVParser() {}
+
+            /** Whether or not we have reached the end of source */
+            bool eof() { return this->_eof; }
+
+            /** Parse the next block of data */
+            virtual void next(size_t bytes) = 0;
+
+            /** Indicate the last block of data has been parsed */
+            void end_feed();
+
+            CONSTEXPR_17 ParseFlags parse_flag(const char ch) const noexcept {
+                return _parse_flags.data()[ch + 128];
+            }
+
+            CONSTEXPR_17 ParseFlags compound_parse_flag(const char ch) const noexcept {
+                return quote_escape_flag(parse_flag(ch), this->quote_escape);
+            }
+
+            /** Whether or not this CSV has a UTF-8 byte order mark */
+            CONSTEXPR bool utf8_bom() const { return this->_utf8_bom; }
+
+            void set_output(RowCollection& rows) { this->_records = &rows; }
+
+        protected:
+            /** @name Current Parser State */
+            ///@{
+            CSVRow current_row;
+            RawCSVDataPtr data_ptr = nullptr;
+            ColNamesPtr _col_names = nullptr;
+            CSVFieldList* fields = nullptr;
+            int field_start = UNINITIALIZED_FIELD;
+            size_t field_length = 0;
+
+            /** An array where the (i + 128)th slot gives the ParseFlags for ASCII character i */
+            ParseFlagMap _parse_flags;
+            ///@}
+
+            /** @name Current Stream/File State */
+            ///@{
+            bool _eof = false;
+
+            /** The size of the incoming CSV */
+            size_t source_size = 0;
+            ///@}
+
+            /** Whether or not source needs to be read in chunks */
+            CONSTEXPR bool no_chunk() const { return this->source_size < ITERATION_CHUNK_SIZE; }
+
+            /** Parse the current chunk of data *
+             *
+             *  @returns How many character were read that are part of complete rows
+             */
+            size_t parse();
+
+            /** Create a new RawCSVDataPtr for a new chunk of data */
+            void reset_data_ptr();
+        private:
+            /** An array where the (i + 128)th slot determines whether ASCII character i should
+             *  be trimmed
+             */
+            WhitespaceMap _ws_flags;
+            bool quote_escape = false;
+            bool field_has_double_quote = false;
+
+            /** Where we are in the current data block */
+            size_t data_pos = 0;
+
+            /** Whether or not an attempt to find Unicode BOM has been made */
+            bool unicode_bom_scan = false;
+            bool _utf8_bom = false;
+
+            /** Where complete rows should be pushed to */
+            RowCollection* _records = nullptr;
+
+            CONSTEXPR_17 bool ws_flag(const char ch) const noexcept {
+                return _ws_flags.data()[ch + 128];
+            }
+
+            size_t& current_row_start() {
+                return this->current_row.data_start;
+            }
+
+            void parse_field() noexcept;
+
+            /** Finish parsing the current field */
+            void push_field();
+
+            /** Finish parsing the current row */
+            void push_row();
+
+            /** Handle possible Unicode byte order mark */
+            void trim_utf8_bom();
+        };
+
+        /** A class for parsing CSV data from a `std::stringstream`
+         *  or an `std::ifstream`
+         */
+        template<typename TStream>
+        class StreamParser: public IBasicCSVParser {
+            using RowCollection = ThreadSafeDeque<CSVRow>;
+
+        public:
+            StreamParser(TStream& source,
+                const CSVFormat& format,
+                const ColNamesPtr& col_names = nullptr
+            ) : IBasicCSVParser(format, col_names), _source(std::move(source)) {};
+
+            StreamParser(
+                TStream& source,
+                internals::ParseFlagMap parse_flags,
+                internals::WhitespaceMap ws_flags) :
+                IBasicCSVParser(parse_flags, ws_flags),
+                _source(std::move(source))
+            {};
+
+            ~StreamParser() {}
+
+            void next(size_t bytes = ITERATION_CHUNK_SIZE) override {
+                if (this->eof()) return;
+
+                // Reset parser state
+                this->field_start = UNINITIALIZED_FIELD;
+                this->field_length = 0;
+                this->reset_data_ptr();
+                this->data_ptr->_data = std::make_shared<std::string>();
+
+                if (source_size == 0) {
+                    const auto start = _source.tellg();
+                    _source.seekg(0, std::ios::end);
+                    const auto end = _source.tellg();
+                    _source.seekg(0, std::ios::beg);
+
+                    source_size = end - start;
+                }
+
+                // Read data into buffer
+                size_t length = std::min(source_size - stream_pos, bytes);
+                std::unique_ptr<char[]> buff(new char[length]);
+                _source.seekg(stream_pos, std::ios::beg);
+                _source.read(buff.get(), length);
+                stream_pos = _source.tellg();
+                ((std::string*)(this->data_ptr->_data.get()))->assign(buff.get(), length);
+
+                // Create string_view
+                this->data_ptr->data = *((std::string*)this->data_ptr->_data.get());
+
+                // Parse
+                this->current_row = CSVRow(this->data_ptr);
+                size_t remainder = this->parse();
+
+                if (stream_pos == source_size || no_chunk()) {
+                    this->_eof = true;
+                    this->end_feed();
+                }
+                else {
+                    this->stream_pos -= (length - remainder);
+                }
+            }
+
+        private:
+            TStream _source;
+            size_t stream_pos = 0;
+        };
+
+        /** Parser for memory-mapped files
+         *
+         *  @par Implementation
+         *  This class constructs moving windows over a file to avoid
+         *  creating massive memory maps which may require more RAM
+         *  than the user has available. It contains logic to automatically
+         *  re-align each memory map to the beginning of a CSV row.
+         *
+         */
+        class MmapParser : public IBasicCSVParser {
+        public:
+            MmapParser(csv::string_view filename,
+                const CSVFormat& format,
+                const ColNamesPtr& col_names = nullptr
+            ) : IBasicCSVParser(format, col_names) {
+                this->_filename = filename.data();
+                this->source_size = get_file_size(filename);
+            };
+
+            ~MmapParser() {}
+
+            void next(size_t bytes) override;
+
+        private:
+            std::string _filename;
+            size_t mmap_pos = 0;
+        };
+    }
+}
+
+
+/** The all encompassing namespace */
+namespace csv {
+    /** Stuff that is generally not of interest to end-users */
+    namespace internals {
+        std::string format_row(const std::vector<std::string>& row, csv::string_view delim = ", ");
+
+        std::vector<std::string> _get_col_names( csv::string_view head, const CSVFormat format = CSVFormat::guess_csv());
+
+        struct GuessScore {
+            double score;
+            size_t header;
+        };
+
+        CSV_INLINE GuessScore calculate_score(csv::string_view head, const CSVFormat& format);
+
+        CSVGuessResult _guess_format(csv::string_view head, const std::vector<char>& delims = { ',', '|', '\t', ';', '^', '~' });
+    }
+
+    std::vector<std::string> get_col_names(
+        csv::string_view filename,
+        const CSVFormat format = CSVFormat::guess_csv());
+
+    /** Guess the delimiter used by a delimiter-separated values file */
+    CSVGuessResult guess_format(csv::string_view filename,
+        const std::vector<char>& delims = { ',', '|', '\t', ';', '^', '~' });
+
+    /** @class CSVReader
+     *  @brief Main class for parsing CSVs from files and in-memory sources
+     *
+     *  All rows are compared to the column names for length consistency
+     *  - By default, rows that are too short or too long are dropped
+     *  - Custom behavior can be defined by overriding bad_row_handler in a subclass
+     */
+    class CSVReader {
+    public:
+        /**
+         * An input iterator capable of handling large files.
+         * @note Created by CSVReader::begin() and CSVReader::end().
+         *
+         * @par Iterating over a file
+         * @snippet tests/test_csv_iterator.cpp CSVReader Iterator 1
+         *
+         * @par Using with `<algorithm>` library
+         * @snippet tests/test_csv_iterator.cpp CSVReader Iterator 2
+         */
+        class iterator {
+        public:
+            #ifndef DOXYGEN_SHOULD_SKIP_THIS
+            using value_type = CSVRow;
+            using difference_type = std::ptrdiff_t;
+            using pointer = CSVRow * ;
+            using reference = CSVRow & ;
+            using iterator_category = std::input_iterator_tag;
+            #endif
+
+            iterator() = default;
+            iterator(CSVReader* reader) : daddy(reader) {};
+            iterator(CSVReader*, CSVRow&&);
+
+            /** Access the CSVRow held by the iterator */
+            CONSTEXPR_14 reference operator*() { return this->row; }
+
+            /** Return a pointer to the CSVRow the iterator has stopped at */
+            CONSTEXPR_14 pointer operator->() { return &(this->row); }
+
+            iterator& operator++();   /**< Pre-increment iterator */
+            iterator operator++(int); /**< Post-increment iterator */
+
+            /** Returns true if iterators were constructed from the same CSVReader
+             *  and point to the same row
+             */
+            CONSTEXPR bool operator==(const iterator& other) const noexcept {
+                return (this->daddy == other.daddy) && (this->i == other.i);
+            }
+
+            CONSTEXPR bool operator!=(const iterator& other) const noexcept { return !operator==(other); }
+        private:
+            CSVReader * daddy = nullptr;  // Pointer to parent
+            CSVRow row;                   // Current row
+            size_t i = 0;               // Index of current row
+        };
+
+        /** @name Constructors
+         *  Constructors for iterating over large files and parsing in-memory sources.
+         */
+         ///@{
+        CSVReader(csv::string_view filename, CSVFormat format = CSVFormat::guess_csv());
+
+        /** Allows parsing stream sources such as `std::stringstream` or `std::ifstream`
+         *
+         *  @tparam TStream An input stream deriving from `std::istream`
+         *  @note   Currently this constructor requires special CSV dialects to be manually
+         *          specified.
+         */
+        template<typename TStream,
+            csv::enable_if_t<std::is_base_of<std::istream, TStream>::value, int> = 0>
+        CSVReader(TStream &source, CSVFormat format = CSVFormat::guess_csv()) : _format(format) {
+            auto head = internals::get_csv_head(source);
+            using Parser = internals::StreamParser<TStream>;
+
+            if (format.guess_delim()) {
+                auto guess_result = internals::_guess_format(head, format.possible_delimiters);
+                format.delimiter(guess_result.delim);
+                format.header = guess_result.header_row;
+                this->_format = format;
+            }
+
+            if (!format.col_names.empty())
+                this->set_col_names(format.col_names);
+
+            this->parser = std::unique_ptr<Parser>(
+                new Parser(source, format, col_names)); // For C++11
+            this->initial_read();
+        }
+        ///@}
+
+        CSVReader(const CSVReader&) = delete; // No copy constructor
+        CSVReader(CSVReader&&) = default;     // Move constructor
+        CSVReader& operator=(const CSVReader&) = delete; // No copy assignment
+        CSVReader& operator=(CSVReader&& other) = default;
+        ~CSVReader() {
+            if (this->read_csv_worker.joinable()) {
+                this->read_csv_worker.join();
+            }
+        }
+
+        /** @name Retrieving CSV Rows */
+        ///@{
+        bool read_row(CSVRow &row);
+        iterator begin();
+        HEDLEY_CONST iterator end() const noexcept;
+
+        /** Returns true if we have reached end of file */
+        bool eof() const noexcept { return this->parser->eof(); };
+        ///@}
+
+        /** @name CSV Metadata */
+        ///@{
+        CSVFormat get_format() const;
+        std::vector<std::string> get_col_names() const;
+        int index_of(csv::string_view col_name) const;
+        ///@}
+
+        /** @name CSV Metadata: Attributes */
+        ///@{
+        /** Whether or not the file or stream contains valid CSV rows,
+         *  not including the header.
+         *
+         *  @note Gives an accurate answer regardless of when it is called.
+         *
+         */
+        CONSTEXPR bool empty() const noexcept { return this->n_rows() == 0; }
+
+        /** Retrieves the number of rows that have been read so far */
+        CONSTEXPR size_t n_rows() const noexcept { return this->_n_rows; }
+
+        /** Whether or not CSV was prefixed with a UTF-8 bom */
+        bool utf8_bom() const noexcept { return this->parser->utf8_bom(); }
+        ///@}
+
+    protected:
+        /**
+         * \defgroup csv_internal CSV Parser Internals
+         * @brief Internals of CSVReader. Only maintainers and those looking to
+         *        extend the parser should read this.
+         * @{
+         */
+
+        /** Sets this reader's column names and associated data */
+        void set_col_names(const std::vector<std::string>&);
+
+        /** @name CSV Settings **/
+        ///@{
+        CSVFormat _format;
+        ///@}
+
+        /** @name Parser State */
+        ///@{
+        /** Pointer to a object containing column information */
+        internals::ColNamesPtr col_names = std::make_shared<internals::ColNames>();
+
+        /** Helper class which actually does the parsing */
+        std::unique_ptr<internals::IBasicCSVParser> parser = nullptr;
+
+        /** Queue of parsed CSV rows */
+        std::unique_ptr<RowCollection> records{new RowCollection(100)};
+
+        size_t n_cols = 0;  /**< The number of columns in this CSV */
+        size_t _n_rows = 0; /**< How many rows (minus header) have been read so far */
+
+        /** @name Multi-Threaded File Reading Functions */
+        ///@{
+        bool read_csv(size_t bytes = internals::ITERATION_CHUNK_SIZE);
+        ///@}
+
+        /**@}*/
+
+    private:
+        /** Whether or not rows before header were trimmed */
+        bool header_trimmed = false;
+
+        /** @name Multi-Threaded File Reading: Flags and State */
+        ///@{
+        std::thread read_csv_worker; /**< Worker thread for read_csv() */
+        ///@}
+
+        /** Read initial chunk to get metadata */
+        void initial_read() {
+            this->read_csv_worker = std::thread(&CSVReader::read_csv, this, internals::ITERATION_CHUNK_SIZE);
+            this->read_csv_worker.join();
+        }
+
+        void trim_header();
+    };
+}
+
+/** @file
+ *  Calculates statistics from CSV files
+ */
+
+#include <unordered_map>
+#include <sstream>
+#include <vector>
+
+namespace csv {
+    /** Class for calculating statistics from CSV files and in-memory sources
+     *
+     *  **Example**
+     *  \include programs/csv_stats.cpp
+     *
+     */
+    class CSVStat {
+    public:
+        using FreqCount = std::unordered_map<std::string, size_t>;
+        using TypeCount = std::unordered_map<DataType, size_t>;
+
+        std::vector<long double> get_mean() const;
+        std::vector<long double> get_variance() const;
+        std::vector<long double> get_mins() const;
+        std::vector<long double> get_maxes() const;
+        std::vector<FreqCount> get_counts() const;
+        std::vector<TypeCount> get_dtypes() const;
+
+        std::vector<std::string> get_col_names() const {
+            return this->reader.get_col_names();
+        }
+
+        CSVStat(csv::string_view filename, CSVFormat format = CSVFormat::guess_csv());
+        CSVStat(std::stringstream& source, CSVFormat format = CSVFormat());
+    private:
+        // An array of rolling averages
+        // Each index corresponds to the rolling mean for the column at said index
+        std::vector<long double> rolling_means;
+        std::vector<long double> rolling_vars;
+        std::vector<long double> mins;
+        std::vector<long double> maxes;
+        std::vector<FreqCount> counts;
+        std::vector<TypeCount> dtypes;
+        std::vector<long double> n;
+
+        // Statistic calculators
+        void variance(const long double&, const size_t&);
+        void count(CSVField&, const size_t&);
+        void min_max(const long double&, const size_t&);
+        void dtype(CSVField&, const size_t&);
+
+        void calc();
+        void calc_chunk();
+        void calc_worker(const size_t&);
+
+        CSVReader reader;
+        std::deque<CSVRow> records = {};
+    };
+}
+
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+namespace csv {
+    /** Returned by get_file_info() */
+    struct CSVFileInfo {
+        std::string filename;               /**< Filename */
+        std::vector<std::string> col_names; /**< CSV column names */
+        char delim;                         /**< Delimiting character */
+        size_t n_rows;                      /**< Number of rows in a file */
+        size_t n_cols;                      /**< Number of columns in a CSV */
+    };
+
+    /** @name Shorthand Parsing Functions
+     *  @brief Convienience functions for parsing small strings
+     */
+     ///@{
+    CSVReader operator ""_csv(const char*, size_t);
+    CSVReader operator ""_csv_no_header(const char*, size_t);
+    CSVReader parse(csv::string_view in, CSVFormat format = CSVFormat());
+    CSVReader parse_no_header(csv::string_view in);
+    ///@}
+
+    /** @name Utility Functions */
+    ///@{
+    std::unordered_map<std::string, DataType> csv_data_types(const std::string&);
+    CSVFileInfo get_file_info(const std::string& filename);
+    int get_col_pos(csv::string_view filename, csv::string_view col_name,
+        const CSVFormat& format = CSVFormat::guess_csv());
+    ///@}
+}
+/** @file
+  *  A standalone header file for writing delimiter-separated files
+  */
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+
+namespace csv {
+    namespace internals {
+        static int DECIMAL_PLACES = 5;
+
+        /**
+         * Calculate the absolute value of a number
+         */
+        template<typename T = int>
+        inline T csv_abs(T x) {
+            return abs(x);
+        }
+
+        template<>
+        inline int csv_abs(int x) {
+            return abs(x);
+        }
+
+        template<>
+        inline long int csv_abs(long int x) {
+            return labs(x);
+        }
+
+        template<>
+        inline long long int csv_abs(long long int x) {
+            return llabs(x);
+        }
+
+        template<>
+        inline float csv_abs(float x) {
+            return fabsf(x);
+        }
+
+        template<>
+        inline double csv_abs(double x) {
+            return fabs(x);
+        }
+
+        template<>
+        inline long double csv_abs(long double x) {
+            return fabsl(x);
+        }
+
+        /** 
+         * Calculate the number of digits in a number
+         */
+        template<
+            typename T,
+            csv::enable_if_t<std::is_arithmetic<T>::value, int> = 0
+        >
+        int num_digits(T x)
+        {
+            x = csv_abs(x);
+
+            int digits = 0;
+
+            while (x >= 1) {
+                x /= 10;
+                digits++;
+            }
+
+            return digits;
+        }
+
+        /** to_string() for unsigned integers */
+        template<typename T,
+            csv::enable_if_t<std::is_unsigned<T>::value, int> = 0>
+        inline std::string to_string(T value) {
+            std::string digits_reverse = "";
+
+            if (value == 0) return "0";
+
+            while (value > 0) {
+                digits_reverse += (char)('0' + (value % 10));
+                value /= 10;
+            }
+
+            return std::string(digits_reverse.rbegin(), digits_reverse.rend());
+        }
+
+        /** to_string() for signed integers */
+        template<
+            typename T,
+            csv::enable_if_t<std::is_integral<T>::value && std::is_signed<T>::value, int> = 0
+        >
+        inline std::string to_string(T value) {
+            if (value >= 0)
+                return to_string((size_t)value);
+
+            return "-" + to_string((size_t)(value * -1));
+        }
+
+        /** to_string() for floating point numbers */
+        template<
+            typename T,
+            csv::enable_if_t<std::is_floating_point<T>::value, int> = 0
+        >
+            inline std::string to_string(T value) {
+#ifdef __clang__
+            return std::to_string(value);
+#else
+            // TODO: Figure out why the below code doesn't work on clang
+                std::string result = "";
+
+                T integral_part;
+                T fractional_part = std::abs(std::modf(value, &integral_part));
+                integral_part = std::abs(integral_part);
+
+                // Integral part
+                if (value < 0) result = "-";
+
+                if (integral_part == 0) {
+                    result += "0";
+                }
+                else {
+                    for (int n_digits = num_digits(integral_part); n_digits > 0; n_digits --) {
+                        int digit = (int)(std::fmod(integral_part, pow10(n_digits)) / pow10(n_digits - 1));
+                        result += (char)('0' + digit);
+                    }
+                }
+
+                // Decimal part
+                result += ".";
+
+                if (fractional_part > 0) {
+                    fractional_part *= (T)(pow10(DECIMAL_PLACES));
+                    for (int n_digits = DECIMAL_PLACES; n_digits > 0; n_digits--) {
+                        int digit = (int)(std::fmod(fractional_part, pow10(n_digits)) / pow10(n_digits - 1));
+                        result += (char)('0' + digit);
+                    }
+                }
+                else {
+                    result += "0";
+                }
+
+                return result;
+#endif
+        }
+    }
+
+    /** Sets how many places after the decimal will be written for floating point numbers
+     *
+     *  @param  precision   Number of decimal places
+     */
+#ifndef __clang___
+    inline static void set_decimal_places(int precision) {
+        internals::DECIMAL_PLACES = precision;
+    }
+#endif
+
+    /** @name CSV Writing */
+    ///@{
+    /** 
+     *  Class for writing delimiter separated values files
+     *
+     *  To write formatted strings, one should
+     *   -# Initialize a DelimWriter with respect to some output stream 
+     *   -# Call write_row() on std::vector<std::string>s of unformatted text
+     *
+     *  @tparam OutputStream The output stream, e.g. `std::ofstream`, `std::stringstream`
+     *  @tparam Delim        The delimiter character
+     *  @tparam Quote        The quote character
+     *  @tparam Flush        True: flush after every writing function,
+     *                       false: you need to flush explicitly if needed.
+     *                       In both cases the destructor will flush.
+     *
+     *  @par Hint
+     *  Use the aliases csv::CSVWriter<OutputStream> to write CSV
+     *  formatted strings and csv::TSVWriter<OutputStream>
+     *  to write tab separated strings
+     *
+     *  @par Example w/ std::vector, std::deque, std::list
+     *  @snippet test_write_csv.cpp CSV Writer Example
+     *
+     *  @par Example w/ std::tuple
+     *  @snippet test_write_csv.cpp CSV Writer Tuple Example
+     */
+    template<class OutputStream, char Delim, char Quote, bool Flush>
+    class DelimWriter {
+    public:
+        /** Construct a DelimWriter over the specified output stream
+         *
+         *  @param  _out           Stream to write to
+         *  @param  _quote_minimal Limit field quoting to only when necessary
+        */
+
+        DelimWriter(OutputStream& _out, bool _quote_minimal = true)
+            : out(_out), quote_minimal(_quote_minimal) {};
+
+        /** Construct a DelimWriter over the file
+         *
+         *  @param[out] filename  File to write to
+         */
+        DelimWriter(const std::string& filename) : DelimWriter(std::ifstream(filename)) {};
+
+        /** Destructor will flush remaining data
+         *
+         */
+        ~DelimWriter() {
+            out.flush();
+        }
+
+        /** Format a sequence of strings and write to CSV according to RFC 4180
+         *
+         *  @warning This does not check to make sure row lengths are consistent
+         *
+         *  @param[in]  record          Sequence of strings to be formatted
+         *
+         *  @return  The current DelimWriter instance (allowing for operator chaining)
+         */
+        template<typename T, size_t Size>
+        DelimWriter& operator<<(const std::array<T, Size>& record) {
+            for (size_t i = 0; i < Size; i++) {
+                out << csv_escape(record[i]);
+                if (i + 1 != Size) out << Delim;
+            }
+
+            end_out();
+            return *this;
+        }
+
+        /** @copydoc operator<< */
+        template<typename... T>
+        DelimWriter& operator<<(const std::tuple<T...>& record) {
+            this->write_tuple<0, T...>(record);
+            return *this;
+        }
+
+        /**
+         * @tparam T A container such as std::vector, std::deque, or std::list
+         * 
+         * @copydoc operator<<
+         */
+        template<
+            typename T, typename Alloc, template <typename, typename> class Container,
+
+            // Avoid conflicting with tuples with two elements
+            csv::enable_if_t<std::is_class<Alloc>::value, int> = 0
+        >
+            DelimWriter& operator<<(const Container<T, Alloc>& record) {
+            const size_t ilen = record.size();
+            size_t i = 0;
+            for (const auto& field : record) {
+                out << csv_escape(field);
+                if (i + 1 != ilen) out << Delim;
+                i++;
+            }
+
+            end_out();
+            return *this;
+        }
+
+        /** Flushes the written data
+         *
+         */
+        void flush() {
+            out.flush();
+        }
+
+    private:
+        template<
+            typename T,
+            csv::enable_if_t<
+                !std::is_convertible<T, std::string>::value
+                && !std::is_convertible<T, csv::string_view>::value
+            , int> = 0
+        >
+        std::string csv_escape(T in) {
+            return internals::to_string(in);
+        }
+
+        template<
+            typename T,
+            csv::enable_if_t<
+                std::is_convertible<T, std::string>::value
+                || std::is_convertible<T, csv::string_view>::value
+            , int> = 0
+        >
+        std::string csv_escape(T in) {
+            IF_CONSTEXPR(std::is_convertible<T, csv::string_view>::value) {
+                return _csv_escape(in);
+            }
+            
+            return _csv_escape(std::string(in));
+        }
+
+        std::string _csv_escape(csv::string_view in) {
+            /** Format a string to be RFC 4180-compliant
+             *  @param[in]  in              String to be CSV-formatted
+             *  @param[out] quote_minimal   Only quote fields if necessary.
+             *                              If False, everything is quoted.
+             */
+
+            // Do we need a quote escape
+            bool quote_escape = false;
+
+            for (auto ch : in) {
+                if (ch == Quote || ch == Delim || ch == '\r' || ch == '\n') {
+                    quote_escape = true;
+                    break;
+                }
+            }
+
+            if (!quote_escape) {
+                if (quote_minimal) return std::string(in);
+                else {
+                    std::string ret(1, Quote);
+                    ret += in.data();
+                    ret += Quote;
+                    return ret;
+                }
+            }
+
+            // Start initial quote escape sequence
+            std::string ret(1, Quote);
+            for (auto ch: in) {
+                if (ch == Quote) ret += std::string(2, Quote);
+                else ret += ch;
+            }
+
+            // Finish off quote escape
+            ret += Quote;
+            return ret;
+        }
+
+        /** Recurisve template for writing std::tuples */
+        template<size_t Index = 0, typename... T>
+        typename std::enable_if<Index < sizeof...(T), void>::type write_tuple(const std::tuple<T...>& record) {
+            out << csv_escape(std::get<Index>(record));
+
+            IF_CONSTEXPR (Index + 1 < sizeof...(T)) out << Delim;
+
+            this->write_tuple<Index + 1>(record);
+        }
+
+        /** Base case for writing std::tuples */
+        template<size_t Index = 0, typename... T>
+        typename std::enable_if<Index == sizeof...(T), void>::type write_tuple(const std::tuple<T...>& record) {
+            (void)record;
+            end_out();
+        }
+
+        /** Ends a line in 'out' and flushes, if Flush is true.*/
+        void end_out() {
+            out << '\n';
+            IF_CONSTEXPR(Flush) out.flush();
+        }
+
+        OutputStream & out;
+        bool quote_minimal;
+    };
+
+    /** An alias for csv::DelimWriter for writing standard CSV files
+     *
+     *  @sa csv::DelimWriter::operator<<()
+     *
+     *  @note Use `csv::make_csv_writer()` to in instatiate this class over
+     *        an actual output stream.
+     */
+    template<class OutputStream, bool Flush = true>
+    using CSVWriter = DelimWriter<OutputStream, ',', '"', Flush>;
+
+    /** Class for writing tab-separated values files
+    *
+     *  @sa csv::DelimWriter::write_row()
+     *  @sa csv::DelimWriter::operator<<()
+     *
+     *  @note Use `csv::make_tsv_writer()` to in instatiate this class over
+     *        an actual output stream.
+     */
+    template<class OutputStream, bool Flush = true>
+    using TSVWriter = DelimWriter<OutputStream, '\t', '"', Flush>;
+
+    /** Return a csv::CSVWriter over the output stream */
+    template<class OutputStream>
+    inline CSVWriter<OutputStream> make_csv_writer(OutputStream& out, bool quote_minimal=true) {
+        return CSVWriter<OutputStream>(out, quote_minimal);
+    }
+
+    /** Return a buffered csv::CSVWriter over the output stream (does not auto flush) */
+    template<class OutputStream>
+    inline CSVWriter<OutputStream, false> make_csv_writer_buffered(OutputStream& out, bool quote_minimal=true) {
+        return CSVWriter<OutputStream, false>(out, quote_minimal);
+    }
+
+    /** Return a csv::TSVWriter over the output stream */
+    template<class OutputStream>
+    inline TSVWriter<OutputStream> make_tsv_writer(OutputStream& out, bool quote_minimal=true) {
+        return TSVWriter<OutputStream>(out, quote_minimal);
+    }
+
+    /** Return a buffered csv::TSVWriter over the output stream (does not auto flush) */
+    template<class OutputStream>
+    inline TSVWriter<OutputStream, false> make_tsv_writer_buffered(OutputStream& out, bool quote_minimal=true) {
+        return TSVWriter<OutputStream, false>(out, quote_minimal);
+    }
+    ///@}
+}
+
+#include <sstream>
+#include <vector>
+
+
+namespace csv {
+    /** Shorthand function for parsing an in-memory CSV string
+     *
+     *  @return A collection of CSVRow objects
+     *
+     *  @par Example
+     *  @snippet tests/test_read_csv.cpp Parse Example
+     */
+    CSV_INLINE CSVReader parse(csv::string_view in, CSVFormat format) {
+        std::stringstream stream(std::string(in.data(), in.length()));
+        return CSVReader(stream, format);
+    }
+
+    /** Parses a CSV string with no headers
+     *
+     *  @return A collection of CSVRow objects
+     */
+    CSV_INLINE CSVReader parse_no_header(csv::string_view in) {
+        CSVFormat format;
+        format.header_row(-1);
+
+        return parse(in, format);
+    }
+
+    /** Parse a RFC 4180 CSV string, returning a collection
+     *  of CSVRow objects
+     *
+     *  @par Example
+     *  @snippet tests/test_read_csv.cpp Escaped Comma
+     *
+     */
+    CSV_INLINE CSVReader operator ""_csv(const char* in, size_t n) {
+        return parse(csv::string_view(in, n));
+    }
+
+    /** A shorthand for csv::parse_no_header() */
+    CSV_INLINE CSVReader operator ""_csv_no_header(const char* in, size_t n) {
+        return parse_no_header(csv::string_view(in, n));
+    }
+
+    /**
+     *  Find the position of a column in a CSV file or CSV_NOT_FOUND otherwise
+     *
+     *  @param[in] filename  Path to CSV file
+     *  @param[in] col_name  Column whose position we should resolve
+     *  @param[in] format    Format of the CSV file
+     */
+    CSV_INLINE int get_col_pos(
+        csv::string_view filename,
+        csv::string_view col_name,
+        const CSVFormat& format) {
+        CSVReader reader(filename, format);
+        return reader.index_of(col_name);
+    }
+
+    /** Get basic information about a CSV file
+     *  @include programs/csv_info.cpp
+     */
+    CSV_INLINE CSVFileInfo get_file_info(const std::string& filename) {
+        CSVReader reader(filename);
+        CSVFormat format = reader.get_format();
+        for (auto it = reader.begin(); it != reader.end(); ++it);
+
+        CSVFileInfo info = {
+            filename,
+            reader.get_col_names(),
+            format.get_delim(),
+            reader.n_rows(),
+            reader.get_col_names().size()
+        };
+
+        return info;
+    }
+}
+/** @file
+ *  Defines an object used to store CSV format settings
+ */
+
+#include <algorithm>
+#include <set>
+
+
+namespace csv {
+    CSV_INLINE CSVFormat& CSVFormat::delimiter(char delim) {
+        this->possible_delimiters = { delim };
+        this->assert_no_char_overlap();
+        return *this;
+    }
+
+    CSV_INLINE CSVFormat& CSVFormat::delimiter(const std::vector<char> & delim) {
+        this->possible_delimiters = delim;
+        this->assert_no_char_overlap();
+        return *this;
+    }
+
+    CSV_INLINE CSVFormat& CSVFormat::quote(char quote) {
+        this->no_quote = false;
+        this->quote_char = quote;
+        this->assert_no_char_overlap();
+        return *this;
+    }
+
+    CSV_INLINE CSVFormat& CSVFormat::trim(const std::vector<char> & chars) {
+        this->trim_chars = chars;
+        this->assert_no_char_overlap();
+        return *this;
+    }
+
+    CSV_INLINE CSVFormat& CSVFormat::column_names(const std::vector<std::string>& names) {
+        this->col_names = names;
+        this->header = -1;
+        return *this;
+    }
+
+    CSV_INLINE CSVFormat& CSVFormat::header_row(int row) {
+        if (row < 0) this->variable_column_policy = VariableColumnPolicy::KEEP;
+
+        this->header = row;
+        this->col_names = {};
+        return *this;
+    }
+
+    CSV_INLINE void CSVFormat::assert_no_char_overlap()
+    {
+        auto delims = std::set<char>(
+            this->possible_delimiters.begin(), this->possible_delimiters.end()),
+            trims = std::set<char>(
+                this->trim_chars.begin(), this->trim_chars.end());
+
+        // Stores intersection of possible delimiters and trim characters
+        std::vector<char> intersection = {};
+
+        // Find which characters overlap, if any
+        std::set_intersection(
+            delims.begin(), delims.end(),
+            trims.begin(), trims.end(),
+            std::back_inserter(intersection));
+
+        // Make sure quote character is not contained in possible delimiters
+        // or whitespace characters
+        if (delims.find(this->quote_char) != delims.end() ||
+            trims.find(this->quote_char) != trims.end()) {
+            intersection.push_back(this->quote_char);
+        }
+
+        if (!intersection.empty()) {
+            std::string err_msg = "There should be no overlap between the quote character, "
+                "the set of possible delimiters "
+                "and the set of whitespace characters. Offending characters: ";
+
+            // Create a pretty error message with the list of overlapping
+            // characters
+            for (size_t i = 0; i < intersection.size(); i++) {
+                err_msg += "'";
+                err_msg += intersection[i];
+                err_msg += "'";
+
+                if (i + 1 < intersection.size())
+                    err_msg += ", ";
+            }
+
+            throw std::runtime_error(err_msg + '.');
+        }
+    }
+}
+
+namespace csv {
+    namespace internals {
+        CSV_INLINE size_t get_file_size(csv::string_view filename) {
+            std::ifstream infile(std::string(filename), std::ios::binary);
+            const auto start = infile.tellg();
+            infile.seekg(0, std::ios::end);
+            const auto end = infile.tellg();
+
+            return end - start;
+        }
+
+        CSV_INLINE std::string get_csv_head(csv::string_view filename) {
+            return get_csv_head(filename, get_file_size(filename));
+        }
+
+        CSV_INLINE std::string get_csv_head(csv::string_view filename, size_t file_size) {
+            const size_t bytes = 500000;
+
+            std::error_code error;
+            size_t length = std::min((size_t)file_size, bytes);
+            auto mmap = mio::make_mmap_source(std::string(filename), 0, length, error);
+
+            if (error) {
+                throw std::runtime_error("Cannot open file " + std::string(filename));
+            }
+
+            return std::string(mmap.begin(), mmap.end());
+        }
+
+#ifdef _MSC_VER
+#pragma region IBasicCVParser
+#endif
+        CSV_INLINE IBasicCSVParser::IBasicCSVParser(
+            const CSVFormat& format,
+            const ColNamesPtr& col_names
+        ) : _col_names(col_names) {
+            if (format.no_quote) {
+                _parse_flags = internals::make_parse_flags(format.get_delim());
+            }
+            else {
+                _parse_flags = internals::make_parse_flags(format.get_delim(), format.quote_char);
+            }
+
+            _ws_flags = internals::make_ws_flags(
+                format.trim_chars.data(), format.trim_chars.size()
+            );
+        }
+
+        CSV_INLINE void IBasicCSVParser::end_feed() {
+            using internals::ParseFlags;
+
+            bool empty_last_field = this->data_ptr
+                && this->data_ptr->_data
+                && !this->data_ptr->data.empty()
+                && (parse_flag(this->data_ptr->data.back()) == ParseFlags::DELIMITER
+                    || parse_flag(this->data_ptr->data.back()) == ParseFlags::QUOTE);
+
+            // Push field
+            if (this->field_length > 0 || empty_last_field) {
+                this->push_field();
+            }
+
+            // Push row
+            if (this->current_row.size() > 0)
+                this->push_row();
+        }
+
+        CSV_INLINE void IBasicCSVParser::parse_field() noexcept {
+            using internals::ParseFlags;
+            auto& in = this->data_ptr->data;
+
+            // Trim off leading whitespace
+            while (data_pos < in.size() && ws_flag(in[data_pos]))
+                data_pos++;
+
+            if (field_start == UNINITIALIZED_FIELD)
+                field_start = (int)(data_pos - current_row_start());
+
+            // Optimization: Since NOT_SPECIAL characters tend to occur in contiguous
+            // sequences, use the loop below to avoid having to go through the outer
+            // switch statement as much as possible
+            while (data_pos < in.size() && compound_parse_flag(in[data_pos]) == ParseFlags::NOT_SPECIAL)
+                data_pos++;
+
+            field_length = data_pos - (field_start + current_row_start());
+
+            // Trim off trailing whitespace, this->field_length constraint matters
+            // when field is entirely whitespace
+            for (size_t j = data_pos - 1; ws_flag(in[j]) && this->field_length > 0; j--)
+                this->field_length--;
+        }
+
+        CSV_INLINE void IBasicCSVParser::push_field()
+        {
+            // Update
+            if (field_has_double_quote) {
+                fields->emplace_back(
+                    field_start == UNINITIALIZED_FIELD ? 0 : (unsigned int)field_start,
+                    field_length,
+                    true
+                );
+                field_has_double_quote = false;
+
+            }
+            else {
+                fields->emplace_back(
+                    field_start == UNINITIALIZED_FIELD ? 0 : (unsigned int)field_start,
+                    field_length
+                );
+            }
+
+            current_row.row_length++;
+
+            // Reset field state
+            field_start = UNINITIALIZED_FIELD;
+            field_length = 0;
+        }
+
+        /** @return The number of characters parsed that belong to complete rows */
+        CSV_INLINE size_t IBasicCSVParser::parse()
+        {
+            using internals::ParseFlags;
+
+            this->quote_escape = false;
+            this->data_pos = 0;
+            this->current_row_start() = 0;
+            this->trim_utf8_bom();
+
+            auto& in = this->data_ptr->data;
+            while (this->data_pos < in.size()) {
+                switch (compound_parse_flag(in[this->data_pos])) {
+                case ParseFlags::DELIMITER:
+                    this->push_field();
+                    this->data_pos++;
+                    break;
+
+                case ParseFlags::NEWLINE:
+                    this->data_pos++;
+
+                    // Catches CRLF (or LFLF, CRCRLF, or any other non-sensical combination of newlines)
+                    while (this->data_pos < in.size() && parse_flag(in[this->data_pos]) == ParseFlags::NEWLINE)
+                        this->data_pos++;
+
+                    // End of record -> Write record
+                    this->push_field();
+                    this->push_row();
+
+                    // Reset
+                    this->current_row = CSVRow(data_ptr, this->data_pos, fields->size());
+                    break;
+
+                case ParseFlags::NOT_SPECIAL:
+                    this->parse_field();
+                    break;
+
+                case ParseFlags::QUOTE_ESCAPE_QUOTE:
+                    if (data_pos + 1 == in.size()) return this->current_row_start();
+                    else if (data_pos + 1 < in.size()) {
+                        auto next_ch = parse_flag(in[data_pos + 1]);
+                        if (next_ch >= ParseFlags::DELIMITER) {
+                            quote_escape = false;
+                            data_pos++;
+                            break;
+                        }
+                        else if (next_ch == ParseFlags::QUOTE) {
+                            // Case: Escaped quote
+                            data_pos += 2;
+                            this->field_length += 2;
+                            this->field_has_double_quote = true;
+                            break;
+                        }
+                    }
+                    
+                    // Case: Unescaped single quote => not strictly valid but we'll keep it
+                    this->field_length++;
+                    data_pos++;
+
+                    break;
+
+                default: // Quote (currently not quote escaped)
+                    if (this->field_length == 0) {
+                        quote_escape = true;
+                        data_pos++;
+                        if (field_start == UNINITIALIZED_FIELD && data_pos < in.size() && !ws_flag(in[data_pos]))
+                            field_start = (int)(data_pos - current_row_start());
+                        break;
+                    }
+
+                    // Case: Unescaped quote
+                    this->field_length++;
+                    data_pos++;
+
+                    break;
+                }
+            }
+
+            return this->current_row_start();
+        }
+
+        CSV_INLINE void IBasicCSVParser::push_row() {
+            current_row.row_length = fields->size() - current_row.fields_start;
+            this->_records->push_back(std::move(current_row));
+        }
+
+        CSV_INLINE void IBasicCSVParser::reset_data_ptr() {
+            this->data_ptr = std::make_shared<RawCSVData>();
+            this->data_ptr->parse_flags = this->_parse_flags;
+            this->data_ptr->col_names = this->_col_names;
+            this->fields = &(this->data_ptr->fields);
+        }
+
+        CSV_INLINE void IBasicCSVParser::trim_utf8_bom() {
+            auto& data = this->data_ptr->data;
+
+            if (!this->unicode_bom_scan && data.size() >= 3) {
+                if (data[0] == '\xEF' && data[1] == '\xBB' && data[2] == '\xBF') {
+                    this->data_pos += 3; // Remove BOM from input string
+                    this->_utf8_bom = true;
+                }
+
+                this->unicode_bom_scan = true;
+            }
+        }
+#ifdef _MSC_VER
+#pragma endregion
+#endif
+
+#ifdef _MSC_VER
+#pragma region Specializations
+#endif
+        CSV_INLINE void MmapParser::next(size_t bytes = ITERATION_CHUNK_SIZE) {
+            // Reset parser state
+            this->field_start = UNINITIALIZED_FIELD;
+            this->field_length = 0;
+            this->reset_data_ptr();
+
+            // Create memory map
+            size_t length = std::min(this->source_size - this->mmap_pos, bytes);
+            std::error_code error;
+            this->data_ptr->_data = std::make_shared<mio::basic_mmap_source<char>>(mio::make_mmap_source(this->_filename, this->mmap_pos, length, error));
+            this->mmap_pos += length;
+            if (error) throw error;
+
+            auto mmap_ptr = (mio::basic_mmap_source<char>*)(this->data_ptr->_data.get());
+
+            // Create string view
+            this->data_ptr->data = csv::string_view(mmap_ptr->data(), mmap_ptr->length());
+
+            // Parse
+            this->current_row = CSVRow(this->data_ptr);
+            size_t remainder = this->parse();            
+
+            if (this->mmap_pos == this->source_size || no_chunk()) {
+                this->_eof = true;
+                this->end_feed();
+            }
+
+            this->mmap_pos -= (length - remainder);
+        }
+#ifdef _MSC_VER
+#pragma endregion
+#endif
+    }
+}
+
+
+namespace csv {
+    namespace internals {
+        CSV_INLINE std::vector<std::string> ColNames::get_col_names() const {
+            return this->col_names;
+        }
+
+        CSV_INLINE void ColNames::set_col_names(const std::vector<std::string>& cnames) {
+            this->col_names = cnames;
+
+            for (size_t i = 0; i < cnames.size(); i++) {
+                this->col_pos[cnames[i]] = i;
+            }
+        }
+
+        CSV_INLINE int ColNames::index_of(csv::string_view col_name) const {
+            auto pos = this->col_pos.find(col_name.data());
+            if (pos != this->col_pos.end())
+                return (int)pos->second;
+
+            return CSV_NOT_FOUND;
+        }
+
+        CSV_INLINE size_t ColNames::size() const noexcept {
+            return this->col_names.size();
+        }
+
+    }
+}
+/** @file
+ *  Defines the data type used for storing information about a CSV row
+ */
+
+#include <cassert>
+#include <functional>
+
+namespace csv {
+    namespace internals {
+        CSV_INLINE RawCSVField& CSVFieldList::operator[](size_t n) const {
+            const size_t page_no = n / _single_buffer_capacity;
+            const size_t buffer_idx = (page_no < 1) ? n : n % _single_buffer_capacity;
+            return this->buffers[page_no][buffer_idx];
+        }
+
+        CSV_INLINE void CSVFieldList::allocate() {
+            buffers.push_back(std::unique_ptr<RawCSVField[]>(new RawCSVField[_single_buffer_capacity]));
+
+            _current_buffer_size = 0;
+            _back = buffers.back().get();
+        }
+    }
+
+    /** Return a CSVField object corrsponding to the nth value in the row.
+     *
+     *  @note This method performs bounds checking, and will throw an
+     *        `std::runtime_error` if n is invalid.
+     *
+     *  @complexity
+     *  Constant, by calling csv::CSVRow::get_csv::string_view()
+     *
+     */
+    CSV_INLINE CSVField CSVRow::operator[](size_t n) const {
+        return CSVField(this->get_field(n));
+    }
+
+    /** Retrieve a value by its associated column name. If the column
+     *  specified can't be round, a runtime error is thrown.
+     *
+     *  @complexity
+     *  Constant. This calls the other CSVRow::operator[]() after
+     *  converting column names into indices using a hash table.
+     *
+     *  @param[in] col_name The column to look for
+     */
+    CSV_INLINE CSVField CSVRow::operator[](const std::string& col_name) const {
+        auto & col_names = this->data->col_names;
+        auto col_pos = col_names->index_of(col_name);
+        if (col_pos > -1) {
+            return this->operator[](col_pos);
+        }
+
+        throw std::runtime_error("Can't find a column named " + col_name);
+    }
+
+    CSV_INLINE CSVRow::operator std::vector<std::string>() const {
+        std::vector<std::string> ret;
+        for (size_t i = 0; i < size(); i++)
+            ret.push_back(std::string(this->get_field(i)));
+
+        return ret;
+    }
+
+    CSV_INLINE csv::string_view CSVRow::get_field(size_t index) const
+    {
+        using internals::ParseFlags;
+
+        if (index >= this->size())
+            throw std::runtime_error("Index out of bounds.");
+
+        const size_t field_index = this->fields_start + index;
+        auto& field = this->data->fields[field_index];
+        auto field_str = csv::string_view(this->data->data).substr(this->data_start + field.start);
+
+        if (field.has_double_quote) {
+            auto& value = this->data->double_quote_fields[field_index];
+            if (value.empty()) {
+                bool prev_ch_quote = false;
+                for (size_t i = 0; i < field.length; i++) {
+                    if (this->data->parse_flags[field_str[i] + 128] == ParseFlags::QUOTE) {
+                        if (prev_ch_quote) {
+                            prev_ch_quote = false;
+                            continue;
+                        }
+                        else {
+                            prev_ch_quote = true;
+                        }
+                    }
+
+                    value += field_str[i];
+                }
+            }
+
+            return csv::string_view(value);
+        }
+
+        return field_str.substr(0, field.length);
+    }
+
+    CSV_INLINE bool CSVField::try_parse_hex(int& parsedValue) {
+        size_t start = 0, end = 0;
+
+        // Trim out whitespace chars
+        for (; start < this->sv.size() && this->sv[start] == ' '; start++);
+        for (end = start; end < this->sv.size() && this->sv[end] != ' '; end++);
+        
+        int value_ = 0;
+
+        size_t digits = (end - start);
+        size_t base16_exponent = digits - 1;
+
+        if (digits == 0) return false;
+
+        for (const auto& ch : this->sv.substr(start, digits)) {
+            int digit = 0;
+
+            switch (ch) {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                digit = static_cast<int>(ch - '0');
+                break;
+            case 'a':
+            case 'A':
+                digit = 10;
+                break;
+            case 'b':
+            case 'B':
+                digit = 11;
+                break;
+            case 'c':
+            case 'C':
+                digit = 12;
+                break;
+            case 'd':
+            case 'D':
+                digit = 13;
+                break;
+            case 'e':
+            case 'E':
+                digit = 14;
+                break;
+            case 'f':
+            case 'F':
+                digit = 15;
+                break;
+            default:
+                return false;
+            }
+
+            value_ += digit * (int)pow(16, (double)base16_exponent);
+            base16_exponent--;
+        }
+
+        parsedValue = value_;
+        return true;
+    }
+
+    CSV_INLINE bool CSVField::try_parse_decimal(long double& dVal, const char decimalSymbol) {
+        // If field has already been parsed to empty, no need to do it aagin:
+        if (this->_type == DataType::CSV_NULL)
+                    return false;
+
+        // Not yet parsed or possibly parsed with other decimalSymbol
+        if (this->_type == DataType::UNKNOWN || this->_type == DataType::CSV_STRING || this->_type == DataType::CSV_DOUBLE)
+            this->_type = internals::data_type(this->sv, &this->value, decimalSymbol); // parse again
+
+        // Integral types are not affected by decimalSymbol and need not be parsed again
+
+        // Either we already had an integral type before, or we we just got any numeric type now.
+        if (this->_type >= DataType::CSV_INT8 && this->_type <= DataType::CSV_DOUBLE) {
+            dVal = this->value;
+            return true;
+        }
+
+        // CSV_NULL or CSV_STRING, not numeric
+        return false;
+    }
+
+#ifdef _MSC_VER
+#pragma region CSVRow Iterator
+#endif
+    /** Return an iterator pointing to the first field. */
+    CSV_INLINE CSVRow::iterator CSVRow::begin() const {
+        return CSVRow::iterator(this, 0);
+    }
+
+    /** Return an iterator pointing to just after the end of the CSVRow.
+     *
+     *  @warning Attempting to dereference the end iterator results
+     *           in dereferencing a null pointer.
+     */
+    CSV_INLINE CSVRow::iterator CSVRow::end() const noexcept {
+        return CSVRow::iterator(this, (int)this->size());
+    }
+
+    CSV_INLINE CSVRow::reverse_iterator CSVRow::rbegin() const noexcept {
+        return std::reverse_iterator<CSVRow::iterator>(this->end());
+    }
+
+    CSV_INLINE CSVRow::reverse_iterator CSVRow::rend() const {
+        return std::reverse_iterator<CSVRow::iterator>(this->begin());
+    }
+
+    CSV_INLINE HEDLEY_NON_NULL(2)
+    CSVRow::iterator::iterator(const CSVRow* _reader, int _i)
+        : daddy(_reader), i(_i) {
+        if (_i < (int)this->daddy->size())
+            this->field = std::make_shared<CSVField>(
+                this->daddy->operator[](_i));
+        else
+            this->field = nullptr;
+    }
+
+    CSV_INLINE CSVRow::iterator::reference CSVRow::iterator::operator*() const {
+        return *(this->field.get());
+    }
+
+    CSV_INLINE CSVRow::iterator::pointer CSVRow::iterator::operator->() const {
+        return this->field;
+    }
+
+    CSV_INLINE CSVRow::iterator& CSVRow::iterator::operator++() {
+        // Pre-increment operator
+        this->i++;
+        if (this->i < (int)this->daddy->size())
+            this->field = std::make_shared<CSVField>(
+                this->daddy->operator[](i));
+        else // Reached the end of row
+            this->field = nullptr;
+        return *this;
+    }
+
+    CSV_INLINE CSVRow::iterator CSVRow::iterator::operator++(int) {
+        // Post-increment operator
+        auto temp = *this;
+        this->operator++();
+        return temp;
+    }
+
+    CSV_INLINE CSVRow::iterator& CSVRow::iterator::operator--() {
+        // Pre-decrement operator
+        this->i--;
+        this->field = std::make_shared<CSVField>(
+            this->daddy->operator[](this->i));
+        return *this;
+    }
+
+    CSV_INLINE CSVRow::iterator CSVRow::iterator::operator--(int) {
+        // Post-decrement operator
+        auto temp = *this;
+        this->operator--();
+        return temp;
+    }
+    
+    CSV_INLINE CSVRow::iterator CSVRow::iterator::operator+(difference_type n) const {
+        // Allows for iterator arithmetic
+        return CSVRow::iterator(this->daddy, i + (int)n);
+    }
+
+    CSV_INLINE CSVRow::iterator CSVRow::iterator::operator-(difference_type n) const {
+        // Allows for iterator arithmetic
+        return CSVRow::iterator::operator+(-n);
+    }
+#ifdef _MSC_VER
+#pragma endregion CSVRow Iterator
+#endif
+}
+
+/** @file
+ *  Defines an input iterator for csv::CSVReader
+ */
+
+
+namespace csv {
+    /** Return an iterator to the first row in the reader */
+    CSV_INLINE CSVReader::iterator CSVReader::begin() {
+        if (this->records->empty()) {
+            this->read_csv_worker = std::thread(&CSVReader::read_csv, this, internals::ITERATION_CHUNK_SIZE);
+            this->read_csv_worker.join();
+
+            // Still empty => return end iterator
+            if (this->records->empty()) return this->end();
+        }
+
+        this->_n_rows++;
+        CSVReader::iterator ret(this, this->records->pop_front());
+        return ret;
+    }
+
+    /** A placeholder for the imaginary past the end row in a CSV.
+     *  Attempting to deference this will lead to bad things.
+     */
+    CSV_INLINE HEDLEY_CONST CSVReader::iterator CSVReader::end() const noexcept {
+        return CSVReader::iterator();
+    }
+
+    /////////////////////////
+    // CSVReader::iterator //
+    /////////////////////////
+
+    CSV_INLINE CSVReader::iterator::iterator(CSVReader* _daddy, CSVRow&& _row) :
+        daddy(_daddy) {
+        row = std::move(_row);
+    }
+
+    /** Advance the iterator by one row. If this CSVReader has an
+     *  associated file, then the iterator will lazily pull more data from
+     *  that file until the end of file is reached.
+     *
+     *  @note This iterator does **not** block the thread responsible for parsing CSV.
+     *
+     */
+    CSV_INLINE CSVReader::iterator& CSVReader::iterator::operator++() {
+        if (!daddy->read_row(this->row)) {
+            this->daddy = nullptr; // this == end()
+        }
+
+        return *this;
+    }
+
+    /** Post-increment iterator */
+    CSV_INLINE CSVReader::iterator CSVReader::iterator::operator++(int) {
+        auto temp = *this;
+        if (!daddy->read_row(this->row)) {
+            this->daddy = nullptr; // this == end()
+        }
+
+        return temp;
+    }
+}
+
+/** @file
+ *  @brief Defines functionality needed for basic CSV parsing
+ */
+
+
+namespace csv {
+    namespace internals {
+        CSV_INLINE std::string format_row(const std::vector<std::string>& row, csv::string_view delim) {
+            /** Print a CSV row */
+            std::stringstream ret;
+            for (size_t i = 0; i < row.size(); i++) {
+                ret << row[i];
+                if (i + 1 < row.size()) ret << delim;
+                else ret << '\n';
+            }
+            ret.flush();
+
+            return ret.str();
+        }
+
+        /** Return a CSV's column names
+         *
+         *  @param[in] filename  Path to CSV file
+         *  @param[in] format    Format of the CSV file
+         *
+         */
+        CSV_INLINE std::vector<std::string> _get_col_names(csv::string_view head, CSVFormat format) {
+            // Parse the CSV
+            auto trim_chars = format.get_trim_chars();
+            std::stringstream source(head.data());
+            RowCollection rows;
+
+            StreamParser<std::stringstream> parser(source, format);
+            parser.set_output(rows);
+            parser.next();
+
+            return CSVRow(std::move(rows[format.get_header()]));
+        }
+
+        CSV_INLINE GuessScore calculate_score(csv::string_view head, const CSVFormat& format) {
+            // Frequency counter of row length
+            std::unordered_map<size_t, size_t> row_tally = { { 0, 0 } };
+
+            // Map row lengths to row num where they first occurred
+            std::unordered_map<size_t, size_t> row_when = { { 0, 0 } };
+
+            // Parse the CSV
+            std::stringstream source(head.data());
+            RowCollection rows;
+
+            StreamParser<std::stringstream> parser(source, format);
+            parser.set_output(rows);
+            parser.next();
+
+            for (size_t i = 0; i < rows.size(); i++) {
+                auto& row = rows[i];
+
+                // Ignore zero-length rows
+                if (row.size() > 0) {
+                    if (row_tally.find(row.size()) != row_tally.end()) {
+                        row_tally[row.size()]++;
+                    }
+                    else {
+                        row_tally[row.size()] = 1;
+                        row_when[row.size()] = i;
+                    }
+                }
+            }
+
+            double final_score = 0;
+            size_t header_row = 0;
+
+            // Final score is equal to the largest
+            // row size times rows of that size
+            for (auto& pair : row_tally) {
+                auto row_size = pair.first;
+                auto row_count = pair.second;
+                double score = (double)(row_size * row_count);
+                if (score > final_score) {
+                    final_score = score;
+                    header_row = row_when[row_size];
+                }
+            }
+
+            return {
+                final_score,
+                header_row
+            };
+        }
+
+        /** Guess the delimiter used by a delimiter-separated values file */
+        CSV_INLINE CSVGuessResult _guess_format(csv::string_view head, const std::vector<char>& delims) {
+            /** For each delimiter, find out which row length was most common.
+             *  The delimiter with the longest mode row length wins.
+             *  Then, the line number of the header row is the first row with
+             *  the mode row length.
+             */
+
+            CSVFormat format;
+            size_t max_score = 0,
+                header = 0;
+            char current_delim = delims[0];
+
+            for (char cand_delim : delims) {
+                auto result = calculate_score(head, format.delimiter(cand_delim));
+
+                if ((size_t)result.score > max_score) {
+                    max_score = (size_t)result.score;
+                    current_delim = cand_delim;
+                    header = result.header;
+                }
+            }
+
+            return { current_delim, (int)header };
+        }
+    }
+
+    /** Return a CSV's column names
+     *
+     *  @param[in] filename  Path to CSV file
+     *  @param[in] format    Format of the CSV file
+     *
+     */
+    CSV_INLINE std::vector<std::string> get_col_names(csv::string_view filename, CSVFormat format) {
+        auto head = internals::get_csv_head(filename);
+
+        /** Guess delimiter and header row */
+        if (format.guess_delim()) {
+            auto guess_result = guess_format(filename, format.get_possible_delims());
+            format.delimiter(guess_result.delim).header_row(guess_result.header_row);
+        }
+
+        return internals::_get_col_names(head, format);
+    }
+
+    /** Guess the delimiter used by a delimiter-separated values file */
+    CSV_INLINE CSVGuessResult guess_format(csv::string_view filename, const std::vector<char>& delims) {
+        auto head = internals::get_csv_head(filename);
+        return internals::_guess_format(head, delims);
+    }
+
+    /** Reads an arbitrarily large CSV file using memory-mapped IO.
+     *
+     *  **Details:** Reads the first block of a CSV file synchronously to get information
+     *               such as column names and delimiting character.
+     *
+     *  @param[in] filename  Path to CSV file
+     *  @param[in] format    Format of the CSV file
+     *
+     *  \snippet tests/test_read_csv.cpp CSVField Example
+     *
+     */
+	CSV_INLINE CSVReader::CSVReader(csv::string_view filename, CSVFormat format) : _format(format) {
+        auto head = internals::get_csv_head(filename);
+        using Parser = internals::MmapParser;
+
+        /** Guess delimiter and header row */
+        if (format.guess_delim()) {
+            auto guess_result = internals::_guess_format(head, format.possible_delimiters);
+            format.delimiter(guess_result.delim);
+            format.header = guess_result.header_row;
+            this->_format = format;
+        }
+
+        if (!format.col_names.empty())
+            this->set_col_names(format.col_names);
+
+        this->parser = std::unique_ptr<Parser>(new Parser(filename, format, this->col_names)); // For C++11
+        this->initial_read();
+    }
+
+    /** Return the format of the original raw CSV */
+    CSV_INLINE CSVFormat CSVReader::get_format() const {
+        CSVFormat new_format = this->_format;
+
+        // Since users are normally not allowed to set
+        // column names and header row simulatenously,
+        // we will set the backing variables directly here
+        new_format.col_names = this->col_names->get_col_names();
+        new_format.header = this->_format.header;
+
+        return new_format;
+    }
+
+    /** Return the CSV's column names as a vector of strings. */
+    CSV_INLINE std::vector<std::string> CSVReader::get_col_names() const {
+        if (this->col_names) {
+            return this->col_names->get_col_names();
+        }
+
+        return std::vector<std::string>();
+    }
+
+    /** Return the index of the column name if found or
+     *         csv::CSV_NOT_FOUND otherwise.
+     */
+    CSV_INLINE int CSVReader::index_of(csv::string_view col_name) const {
+        auto _col_names = this->get_col_names();
+        for (size_t i = 0; i < _col_names.size(); i++)
+            if (_col_names[i] == col_name) return (int)i;
+
+        return CSV_NOT_FOUND;
+    }
+
+    CSV_INLINE void CSVReader::trim_header() {
+        if (!this->header_trimmed) {
+            for (int i = 0; i <= this->_format.header && !this->records->empty(); i++) {
+                if (i == this->_format.header && this->col_names->empty()) {
+                    this->set_col_names(this->records->pop_front());
+                }
+                else {
+                    this->records->pop_front();
+                }
+            }
+
+            this->header_trimmed = true;
+        }
+    }
+
+    /**
+     *  @param[in] names Column names
+     */
+    CSV_INLINE void CSVReader::set_col_names(const std::vector<std::string>& names)
+    {
+        this->col_names->set_col_names(names);
+        this->n_cols = names.size();
+    }
+
+    /**
+     * Read a chunk of CSV data.
+     *
+     * @note This method is meant to be run on its own thread. Only one `read_csv()` thread
+     *       should be active at a time.
+     *
+     * @param[in] bytes Number of bytes to read.
+     *
+     * @see CSVReader::read_csv_worker
+     * @see CSVReader::read_row()
+     */
+    CSV_INLINE bool CSVReader::read_csv(size_t bytes) {
+        // Tell read_row() to listen for CSV rows
+        this->records->notify_all();
+
+        this->parser->set_output(*this->records);
+        this->parser->next(bytes);
+
+        if (!this->header_trimmed) {
+            this->trim_header();
+        }
+
+        // Tell read_row() to stop waiting
+        this->records->kill_all();
+
+        return true;
+    }
+
+    /**
+     * Retrieve rows as CSVRow objects, returning true if more rows are available.
+     *
+     * @par Performance Notes
+     *  - Reads chunks of data that are csv::internals::ITERATION_CHUNK_SIZE bytes large at a time
+     *  - For performance details, read the documentation for CSVRow and CSVField.
+     *
+     * @param[out] row The variable where the parsed row will be stored
+     * @see CSVRow, CSVField
+     *
+     * **Example:**
+     * \snippet tests/test_read_csv.cpp CSVField Example
+     *
+     */
+    CSV_INLINE bool CSVReader::read_row(CSVRow &row) {
+        while (true) {
+            if (this->records->empty()) {
+                if (this->records->is_waitable())
+                    // Reading thread is currently active => wait for it to populate records
+                    this->records->wait();
+                else if (this->parser->eof())
+                    // End of file and no more records
+                    return false;
+                else {
+                    // Reading thread is not active => start another one
+                    if (this->read_csv_worker.joinable())
+                        this->read_csv_worker.join();
+
+                    this->read_csv_worker = std::thread(&CSVReader::read_csv, this, internals::ITERATION_CHUNK_SIZE);
+                }
+            }
+            else if (this->records->front().size() != this->n_cols &&
+                this->_format.variable_column_policy != VariableColumnPolicy::KEEP) {
+                auto errored_row = this->records->pop_front();
+
+                if (this->_format.variable_column_policy == VariableColumnPolicy::THROW) {
+                    if (errored_row.size() < this->n_cols)
+                        throw std::runtime_error("Line too short " + internals::format_row(errored_row));
+
+                    throw std::runtime_error("Line too long " + internals::format_row(errored_row));
+                }
+            }
+            else {
+                row = this->records->pop_front();
+                this->_n_rows++;
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+/** @file
+ *  Implements JSON serialization abilities
+ */
+
+
+namespace csv {
+    /*
+    The implementations for json_extra_space() and json_escape_string()
+    were modified from source code for JSON for Modern C++.
+
+    The respective license is below:
+
+    The code is licensed under the [MIT
+    License](http://opensource.org/licenses/MIT):
+    
+    Copyright &copy; 2013-2015 Niels Lohmann.
+    
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation files
+    (the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge,
+    publish, distribute, sublicense, and/or sell copies of the Software,
+    and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+    BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+    ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    */
+
+    namespace internals {
+        /*!
+         @brief calculates the extra space to escape a JSON string
+
+         @param[in] s  the string to escape
+         @return the number of characters required to escape string @a s
+
+         @complexity Linear in the length of string @a s.
+        */
+        static std::size_t json_extra_space(csv::string_view& s) noexcept
+        {
+            std::size_t result = 0;
+
+
+            for (const auto& c : s)
+            {
+                switch (c)
+                {
+                case '"':
+                case '\\':
+                case '\b':
+                case '\f':
+                case '\n':
+                case '\r':
+                case '\t':
+                {
+                    // from c (1 byte) to \x (2 bytes)
+                    result += 1;
+                    break;
+                }
+
+
+                default:
+                {
+                    if (c >= 0x00 && c <= 0x1f)
+                    {
+                        // from c (1 byte) to \uxxxx (6 bytes)
+                        result += 5;
+                    }
+                    break;
+                }
+                }
+            }
+
+
+            return result;
+        }
+
+        CSV_INLINE std::string json_escape_string(csv::string_view s) noexcept
+        {
+            const auto space = json_extra_space(s);
+            if (space == 0)
+            {
+                return std::string(s);
+            }
+
+            // create a result string of necessary size
+            size_t result_size = s.size() + space;
+            std::string result(result_size, '\\');
+            std::size_t pos = 0;
+
+            for (const auto& c : s)
+            {
+                switch (c)
+                {
+                // quotation mark (0x22)
+                case '"':
+                {
+                    result[pos + 1] = '"';
+                    pos += 2;
+                    break;
+                }
+
+
+                // reverse solidus (0x5c)
+                case '\\':
+                {
+                    // nothing to change
+                    pos += 2;
+                    break;
+                }
+
+
+                // backspace (0x08)
+                case '\b':
+                {
+                    result[pos + 1] = 'b';
+                    pos += 2;
+                    break;
+                }
+
+
+                // formfeed (0x0c)
+                case '\f':
+                {
+                    result[pos + 1] = 'f';
+                    pos += 2;
+                    break;
+                }
+
+
+                // newline (0x0a)
+                case '\n':
+                {
+                    result[pos + 1] = 'n';
+                    pos += 2;
+                    break;
+                }
+
+
+                // carriage return (0x0d)
+                case '\r':
+                {
+                    result[pos + 1] = 'r';
+                    pos += 2;
+                    break;
+                }
+
+
+                // horizontal tab (0x09)
+                case '\t':
+                {
+                    result[pos + 1] = 't';
+                    pos += 2;
+                    break;
+                }
+
+
+                default:
+                {
+                    if (c >= 0x00 && c <= 0x1f)
+                    {
+                        // print character c as \uxxxx
+                        snprintf(&result[pos + 1], result_size - pos - 1, "u%04x", int(c));
+                        pos += 6;
+                        // overwrite trailing null character
+                        result[pos] = '\\';
+                    }
+                    else
+                    {
+                        // all other characters are added as-is
+                        result[pos++] = c;
+                    }
+                    break;
+                }
+                }
+            }
+
+            return result;
+        }
+    }
+
+    /** Convert a CSV row to a JSON object, i.e.
+     *  `{"col1":"value1","col2":"value2"}`
+     *
+     *  @note All strings are properly escaped. Numeric values are not quoted.
+     *  @param[in] subset A subset of columns to contain in the JSON.
+     *                    Leave empty for original columns.
+     */
+    CSV_INLINE std::string CSVRow::to_json(const std::vector<std::string>& subset) const {
+        std::vector<std::string> col_names = subset;
+        if (subset.empty()) {
+            col_names = this->data ? this->get_col_names() : std::vector<std::string>({});
+        }
+
+        const size_t _n_cols = col_names.size();
+        std::string ret = "{";
+        
+        for (size_t i = 0; i < _n_cols; i++) {
+            auto& col = col_names[i];
+            auto field = this->operator[](col);
+
+            // TODO: Possible performance enhancements by caching escaped column names
+            ret += '"' + internals::json_escape_string(col) + "\":";
+
+            // Add quotes around strings but not numbers
+            if (field.is_num())
+                 ret += internals::json_escape_string(field.get<csv::string_view>());
+            else
+                ret += '"' + internals::json_escape_string(field.get<csv::string_view>()) + '"';
+
+            // Do not add comma after last string
+            if (i + 1 < _n_cols)
+                ret += ',';
+        }
+
+        ret += '}';
+        return ret;
+    }
+
+    /** Convert a CSV row to a JSON array, i.e.
+     *  `["value1","value2",...]`
+     *
+     *  @note All strings are properly escaped. Numeric values are not quoted.
+     *  @param[in] subset A subset of columns to contain in the JSON.
+     *                    Leave empty for all columns.
+     */
+    CSV_INLINE std::string CSVRow::to_json_array(const std::vector<std::string>& subset) const {
+        std::vector<std::string> col_names = subset;
+        if (subset.empty())
+            col_names = this->data ? this->get_col_names() : std::vector<std::string>({});
+
+        const size_t _n_cols = col_names.size();
+        std::string ret = "[";
+
+        for (size_t i = 0; i < _n_cols; i++) {
+            auto field = this->operator[](col_names[i]);
+
+            // Add quotes around strings but not numbers
+            if (field.is_num())
+                ret += internals::json_escape_string(field.get<csv::string_view>());
+            else
+                ret += '"' + internals::json_escape_string(field.get<csv::string_view>()) + '"';
+
+            // Do not add comma after last string
+            if (i + 1 < _n_cols)
+                ret += ',';
+        }
+
+        ret += ']';
+        return ret;
+    }
+}
+
+/** @file
+ *  Calculates statistics from CSV files
+ */
+
+#include <string>
+
+namespace csv {
+    /** Calculate statistics for an arbitrarily large file. When this constructor
+     *  is called, CSVStat will process the entire file iteratively. Once finished,
+     *  methods like get_mean(), get_counts(), etc... can be used to retrieve statistics.
+     */
+    CSV_INLINE CSVStat::CSVStat(csv::string_view filename, CSVFormat format) :
+        reader(filename, format) {
+        this->calc();
+    }
+
+    /** Calculate statistics for a CSV stored in a std::stringstream */
+    CSV_INLINE CSVStat::CSVStat(std::stringstream& stream, CSVFormat format) :
+        reader(stream, format) {
+        this->calc();
+    }
+
+    /** Return current means */
+    CSV_INLINE std::vector<long double> CSVStat::get_mean() const {
+        std::vector<long double> ret;        
+        for (size_t i = 0; i < this->get_col_names().size(); i++) {
+            ret.push_back(this->rolling_means[i]);
+        }
+        return ret;
+    }
+
+    /** Return current variances */
+    CSV_INLINE std::vector<long double> CSVStat::get_variance() const {
+        std::vector<long double> ret;        
+        for (size_t i = 0; i < this->get_col_names().size(); i++) {
+            ret.push_back(this->rolling_vars[i]/(this->n[i] - 1));
+        }
+        return ret;
+    }
+
+    /** Return current mins */
+    CSV_INLINE std::vector<long double> CSVStat::get_mins() const {
+        std::vector<long double> ret;        
+        for (size_t i = 0; i < this->get_col_names().size(); i++) {
+            ret.push_back(this->mins[i]);
+        }
+        return ret;
+    }
+
+    /** Return current maxes */
+    CSV_INLINE std::vector<long double> CSVStat::get_maxes() const {
+        std::vector<long double> ret;        
+        for (size_t i = 0; i < this->get_col_names().size(); i++) {
+            ret.push_back(this->maxes[i]);
+        }
+        return ret;
+    }
+
+    /** Get counts for each column */
+    CSV_INLINE std::vector<CSVStat::FreqCount> CSVStat::get_counts() const {
+        std::vector<FreqCount> ret;
+        for (size_t i = 0; i < this->get_col_names().size(); i++) {
+            ret.push_back(this->counts[i]);
+        }
+        return ret;
+    }
+
+    /** Get data type counts for each column */
+    CSV_INLINE std::vector<CSVStat::TypeCount> CSVStat::get_dtypes() const {
+        std::vector<TypeCount> ret;        
+        for (size_t i = 0; i < this->get_col_names().size(); i++) {
+            ret.push_back(this->dtypes[i]);
+        }
+        return ret;
+    }
+
+    CSV_INLINE void CSVStat::calc_chunk() {
+        /** Only create stats counters the first time **/
+        if (dtypes.empty()) {
+            /** Go through all records and calculate specified statistics */
+            for (size_t i = 0; i < this->get_col_names().size(); i++) {
+                dtypes.push_back({});
+                counts.push_back({});
+                rolling_means.push_back(0);
+                rolling_vars.push_back(0);
+                mins.push_back(NAN);
+                maxes.push_back(NAN);
+                n.push_back(0);
+            }
+        }
+
+        // Start threads
+        std::vector<std::thread> pool;
+        for (size_t i = 0; i < this->get_col_names().size(); i++)
+            pool.push_back(std::thread(&CSVStat::calc_worker, this, i));
+
+        // Block until done
+        for (auto& th : pool)
+            th.join();
+
+        this->records.clear();
+    }
+
+    CSV_INLINE void CSVStat::calc() {
+        constexpr size_t CALC_CHUNK_SIZE = 5000;
+
+        for (auto& row : reader) {
+            this->records.push_back(std::move(row));
+
+            /** Chunk rows */
+            if (this->records.size() == CALC_CHUNK_SIZE) {
+                calc_chunk();
+            }
+        }
+
+        if (!this->records.empty()) {
+          calc_chunk();
+        }
+    }
+
+    CSV_INLINE void CSVStat::calc_worker(const size_t &i) {
+        /** Worker thread for CSVStat::calc() which calculates statistics for one column.
+         * 
+         *  @param[in] i Column index
+         */
+
+        auto current_record = this->records.begin();
+
+        for (size_t processed = 0; current_record != this->records.end(); processed++) {
+            if (current_record->size() == this->get_col_names().size()) {
+                auto current_field = (*current_record)[i];
+
+                // Optimization: Don't count() if there's too many distinct values in the first 1000 rows
+                if (processed < 1000 || this->counts[i].size() <= 500)
+                    this->count(current_field, i);
+
+                this->dtype(current_field, i);
+
+                // Numeric Stuff
+                if (current_field.is_num()) {
+                    long double x_n = current_field.get<long double>();
+
+                    // This actually calculates mean AND variance
+                    this->variance(x_n, i);
+                    this->min_max(x_n, i);
+                }
+            }
+            else if (this->reader.get_format().get_variable_column_policy() == VariableColumnPolicy::THROW) {
+                throw std::runtime_error("Line has different length than the others " + internals::format_row(*current_record));
+            }
+
+            ++current_record;
+        }
+    }
+
+    CSV_INLINE void CSVStat::dtype(CSVField& data, const size_t &i) {
+        /** Given a record update the type counter
+         *  @param[in]  record Data observation
+         *  @param[out] i      The column index that should be updated
+         */
+        
+        auto type = data.type();
+        if (this->dtypes[i].find(type) !=
+            this->dtypes[i].end()) {
+            // Increment count
+            this->dtypes[i][type]++;
+        } else {
+            // Initialize count
+            this->dtypes[i].insert(std::make_pair(type, 1));
+        }
+    }
+
+    CSV_INLINE void CSVStat::count(CSVField& data, const size_t &i) {
+        /** Given a record update the frequency counter
+         *  @param[in]  record Data observation
+         *  @param[out] i      The column index that should be updated
+         */
+
+        auto item = data.get<std::string>();
+
+        if (this->counts[i].find(item) !=
+            this->counts[i].end()) {
+            // Increment count
+            this->counts[i][item]++;
+        } else {
+            // Initialize count
+            this->counts[i].insert(std::make_pair(item, 1));
+        }
+    }
+
+    CSV_INLINE void CSVStat::min_max(const long double &x_n, const size_t &i) {
+        /** Update current minimum and maximum
+         *  @param[in]  x_n Data observation
+         *  @param[out] i   The column index that should be updated
+         */
+        if (std::isnan(this->mins[i]))
+            this->mins[i] = x_n;
+        if (std::isnan(this->maxes[i]))
+            this->maxes[i] = x_n;
+        
+        if (x_n < this->mins[i])
+            this->mins[i] = x_n;
+        else if (x_n > this->maxes[i])
+            this->maxes[i] = x_n;
+    }
+
+    CSV_INLINE void CSVStat::variance(const long double &x_n, const size_t &i) {
+        /** Given a record update rolling mean and variance for all columns
+         *  using Welford's Algorithm
+         *  @param[in]  x_n Data observation
+         *  @param[out] i   The column index that should be updated
+         */
+        long double& current_rolling_mean = this->rolling_means[i];
+        long double& current_rolling_var = this->rolling_vars[i];
+        long double& current_n = this->n[i];
+        long double delta;
+        long double delta2;
+
+        current_n++;
+        
+        if (current_n == 1) {
+            current_rolling_mean = x_n;
+        } else {
+            delta = x_n - current_rolling_mean;
+            current_rolling_mean += delta/current_n;
+            delta2 = x_n - current_rolling_mean;
+            current_rolling_var += delta*delta2;
+        }
+    }
+
+    /** Useful for uploading CSV files to SQL databases.
+     *
+     *  Return a data type for each column such that every value in a column can be
+     *  converted to the corresponding data type without data loss.
+     *  @param[in]  filename The CSV file
+     *
+     *  \return A mapping of column names to csv::DataType enums
+     */
+    CSV_INLINE std::unordered_map<std::string, DataType> csv_data_types(const std::string& filename) {
+        CSVStat stat(filename);
+        std::unordered_map<std::string, DataType> csv_dtypes;
+
+        auto col_names = stat.get_col_names();
+        auto temp = stat.get_dtypes();
+
+        for (size_t i = 0; i < stat.get_col_names().size(); i++) {
+            auto& col = temp[i];
+            auto& col_name = col_names[i];
+
+            if (col[DataType::CSV_STRING])
+                csv_dtypes[col_name] = DataType::CSV_STRING;
+            else if (col[DataType::CSV_INT64])
+                csv_dtypes[col_name] = DataType::CSV_INT64;
+            else if (col[DataType::CSV_INT32])
+                csv_dtypes[col_name] = DataType::CSV_INT32;
+            else if (col[DataType::CSV_INT16])
+                csv_dtypes[col_name] = DataType::CSV_INT16;
+            else if (col[DataType::CSV_INT8])
+                csv_dtypes[col_name] = DataType::CSV_INT8;
+            else
+                csv_dtypes[col_name] = DataType::CSV_DOUBLE;
+        }
+
+        return csv_dtypes;
+    }
+}
+
+
+#endif

--- a/extensions/omni_csv/docs/index.md
+++ b/extensions/omni_csv/docs/index.md
@@ -1,0 +1,113 @@
+# CSV Toolkit
+
+This extension provides direct CSV parsing and encoding capabilities without having to use `COPY`,
+enabling inline CSV processing within SQL queries and programmatic workflows.
+
+## Installation and Setup
+
+```postgresql
+-- Install the extension
+create extension omni_csv;
+
+-- All functions are available in the omni_csv schema
+```
+
+## Core Functions
+
+### `omni_csv.csv_info(csv text)` - Inspect CSV Structure
+
+Analyze the structure of CSV data by extracting column names from the header row:
+
+```postgresql
+select *
+from
+    omni_csv.csv_info(E'name,age,city\nJohn,25,NYC\nJane,30,LA');
+```
+
+**Returns:**
+
+```
+ column_name 
+-------------
+ name
+ age
+ city
+```
+
+This function is essential for working with dynamic or unknown CSV structures, allowing you to discover the schema
+before parsing the data.
+
+**Use cases:**
+
+- Validating CSV uploads before processing
+- Building dynamic queries based on CSV structure
+- API endpoints that accept arbitrary CSV formats
+
+### `omni_csv.parse(csv text)` - Parse CSV Data
+
+Transform CSV text into queryable records:
+
+```postgresql
+select *
+from
+    omni_csv.parse(E'name,age,city\nJohn,25,NYC\nJane,30,LA')
+        as t(name text, age text, city text);
+```
+
+**Returns:**
+
+```
+ name | age | city 
+------+-----+------
+ John |  25 | NYC
+ Jane |  30 | LA
+```
+
+**Key Requirements:**
+
+- Must specify column structure using `as t(column_name text, ...)`
+- The number of columns should match
+
+### `omni_csv.csv_agg(record)` - Generate CSV from records
+
+Convert query results back into CSV format:
+
+```postgresql
+select
+    omni_csv.csv_agg(t)
+from
+    (select
+         name,
+         age,
+         city
+     from
+         employees
+     where
+         department = 'Engineering'
+     order by name) t;
+```
+
+**Returns:** A complete CSV string with headers and properly escaped values.
+
+!!! warning "Limitations & caveats"
+
+    Currently, on an empty set, this aggregate won't encode headers either, returning an empty string.
+
+## Limitations and Considerations
+
+- **Memory Usage**: Large CSV strings are processed entirely in memory
+- **Type Declaration**: Column types must be explicitly specified in `as t(...)` clause
+- **No Streaming**: Not suitable for extremely large datasets that exceed memory limits
+- **Schema Rigidity**: Once declared, the column structure cannot be changed within the same query
+- **Performance**: For repeated access to the same CSV, consider materializing the parsed data
+
+## Comparison with Alternatives
+
+| Method         | Use Case                        | Pros                                | Cons                        |
+|----------------|---------------------------------|-------------------------------------|-----------------------------|
+| `omni_csv`     | Programmatic, inline processing | No temp files, full SQL integration | Memory limited              |
+| `COPY`         | Bulk data loading               | Very fast, streaming                | Requires file system access |
+| External tools | Very large datasets             | Can handle any size                 | Additional dependencies     |
+
+The `omni_csv` extension excels in scenarios where CSV data needs to be processed as part of complex SQL workflows, API
+endpoints, or data transformation pipelines without the overhead of temporary files or external processes.

--- a/extensions/omni_csv/migrate/1_init.sql
+++ b/extensions/omni_csv/migrate/1_init.sql
@@ -1,0 +1,2 @@
+/*{% include "../src/instantiate.sql" %}*/
+select instantiate(schema => 'omni_csv');

--- a/extensions/omni_csv/mkdocs.yml
+++ b/extensions/omni_csv/mkdocs.yml
@@ -1,0 +1,2 @@
+INHERIT: ../../mkdocs.base.yml
+site_name: omni_csv

--- a/extensions/omni_csv/omni_csv.cpp
+++ b/extensions/omni_csv/omni_csv.cpp
@@ -1,0 +1,84 @@
+#include <cppgres.hpp>
+
+extern "C" {
+PG_MODULE_MAGIC;
+}
+
+#include <csv.hpp>
+#include <ranges>
+
+constexpr auto default_format() {
+  csv::CSVFormat format;
+  format.delimiter({'|', ',', '\t'});
+  return format;
+}
+
+std::vector<std::string> csv_info_function(std::string_view csv) {
+  csv::CSVFormat format = default_format();
+  auto doc = csv::parse(csv, format);
+  return doc.get_col_names();
+}
+
+postgres_function(csv_info, csv_info_function);
+
+auto parse_function(std::string_view csv) {
+  csv::CSVFormat format = default_format();
+  auto doc = csv::parse(csv, format);
+
+  std::vector<cppgres::record> result;
+
+  auto size = doc.get_col_names().size();
+  cppgres::tuple_descriptor td(size);
+  for (auto i = 0; i < size; i++) {
+    td.set_type(i, cppgres::type{.oid = TEXTOID});
+  }
+
+  for (auto &row : doc) {
+    std::vector<std::string> values = row;
+    result.emplace_back(td, values.begin(), values.end());
+  }
+
+  return result;
+}
+
+postgres_function(parse, parse_function);
+
+struct csv_aggregate {
+  bool header_written = false;
+  std::stringstream buffer;
+  csv::CSVWriter<std::stringstream> writer;
+
+  csv_aggregate() : writer(buffer) {}
+
+  void update(cppgres::record &record) {
+    auto td = record.get_tuple_descriptor();
+
+    // Prepare the header
+    if (!header_written) {
+      std::vector<std::string> header;
+      for (auto i = 0; i < td.attributes(); i++) {
+        header.emplace_back(td.get_name(i));
+      }
+      writer << header;
+      header_written = true;
+    }
+
+    // Figure out how to output the types
+    std::vector<regproc> output;
+    for (auto i = 0; i < td.attributes(); i++) {
+      cppgres::syscache<Form_pg_type, cppgres::oid> cache(td.get_type(i).oid);
+      output.push_back((*cache).typoutput);
+    }
+
+    auto it =
+        std::views::iota(0, record.attributes()) | std::views::transform([&](int i) {
+          return cppgres::ffi_guard{::OidOutputFunctionCall}(output[i], record.get_attribute(i));
+        });
+
+    writer << it;
+  }
+
+  std::string finalize() const { return buffer.str(); }
+};
+
+declare_aggregate(csv, csv_aggregate, cppgres::record);

--- a/extensions/omni_csv/src/instantiate.sql
+++ b/extensions/omni_csv/src/instantiate.sql
@@ -1,0 +1,39 @@
+create function instantiate(schema regnamespace default 'omni_csv') returns void
+    language plpgsql
+as
+$instantiate$
+declare
+    old_search_path text := current_setting('search_path');
+begin
+    -- Set the search path to target schema and public
+    perform
+        set_config('search_path', schema::text || ',public', true);
+
+    create function csv_info(csv text)
+        returns table
+                (
+                    column_name text
+                )
+        language c
+    as
+    'MODULE_PATHNAME';
+
+    create function parse(csv text)
+        returns setof record
+        language c as
+    'MODULE_PATHNAME';
+
+    create function csv_sfunc(internal, record) returns internal
+        language c as
+    'MODULE_PATHNAME';
+
+    create function csv_ffunc(internal) returns text
+        language c as
+    'MODULE_PATHNAME';
+
+    create aggregate csv_agg(record) (sfunc = csv_sfunc, finalfunc = csv_ffunc, stype = internal);
+
+    -- Restore the path
+    perform set_config('search_path', old_search_path, true);
+end
+$instantiate$;

--- a/extensions/omni_csv/tests/test.yml
+++ b/extensions/omni_csv/tests/test.yml
@@ -1,0 +1,79 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 64
+    omni_worker.workers: 10
+  init:
+  - create extension omni_csv cascade
+
+tests:
+
+- name: csv info (commas)
+  query: select * from omni_csv.csv_info(E'col1,col2\n1,2')
+  results:
+  - column_name: col1
+  - column_name: col2
+
+- name: csv info (bars)
+  query: select * from omni_csv.csv_info(E'col1|col2\n1|2')
+  results:
+  - column_name: col1
+  - column_name: col2
+
+- name: csv info (tabs)
+  query: select * from omni_csv.csv_info(E'col1\tcol2\n1\t2')
+  results:
+  - column_name: col1
+  - column_name: col2
+
+- name: csv data (commas)
+  query: select * from omni_csv.parse(E'col1,col2\n1,2\n"a,b",c') as (col1 text, col2 text)
+  results:
+  - col1: 1
+    col2: 2
+  - col1: a,b
+    col2: c
+
+- name: csv data (tabs)
+  query: select *
+         from
+             omni_csv.parse(E'col1\tcol2\n1\t2\n"a\tb"\tc') as (col1 text, col2 text)
+  results:
+  - col1: 1
+    col2: 2
+  - col1: "a\tb"
+    col2: c
+
+- name: aggregation
+  query: select
+             omni_csv.csv_agg(t)
+         from
+                 (values ('hello,', 'world'), ('John', 'Doe')) t
+  results:
+  - csv_agg: "column1,column2\n\"hello,\",world\nJohn,Doe\n"
+
+- name: aggregation (other types)
+  query: select
+             omni_csv.csv_agg(t)
+         from
+                 (values (1, 'test')) t
+  results:
+  - csv_agg: "column1,column2\n1,test\n"
+
+- name: aggregation (column names)
+  query: select
+             omni_csv.csv_agg(t)
+         from
+                 (values (1, 'test')) t(val, note)
+  results:
+  - csv_agg: "val,note\n1,test\n"
+
+- name: empty set aggregation
+  query: select
+             omni_csv.csv_agg(t)
+         from
+                 (select 1, 'test' limit 0) t(val, note)
+  results:
+  # TODO: Ideally, this should be headers. But it isn't right now.
+  - csv_agg: ""

--- a/versions.txt
+++ b/versions.txt
@@ -4,6 +4,7 @@ omni_auth=0.1.3
 omni_containers=0.2.0
 omni_cloudevents=0.1.0
 omni_credentials=0.2.0
+omni_csv=0.1.0
 omni_http=0.1.0
 omni_httpc=0.1.5
 omni_httpd=0.4.9


### PR DESCRIPTION
On the surface, Postgres has good support for CSVs – but it is limited to the `COPY` commands, which are not as useful in a query context.

Solution: add omni_csv extension to the mix