### PR TITLE
Problem: omni_httpd may fail to start

### DIFF
--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.10] - TBD
 
+### Fixed
+
+* May fail to start with `name must be under 64 bytes long` [#900](https://github.com/omnigres/omnigres/pull/900)
+
 ## [0.4.9] - 2025-07-31
 
 ### Added

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -259,8 +259,7 @@ void _Omni_init(const omni_handle *handle) {
                                      init_semaphore, NULL, &semaphore_found);
 
   bool worker_bgw_found;
-  const char *master_worker_mem_name =
-      psprintf(OMNI_HTTPD_MASTER_WORKER, get_database_name(MyDatabaseId));
+  const char *master_worker_mem_name = psprintf(OMNI_HTTPD_MASTER_WORKER, MyDatabaseId);
   master_worker_bgw =
       handle->allocate_shmem(handle, master_worker_mem_name, sizeof(*master_worker_bgw),
                              register_start_master_worker, NULL, &worker_bgw_found);

--- a/extensions/omni_httpd/omni_httpd.h
+++ b/extensions/omni_httpd/omni_httpd.h
@@ -42,7 +42,7 @@ static const char *OMNI_HTTPD_CONFIGURATION_RELOAD_SEMAPHORE =
 
 static const char *OMNI_HTTPD_CONFIGURATION_CONTROL = "omni_httpd(%d):" EXT_VERSION ":_control";
 
-static const char *OMNI_HTTPD_MASTER_WORKER = "omni_httpd(%s):" EXT_VERSION ":_master_worker";
+static const char *OMNI_HTTPD_MASTER_WORKER = "omni_httpd(%d):" EXT_VERSION ":_master_worker";
 
 static const char *OMNI_HTTPD_GUC_NUM_HTTP_WORKERS =
     "omni_httpd:" EXT_VERSION ":_guc_num_http_workers";


### PR DESCRIPTION
Error: `name must be under 64 bytes long`

Solution: ensure allocation name is short enough

omni can only accommodate keys sized under NAMELEN, so attempt to do so.