### PR TITLE
Problem: omni error reporting

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.12] - TBD
 
+### Fixed
+
+* Better error reporting [#902](https://github.com/omnigres/omnigres/pull/902)
+
 ## [0.2.11] - 2025-07-17
 
 ### Fixed

--- a/extensions/omni/omni.c
+++ b/extensions/omni/omni.c
@@ -672,10 +672,10 @@ static struct dsa_ref {
                              omni_allocate_shmem_callback_function init, void *data,
                              HASHACTION action, bool *found) {
   if (strlen(name) > NAMEDATALEN - 1) {
-    ereport(ERROR, errmsg("name must be under 64 bytes long"));
+    ereport(ERROR, errmsg("name must be under 64 bytes long"), errdetail("name: %s", name));
   }
   if (size == 0) {
-    ereport(ERROR, errmsg("size must be larger than 0"));
+    ereport(ERROR, errmsg("size must be larger than 0", errdetail("size: %zu", size)));
   }
   omni_handle_private *phandle = struct_from_member(omni_handle_private, handle, handle);
   LWLockAcquire(&(locks + OMNI_LOCK_ALLOCATION)->lock,


### PR DESCRIPTION
It does not show details, like: `"name must be under 64 bytes long`:

Which name?

Solution: include more details