### PR TITLE
Problem: capturing schemas in full

### DIFF
--- a/extensions/omni_schema/CHANGELOG.md
+++ b/extensions/omni_schema/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.0] - TBD
 
+### Added
+
+* Schema dump and restore functionality [#908](https://github.com/omnigres/omnigres/pull/908)
+
 ## [0.3.0] - 2025-03-01
 
 ### Added

--- a/extensions/omni_schema/docs/dump_restore.md
+++ b/extensions/omni_schema/docs/dump_restore.md
@@ -1,0 +1,98 @@
+# Database Dump and Restore Functions
+
+The `omni_schema` extension provides two functions for dumping and restoring Postgres databases across connections.
+
+## dump()
+
+Dumps schema and/or data from a remote Postgres database using `pg_dump` command line tool.
+
+```sql
+select omni_schema.dump(connstr, schema, data);
+```
+
+### Parameters
+
+| Parameter | Type   | Default    | Description                                    |
+|-----------|--------|------------|------------------------------------------------|
+| `connstr` | `text` | (required) | libpq connection string to the source database |
+| `schema`  | `bool` | `true`     | Include schema (DDL) in the dump               |
+| `data`    | `bool` | `true`     | Include data (DML) in the dump                 |
+
+### Return Value
+
+Returns `text` containing the SQL dump output.
+
+### Examples
+
+```sql
+-- Dump everything (schema + data)
+select omni_schema.dump('host=remote.db.com dbname=mydb user=postgres');
+
+-- Schema only
+select omni_schema.dump('host=localhost dbname=test', true, false);
+
+-- Data only  
+select omni_schema.dump('host=localhost dbname=test', false, true);
+```
+
+## restore()
+
+Restores SQL schema to a remote Postgres database using `psql` command-line tool.
+
+```sql
+select omni_schema.restore(connstr, schema);
+```
+
+### Parameters
+
+| Parameter | Type   | Description                                        |
+|-----------|--------|----------------------------------------------------|
+| `connstr` | `text` | libpq connection string to the target database     |
+| `schema`  | `text` | SQL statements to execute (obtained from `dump()`) |
+
+### Return Value
+
+Returns `void`.
+
+### Example
+
+```sql
+-- Restore a previously dumped schema
+do
+$$
+    declare
+      dumped_sql text;
+    begin
+      dumped_sql := omni_schema.dump('host=source.db user=postgres dbname=mydb');
+      perform omni_schema.restore('host=target.db user=postgres dbname=newdb', dumped_sql);
+    end
+$$;
+```
+
+## Security Considerations
+
+Functions that call `pg_dump` and `psql` ar marked `SECURITY DEFINER`, meaning they execute with the privileges of the
+function creator (`omni_schema_external_tool_caller` role created by the extension) rather
+than the caller. This allows us to contain privileges required to do such operations.
+
+!!! warning "Authentication caveat"
+
+    It is important to note that actual invocations of `pg_dump` and `psql` will assume the credentials of a     local user, which may result in slightly different authentication. We do, however, validate connectivity with the given connection string prior to these invocations. To avoid unwanted local authentication, we recommend setting `host` connection string parameter to a network address.
+
+### Protection Against SQL Injection
+
+- **Connection string validation**: Both functions use `dblink_connect()` to validate connection strings before passing
+  them to shell commands
+- **Shell escaping**: Connection strings are properly escaped using `%L` format specifier to prevent shell injection
+
+### Access Control
+
+These functions can:
+
+- Execute `pg_dump` and `psql` commands on the system
+- Connect to any database the Postgres server can reach
+
+### Connection String Security
+
+Connection strings may contain sensitive information (passwords, hostnames). Ensure appropriate logging and audit
+controls are in place.

--- a/extensions/omni_schema/docs/reference.md
+++ b/extensions/omni_schema/docs/reference.md
@@ -1,4 +1,4 @@
-# omni_schema
+# Schema Management
 
 This extension allows application schemas to be managed easily, both during development and deployment.
 

--- a/extensions/omni_schema/migrate/10_dump.sql
+++ b/extensions/omni_schema/migrate/10_dump.sql
@@ -1,0 +1,21 @@
+/*{% include "../src/_validate_connstr.sql" %}*/
+/*{% include "../src/dump.sql" %}*/
+/*{% include "../src/restore.sql" %}*/
+
+do
+$$
+    begin
+        perform from pg_roles where rolname = 'omni_schema_external_tool_caller';
+        if found then
+            return;
+        end if;
+        create role omni_schema_external_tool_caller nologin;
+        grant pg_execute_server_program to omni_schema_external_tool_caller;
+        grant usage on schema omni_schema to omni_schema_external_tool_caller;
+        grant execute on function pg_config to omni_schema_external_tool_caller;
+
+        alter function _dump owner to omni_schema_external_tool_caller;
+        alter function _restore owner to omni_schema_external_tool_caller;
+
+    end;
+$$;

--- a/extensions/omni_schema/src/_validate_connstr.sql
+++ b/extensions/omni_schema/src/_validate_connstr.sql
@@ -1,0 +1,16 @@
+create function _validate_connstr(connstr text) returns void
+    security invoker
+    language plpgsql
+as
+$$
+begin
+    begin
+        perform dblink_connect('dump_' || connstr, connstr);
+        perform dblink_disconnect('dump_' || connstr);
+    exception
+        when others then
+            raise exception 'Invalid connection string: %', sqlerrm;
+    end;
+    return;
+end;
+$$;

--- a/extensions/omni_schema/src/dump.sql
+++ b/extensions/omni_schema/src/dump.sql
@@ -1,0 +1,42 @@
+create function _dump(connstr text, schema bool default true, data bool default true) returns text
+    security definer
+    set search_path = pg_temp, public
+    language plpgsql
+as
+$$
+declare
+    bindir text;
+    dump   text;
+    opts   text := '';
+begin
+    case
+        when data and not schema then opts := '-a';
+        when not data and schema then opts := '-s';
+        when data and schema then null;
+        when not data and not schema then raise exception 'either schema or data must be included';
+        end case;
+
+    select setting from pg_config() where name = 'BINDIR' into bindir;
+    create temporary table _pg_dump
+    (
+        value text
+    ) on commit drop;
+    execute format(
+            $copy$copy _pg_dump from program $p$%L/pg_dump %s %L$p$ delimiter E'\x1E' $copy$,
+            bindir,
+            opts,
+            connstr);
+    select string_agg(value, '\n') from _pg_dump into dump;
+    return dump;
+end;
+$$;
+
+create function dump(connstr text, schema bool default true, data bool default true) returns text
+    language plpgsql
+as
+$$
+begin
+    perform omni_schema._validate_connstr(connstr);
+    return omni_schema._dump(connstr, schema, data);
+end;
+$$;

--- a/extensions/omni_schema/src/restore.sql
+++ b/extensions/omni_schema/src/restore.sql
@@ -1,0 +1,35 @@
+create function _restore(connstr text, schema text) returns void
+    security definer
+    set search_path = pg_temp, public
+    language plpgsql
+as
+$$
+declare
+    bindir text;
+    dump   text;
+begin
+    select setting from pg_config() where name = 'BINDIR' into bindir;
+    create temporary table _pg_restore
+    (
+        value text
+    ) on commit drop;
+    insert into _pg_restore select v from unnest(string_to_array(schema, E'\\n')) v;
+    execute format(
+            $copy$copy _pg_restore to program $p$%L/psql %L$p$ $copy$,
+            bindir,
+            connstr);
+    return;
+end;
+$$;
+
+create function restore(connstr text, schema text) returns void
+    language plpgsql
+as
+$$
+begin
+    perform omni_schema._validate_connstr(connstr);
+
+    perform omni_schema._restore(connstr, schema);
+    return;
+end;
+$$;

--- a/extensions/omni_schema/tests/dump_restore.yml
+++ b/extensions/omni_schema/tests/dump_restore.yml
@@ -1,0 +1,119 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_schema cascade
+
+tests:
+
+- name: smoke test
+  transaction: false
+  tests:
+  - create database source
+  - create database target
+  - name: prepare source
+    database: source
+    query: |
+      create table example as
+      select 1 as i
+  - |
+    create table src as
+    select omni_schema.dump('host=127.0.0.1 dbname=source user=yregress port=' ||
+                            current_setting('port'))
+  - |
+    select omni_schema.restore(
+                   'host=127.0.0.1 dbname=target user=yregress port=' || current_setting('port'),
+                   dump)
+    from src
+  - name: check target
+    database: target
+    query: select *
+           from example
+    results:
+    - i: 1
+  - drop database source
+  - drop database target
+  - drop table src
+
+- name: smoke test (no data)
+  transaction: false
+  tests:
+  - create database source
+  - create database target
+  - name: prepare source
+    database: source
+    query: |
+      create table example as
+      select 1 as i
+  - |
+    create table src as
+    select omni_schema.dump(
+                   'host=127.0.0.1 dbname=source user=yregress port=' || current_setting('port'),
+                            data => false)
+  - |
+    select omni_schema.restore(
+                   'host=127.0.0.1 dbname=target user=yregress port=' || current_setting('port'),
+                   dump)
+    from src
+  - name: check target
+    database: target
+    query: select *
+           from example
+    results: [ ]
+  - drop database source
+  - drop database target
+  - drop table src
+
+- name: smoke test (no schema)
+  transaction: false
+  tests:
+  - create database source
+  - create database target
+  - name: prepare source
+    database: source
+    query: |
+      create table example as
+      select 1 as i
+  - |
+    create table src as
+    select omni_schema.dump(
+                   'host=127.0.0.1 dbname=source user=yregress port=' || current_setting('port'),
+                            data => false)
+  - |
+    select omni_schema.restore(
+                   'host=127.0.0.1 dbname=target user=yregress port=' || current_setting('port'),
+                   dump)
+    from src
+  - name: check target
+    database: target
+    query: select *
+           from example
+    results: [ ]
+  - drop table src
+  - |
+    create table src as
+    select omni_schema.dump(
+                   'host=127.0.0.1 dbname=source user=yregress port=' || current_setting('port'),
+                            schema => false)
+  - |
+    select omni_schema.restore(
+                   'host=127.0.0.1 dbname=target user=yregress port=' || current_setting('port'),
+                   dump)
+    from src
+  - name: check target
+    database: target
+    query: select *
+           from example
+    results:
+    - i: 1
+  - drop database source
+  - drop database target
+  - drop table src
+
+- name: injection attacks
+  tests:
+  - query: select omni_schema.dump('host=127.0.0.1 dbname=source user=yregress port=; touch /')
+    error: "Invalid connection string: could not establish connection"
+  - query: select omni_schema.dump('host=127.0.0.1 dbname=source user=yregress port=''; touch /')
+    error: "Invalid connection string: could not establish connection"
+  - query: select omni_schema.dump('host=127.0.0.1 dbname=source user=yregress port="; touch /')
+    error: "Invalid connection string: could not establish connection"


### PR DESCRIPTION
While we can capture meta catalog, this takes time and is not guaranteed to be a full copy of the catalog.

Solution: allow capturing and restoring schema as SQL

This is done by calling pg_dump and psql externally.