### PR TITLE
Problem: omni_schema dump ordering may be incorrect

### DIFF
--- a/extensions/omni_schema/CHANGELOG.md
+++ b/extensions/omni_schema/CHANGELOG.md
@@ -9,7 +9,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-* Schema dump and restore functionality [#908](https://github.com/omnigres/omnigres/pull/908)
+* Schema dump and restore
+  functionality [#908](https://github.com/omnigres/omnigres/pull/908),[#910](https://github.com/omnigres/omnigres/pull/910)
 
 ## [0.3.0] - 2025-03-01
 


### PR DESCRIPTION
The schema file lines may be misordered.

Solution: ensure we capture their order

While at it, ensure we only have another unused character for `null`