### PR TITLE
Problem: loading Kubernetes credentials

### DIFF
--- a/extensions/omni_kube/CHANGELOG.md
+++ b/extensions/omni_kube/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 * Universal resource management framework [#914](https://github.com/omnigres/omnigres/pull/914)
+* Credential loading [#916](https://github.com/omnigres/omnigres/pull/916)
 
 ### Removed
 

--- a/extensions/omni_kube/CMakeLists.txt
+++ b/extensions/omni_kube/CMakeLists.txt
@@ -15,4 +15,4 @@ add_postgresql_extension(
         COMMENT "Kubernetes (k8s) integration"
         SCHEMA omni_kube
         RELOCATABLE false
-        REQUIRES omni_httpc omni_web omni_var pgcrypto)
+        REQUIRES omni_httpc omni_web omni_var omni_yaml pgcrypto)

--- a/extensions/omni_kube/docs/credentials.md
+++ b/extensions/omni_kube/docs/credentials.md
@@ -1,0 +1,315 @@
+# Credentials
+
+omni_kube provides flexible credential loading capabilities that support multiple Kubernetes authentication methods,
+including kubeconfig files and in-cluster service account credentials.
+
+## Overview
+
+The credential loading system supports:
+
+1. **Kubeconfig-based authentication** - Load credentials from standard Kubernetes configuration files
+2. **In-cluster authentication** - Automatic detection and use of service account credentials when running inside a
+   Kubernetes pod
+3. **Multiple authentication methods** - Support for certificates, tokens, and file-based credentials
+
+## Functions
+
+### `omni_kube.load_kubeconfig(config jsonb, context text default null, local boolean default false)`
+
+Loads Kubernetes credentials from a parsed kubeconfig JSON object.
+
+**Parameters:**
+
+- `config` (jsonb): The parsed kubeconfig as a JSON object
+- `context` (text, optional): The context to use. If null, uses the `current-context` from the config
+- `local` (boolean, default false): If true, configuration is only visible to the current transaction. If false,
+  configuration persists for the entire session
+
+**Example:**
+
+```postgresql
+-- Load from a JSONB config object
+select omni_kube.load_kubeconfig('{"current-context": "my-cluster", ...}'::jsonb);
+
+-- Use a specific context
+select omni_kube.load_kubeconfig(config_object, 'production-cluster');
+```
+
+### `omni_kube.load_kubeconfig(config json, context text default null, local boolean default false)`
+
+Loads Kubernetes credentials from a JSON kubeconfig object (automatically converts to jsonb).
+
+**Parameters:**
+
+- `config` (json): The kubeconfig as a JSON object
+- `context` (text, optional): The context to use
+- `local` (boolean, default false): Configuration scope (transaction vs session)
+
+### `omni_kube.load_kubeconfig(filename text, context text default null, local boolean default false)`
+
+Loads Kubernetes credentials directly from a kubeconfig file.
+
+**Parameters:**
+
+- `filename` (text): Path to the kubeconfig file
+- `context` (text, optional): The context to use
+- `local` (boolean, default false): Configuration scope (transaction vs session)
+
+!!! warning "Permissions required"
+
+    **Note**: This function uses `pg_read_file()` internally, which requires superuser privileges or the
+
+    `pg_read_server_files` role. If you don't have these privileges, load the file contents manually and use the JSON/JSONB version instead:
+
+     ```postgresql
+     -- Alternative for non-superusers (requires external file reading)
+     \set kubeconfig `cat ~/.kube/config`
+     select omni_kube.load_kubeconfig(omni_yaml.to_json(:'kubeconfig'));
+     ```
+
+**Example:**
+
+```postgresql
+-- Load default kubeconfig (requires superuser or pg_read_server_files role)
+select omni_kube.load_kubeconfig('/home/user/.kube/config');
+
+-- Load specific kubeconfig with custom context
+select omni_kube.load_kubeconfig('/path/to/kubeconfig', 'staging');
+```
+
+### `omni_kube.pod_credentials()`
+
+Automatically detects and returns service account credentials when running inside a Kubernetes pod.
+
+**Returns:**
+
+- `token` (text): The service account token
+- `cacert` (text): The cluster CA certificate
+
+> **Note**: This function uses `pg_read_file()` and `pg_stat_file()` internally to access service account files mounted
+> by Kubernetes. It requires superuser privileges or the `pg_read_server_files` role. This function is typically used
+> when
+> Postgres is running inside a Kubernetes pod with a service account.
+
+**Example:**
+
+```postgresql
+-- Check for in-cluster credentials (requires superuser or pg_read_server_files role)
+select *
+from omni_kube.pod_credentials();
+```
+
+## Supported Authentication Methods
+
+### 1. Client Certificates (Embedded)
+
+Certificates and keys embedded directly in the kubeconfig as base64-encoded data:
+
+```yaml
+users:
+- name: my-user
+  user:
+    client-certificate-data: LS0tLS1CRUdJTi... # base64 encoded cert
+    client-key-data: LS0tLS1CRUdJTi...         # base64 encoded key
+```
+
+**Configuration Variables Set:**
+
+- `omni_kube.clientcert` - The client certificate (PEM format)
+- `omni_kube.client_private_key` - The client private key (PEM format)
+
+### 2. Client Certificates (File References)
+
+Certificates and keys stored in separate files:
+
+```yaml
+users:
+- name: my-user
+  user:
+    client-certificate: /path/to/client.crt
+    client-key: /path/to/client.key
+```
+
+> **Note**: This method requires file system access via `pg_read_file()`, which needs superuser privileges or the
+`pg_read_server_files` role.
+
+**Configuration Variables Set:**
+
+- `omni_kube.clientcert` - The client certificate (loaded from file)
+- `omni_kube.client_private_key` - The client private key (loaded from file)
+
+### 3. Bearer Token (Embedded)
+
+Token embedded directly in the kubeconfig:
+
+```yaml
+users:
+- name: my-user
+  user:
+    token: eyJhbGciOiJSUzI1NiIsImtpZCI6...
+```
+
+**Configuration Variables Set:**
+
+- `omni_kube.token` - The bearer token
+
+### 4. Bearer Token (File Reference)
+
+Token stored in a separate file:
+
+```yaml
+users:
+- name: my-user
+  user:
+    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+```
+
+> **Note**: This method requires file system access via `pg_read_file()`, which needs superuser privileges or the
+`pg_read_server_files` role.
+
+**Configuration Variables Set:**
+
+- `omni_kube.token` - The bearer token (loaded from file)
+
+### 5. In-Cluster Service Account
+
+When running inside a Kubernetes pod, service account credentials are automatically available:
+
+- Token: `/var/run/secrets/kubernetes.io/serviceaccount/token`
+- CA Certificate: `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
+- Namespace: `/var/run/secrets/kubernetes.io/serviceaccount/namespace`
+
+> **Note**: Accessing these files requires superuser privileges or the `pg_read_server_files` role. This is typically
+> configured when deploying Postgres inside Kubernetes.
+
+## Privilege Requirements
+
+Several functions require elevated privileges to access the file system:
+
+### Required Roles/Privileges
+
+- **Superuser**: Full access to all file operations
+- **pg_read_server_files**: Granted role that allows reading server files
+
+### Granting Privileges
+
+```postgresql
+-- Grant pg_read_server_files role to a user
+grant pg_read_server_files to myuser;
+
+-- Or create a superuser (use with caution)
+alter user myuser superuser;
+```
+
+### Alternative Approaches for Non-Privileged Users
+
+If you cannot grant file reading privileges, use these alternatives:
+
+#### Load Kubeconfig via psql
+
+```postgresql
+-- Using psql variable substitution
+\set kubeconfig `cat ~/.kube/config`
+select omni_kube.load_kubeconfig(omni_yaml.to_json(:'kubeconfig'));
+```
+
+#### Manual Token Loading
+
+```postgresql
+-- Load token manually and set configuration
+\set token `cat /var/run/secrets/kubernetes.io/serviceaccount/token`
+\set cacert `cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
+
+-- Set configuration manually
+select set_config('omni_kube.token', :'token', false);
+select set_config('omni_kube.cacert', :'cacert', false);
+select set_config('omni_kube.server', 'https://kubernetes.default.svc', false);
+```
+
+## Cluster Configuration
+
+All authentication methods also configure cluster connection details:
+
+**Configuration Variables Set:**
+
+- `omni_kube.server` - The Kubernetes API server URL
+- `omni_kube.cacert` - The cluster CA certificate (PEM format)
+
+### CA Certificate Handling
+
+The system supports multiple ways to specify the cluster CA certificate:
+
+```yaml
+clusters:
+- name: my-cluster
+  cluster:
+    server: https://kubernetes.example.com:6443
+    # Option 1: Embedded base64-encoded certificate
+    certificate-authority-data: LS0tLS1CRUdJTi...
+    # Option 2: File reference (requires file system access)
+    certificate-authority: /path/to/ca.crt
+```
+
+## Error Handling
+
+The credential loading functions provide comprehensive error handling:
+
+### Missing Context
+
+```postgresql
+-- Will raise an exception if context doesn't exist
+select omni_kube.load_kubeconfig('/home/user/.kube/config', 'nonexistent-context');
+-- ERROR: Context 'nonexistent-context' not found in kubeconfig
+```
+
+### Permission Errors
+
+```postgresql
+-- Will raise an exception if lacking file reading privileges
+select omni_kube.load_kubeconfig('/home/user/.kube/config');
+-- ERROR: permission denied to read file
+```
+
+### Unsupported Authentication Methods
+
+```postgresql
+-- For exec plugins or auth providers
+select omni_kube.load_kubeconfig('/home/user/.kube/config', 'exec-context');
+-- NOTICE: Exec plugin authentication detected but not yet supported
+-- ERROR: Exec plugin authentication requires external command execution
+```
+
+### Missing Files
+
+```postgresql
+-- Will raise an exception if referenced files don't exist
+select omni_kube.load_kubeconfig('/nonexistent/kubeconfig');
+-- ERROR: could not open file "/nonexistent/kubeconfig"
+```
+
+## Configuration Variables
+
+After successful credential loading, the following Postgres configuration variables are available:
+
+| Variable                       | Description                  | Example                               |
+|--------------------------------|------------------------------|---------------------------------------|
+| `omni_kube.server`             | Kubernetes API server URL    | `https://kubernetes.example.com:6443` |
+| `omni_kube.cacert`             | Cluster CA certificate (PEM) | `-----BEGIN CERTIFICATE-----\n...`    |
+| `omni_kube.clientcert`         | Client certificate (PEM)     | `-----BEGIN CERTIFICATE-----\n...`    |
+| `omni_kube.client_private_key` | Client private key (PEM)     | `-----BEGIN PRIVATE KEY-----\n...`    |
+| `omni_kube.token`              | Bearer token                 | `eyJhbGciOiJSUzI1NiIs...`             |
+
+These variables are automatically used by other omni_kube functions for API authentication.
+
+## Security Considerations
+
+- **File Permissions**: Ensure kubeconfig files have appropriate permissions (typically 600)
+- **Postgres Privileges**: File reading functions require elevated privileges. Grant only `pg_read_server_files` when
+  possible instead of superuser
+- **Service Account Tokens**: In-cluster tokens are automatically rotated by Kubernetes
+- **Configuration Scope**: Credentials are loaded at the session level and persist for the duration of the database
+  connection
+- **Sensitive Data**: Configuration variables containing sensitive data should be handled according to your security
+  policies
+- **Least Privilege**: Consider using manual credential loading via psql for environments where file system access
+  should be restricted

--- a/extensions/omni_kube/docs/internals_api.md
+++ b/extensions/omni_kube/docs/internals_api.md
@@ -1,4 +1,4 @@
-# Kubernetes API
+# Internals: Kubernetes API
 
 ## `omni_kube.api()`
 

--- a/extensions/omni_kube/docs/resources.md
+++ b/extensions/omni_kube/docs/resources.md
@@ -1,4 +1,4 @@
-# omni_kube Resource Management
+# Resource Management
 
 omni_kube provides a comprehensive Postgres-based interface for managing Kubernetes resources through SQL views and
 functions. This system allows you to interact with Kubernetes API resources using standard SQL operations.

--- a/extensions/omni_kube/mkdocs.yml
+++ b/extensions/omni_kube/mkdocs.yml
@@ -1,2 +1,6 @@
 INHERIT: ../../mkdocs.base.yml
 site_name: omni_kube
+nav:
+- 'credentials.md'
+- 'resources.md'
+- 'internals_api.md'

--- a/extensions/omni_kube/src/instantiate.sql
+++ b/extensions/omni_kube/src/instantiate.sql
@@ -10,6 +10,7 @@ begin
 
     /*{% include "api.sql" %}*/
     /*{% include "pod_credentials.sql" %}*/
+    /*{% include "load_kubeconfig.sql" %}*/
 
     -- Core views
 

--- a/extensions/omni_kube/src/load_kubeconfig.sql
+++ b/extensions/omni_kube/src/load_kubeconfig.sql
@@ -1,0 +1,110 @@
+create function load_kubeconfig(config jsonb, context text default null, local boolean default false)
+    returns void as
+$$
+declare
+    context_config jsonb;
+    cluster_name   text;
+    user_name      text;
+    cluster_config jsonb;
+    user_config    jsonb;
+begin
+    -- Get current context unless passed
+    context := coalesce(context, config ->> 'current-context');
+
+    -- Find context configuration
+    select ctx
+    into context_config
+    from jsonb_array_elements(config -> 'contexts') as ctx
+    where ctx ->> 'name' = context;
+
+    if context_config is null then
+        raise exception 'context ''%'' not found', context;
+    end if;
+
+    cluster_name := context_config -> 'context' ->> 'cluster';
+    user_name := context_config -> 'context' ->> 'user';
+
+    -- Find cluster configuration
+    select cluster
+    into cluster_config
+    from jsonb_array_elements(config -> 'clusters') as cluster
+    where cluster ->> 'name' = cluster_name;
+
+    -- Find user configuration
+    select "user"
+    into user_config
+    from jsonb_array_elements(config -> 'users') as "user"
+    where "user" ->> 'name' = user_name;
+
+    -- Set server and CA cert
+    perform set_config('omni_kube.server',
+                       cluster_config -> 'cluster' ->> 'server', local);
+
+    if cluster_config -> 'cluster' ->> 'certificate-authority-data' is not null then
+        perform set_config('omni_kube.cacert',
+                           convert_from(decode(cluster_config -> 'cluster' ->> 'certificate-authority-data', 'base64'),
+                                        'utf8'),
+                           local);
+    elsif cluster_config -> 'cluster' ->> 'certificate-authority' is not null then
+        perform set_config('omni_kube.cacert',
+                           pg_read_file(cluster_config -> 'cluster' ->> 'certificate-authority'),
+                           local);
+    end if;
+
+    -- Handle different authentication methods
+    if user_config -> 'user' ->> 'client-certificate-data' is not null then
+        -- Embedded certificates
+        perform set_config('omni_kube.clientcert',
+                           convert_from(decode(user_config -> 'user' ->> 'client-certificate-data', 'base64'), 'utf8'),
+                           local);
+        perform set_config('omni_kube.client_private_key',
+                           convert_from(decode(user_config -> 'user' ->> 'client-key-data', 'base64'), 'utf8'),
+                           local);
+
+    elsif user_config -> 'user' ->> 'client-certificate' is not null then
+        -- Certificate files
+        perform set_config('omni_kube.clientcert',
+                           pg_read_file(user_config -> 'user' ->> 'client-certificate'),
+                           local);
+        perform set_config('omni_kube.client_private_key',
+                           pg_read_file(user_config -> 'user' ->> 'client-key'),
+                           local);
+
+    elsif user_config -> 'user' ->> 'token' is not null then
+        -- Token authentication
+        perform set_config('omni_kube.token',
+                           user_config -> 'user' ->> 'token',
+                           local);
+
+    elsif user_config -> 'user' ->> 'tokenFile' is not null then
+        -- Token from file
+        perform set_config('omni_kube.token',
+                           trim(pg_read_file(user_config -> 'user' ->> 'tokenFile')),
+                           local);
+
+    elsif user_config -> 'user' -> 'exec' is not null then
+        -- Exec plugin - this would require executing external commands
+        raise notice 'Exec plugin authentication detected but not yet supported';
+        raise exception 'Exec plugin authentication requires external command execution';
+
+    elsif user_config -> 'user' -> 'auth-provider' is not null then
+        -- Auth provider - complex, provider-specific logic needed
+        raise notice 'Auth provider detected: %', user_config -> 'user' -> 'auth-provider' ->> 'name';
+        raise exception 'Auth provider authentication not yet supported';
+
+    else
+        raise exception 'No supported authentication method found in kubeconfig';
+    end if;
+
+end;
+$$ language plpgsql;
+
+create function load_kubeconfig(config json, context text default null, local boolean default false)
+    returns void
+    language sql
+return load_kubeconfig(config::jsonb, context, local);
+
+create function load_kubeconfig(filename text, context text default null, local boolean default false)
+    returns void
+    language sql
+return load_kubeconfig(omni_yaml.to_json(pg_read_file(filename)), context, local);


### PR DESCRIPTION
In-container credentials are picked up automatically but everything else is much harder.

Solution: introduce `load_kubeconfig` to simplify credentials