### PR TITLE
Problem: flaky omni_kube test

### DIFF
--- a/extensions/omni_kube/CHANGELOG.md
+++ b/extensions/omni_kube/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.0] - TBD
 
+### Added
+
+* Support for `generateName` [#923](https://github.com/omnigres/omnigres/pull/923)
+
 ## [0.2.0] - 2025-07-24
 
 ### Added

--- a/extensions/omni_kube/src/resource_view.sql
+++ b/extensions/omni_kube/src/resource_view.sql
@@ -42,17 +42,19 @@ begin
       spec_ns text;
       name text;
       url text;
+      metadata jsonb;
     begin
       if new.uid is not null then
          raise exception 'new resources can''t have uid';
       end if;
-      spec_ns := coalesce(coalesce(new.resource->'metadata','{"namespace": "default"}'::jsonb)->>'namespace', 'default');
+      metadata := coalesce(new.resource->'metadata','{"namespace": "default"}'::jsonb);
+      spec_ns := coalesce(metadata->>'namespace', 'default');
       if new.namespace is not null and spec_ns != new.namespace then
         raise exception 'namespace (%%) must match metadata (%%)', new.namespace, spec_ns;
       end if;
-      name := coalesce(coalesce(new.resource->'metadata','{}')->>'name', new.name);
+      name := coalesce(coalesce(metadata->>'name', metadata->>'generateName'), new.name);
       if name is null then
-        raise exception 'resource is required to have a name';
+        raise exception 'resource is required to have `name` or `generateName`';
       end if;
       if new.name is not null and name != new.name then
         raise exception 'name (%%) must match metadata (%%)', new.name, name;

--- a/extensions/omni_kube/tests/test.yml
+++ b/extensions/omni_kube/tests/test.yml
@@ -77,58 +77,41 @@ tests:
            from pods
     results:
     - non_empty: true
-  - name: cleanup from previous failures
+  - name: clean up from previous failures
     query: |
-      do
-      $$
-          declare
-              exit_flag boolean := false;
-          begin
-              while not exit_flag
-                  loop
-                      delete
-                      from pods
-                      where name = 'nginx-pod-omni-kube';
-                      -- check
-                      select count(*) = 0
-                      into exit_flag
-                      from pods
-                      where name = 'nginx-pod-omni-kube';
-                  end loop;
-          exception
-              when others then
-                  if sqlerrm = 'NotFound' then
-                      null;
-                  else
-                      raise;
-                  end if;
-          end;
-      $$
+      delete
+      from pods
+      where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
+  - name: should be clean
+    query: select
+           from pods
+           where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
+    results: [ ]
   - name: insert into it
     query: |
       insert into pods (resource)
-      values ('{ "metadata": { "name": "nginx-pod-omni-kube", "labels": {"omnigres.com/test": "true"} }, "spec": { "containers": [{ "name": "test", "image": "nginx" }] } }')
+      values ('{ "metadata": { "generateName": "nginx-pod-omni-kube-", "labels": {"omnigres.com/test": "true"} }, "spec": { "containers": [{ "name": "test", "image": "nginx" }] } }')
   - name: find it
-    query: select name
+    query: select true as found
            from pods
-           where name = 'nginx-pod-omni-kube'
+           where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
     results:
-    - name: nginx-pod-omni-kube
+    - found: true
   - name: wait for things to settle (to prevent Conflict)
     query: select pg_sleep(1)
   - name: update it
     query: |
       update pods
       set resource = jsonb_set(resource, '{metadata,labels,omnigres.com/test}', '"passed"')
-      where name = 'nginx-pod-omni-kube'
+      where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
   - name: check labels
     query: select resource -> 'metadata' -> 'labels' labels
            from pods
-           where name = 'nginx-pod-omni-kube'
+           where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
     results:
     - labels:
         "omnigres.com/test": passed
   - name: cleanup
     query: delete
            from pods
-           where name = 'nginx-pod-omni-kube'
+           where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null


### PR DESCRIPTION
Deleting previously failed pods would lock up (because it's sharing a snapshot cached by `api()`)

Solution: use `generateName` to generate pod name instead and use labeling to find & clean up.

This necessitated adding support for `generateName` in `resource_view`