### PR TITLE
Problem: watching Kubernetes resources

### DIFF
--- a/extensions/omni_kube/CHANGELOG.md
+++ b/extensions/omni_kube/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 * Support for `generateName` [#923](https://github.com/omnigres/omnigres/pull/923)
+* Basic support for watches [#924](https://github.com/omnigres/omnigres/pull/924)
 
 ## [0.2.0] - 2025-07-24
 

--- a/extensions/omni_kube/docs/internals_api.md
+++ b/extensions/omni_kube/docs/internals_api.md
@@ -2,23 +2,113 @@
 
 ## `omni_kube.api()`
 
-This is the central function to invoke Kubernetes API calls
+This is the central function to invoke Kubernetes API calls. It supports both single and batch requests.
+
+### Single Request
+
+```sql
+omni_kube.api(path, [server], [cacert], [clientcert], [token], [method], [body], [stream])
+```
 
 |  **Parameter** | **Type**                      | **Description**                                                 |
 |---------------:|-------------------------------|-----------------------------------------------------------------|
-|       **path** | text                          | Request path                                                    |
+|       **path** | text                          | Request path (must start with `/`)                              |
 |     **server** | text                          | Kubernetes server, defaults to `https://kubernetes.default.svc` |
 |     **cacert** | text                          | CA certificate                                                  |
 | **clientcert** | omni_httpc.client_certificate | Client certificate                                              |
 |      **token** | text                          | Bearer token                                                    |
 |     **method** | omni_http.http_method         | HTTP method, defaults to `GET`                                  |
 |       **body** | jsonb                         | Request body                                                    |
+|     **stream** | boolean                       | Stream mode for multiple JSON objects, defaults to `false`      |
+
+**Returns:** `jsonb` - The response body
+
+### Batch Request
+
+```sql
+omni_kube.api(paths, [server], [cacert], [clientcert], [token], [methods], [bodies], [stream])
+```
+
+|  **Parameter** | **Type**                      | **Description**                                                 |
+|---------------:|-------------------------------|-----------------------------------------------------------------|
+|      **paths** | text[]                        | Array of request paths                                          |
+|     **server** | text                          | Kubernetes server, defaults to `https://kubernetes.default.svc` |
+|     **cacert** | text                          | CA certificate                                                  |
+| **clientcert** | omni_httpc.client_certificate | Client certificate                                              |
+|      **token** | text                          | Bearer token                                                    |
+|    **methods** | omni_http.http_method[]       | Array of HTTP methods (defaults to `GET` for all requests)      |
+|     **bodies** | jsonb[]                       | Array of request bodies                                         |
+|     **stream** | boolean                       | Stream mode for multiple JSON objects, defaults to `false`      |
+
+**Returns:** `TABLE(response jsonb, status int2)` - Response body and HTTP status for each request
+
+### Caching & Error Handling
+
+- Single requests are cached per statement using request digest
+- Single requests with status codes ≥ 400 raise exceptions with Kubernetes error details
+- Stream mode converts newline-delimited JSON responses into JSONB arrays
+
+## `omni_kube.watch()`
+
+This function enables watching Kubernetes resources for changes using the Kubernetes watch API.
+
+### Single Resource Watch
+
+```sql
+omni_kube.watch(group_version, resource, [resource_version], [timeout])
+```
+
+|        **Parameter** | **Type** | **Description**                                    |
+|---------------------:|----------|----------------------------------------------------|
+|    **group_version** | text     | API group version (e.g., `v1`, `apps/v1`)          |
+|         **resource** | text     | Resource type (e.g., `pods`, `deployments`)        |
+| **resource_version** | text     | Specific resource version to watch from (optional) |
+|          **timeout** | int      | Watch timeout in seconds, defaults to `1`          |
+
+**Returns:** `TABLE(events jsonb[], status int2)` - Events and HTTP status for each watch stream.
+
+### Batch Resource Watch
+
+```sql
+omni_kube.watch(group_versions, resources, [resource_versions], [timeout])
+```
+
+|         **Parameter** | **Type** | **Description**                                     |
+|----------------------:|----------|-----------------------------------------------------|
+|    **group_versions** | text[]   | Array of API group versions                         |
+|         **resources** | text[]   | Array of resource types                             |
+| **resource_versions** | text[]   | Array of resource versions to watch from (optional) |
+|           **timeout** | int      | Watch timeout in seconds, defaults to `1`           |
+
+**Returns:** `TABLE(events jsonb[], status int2)` - Events and HTTP status for each watch stream.
+
+### Behavior Notes
+
+- **Resource Version Handling**: When `resource_version` is not specified, the function automatically fetches the
+  current resource version and starts watching from that point
+- **Timeout Behavior**: The function will wait for the specified timeout duration before returning. Setting a long
+  timeout will cause the function to block for that entire duration
+
+### Example Usage
+
+```sql
+-- Watch pods in the default namespace with 30-second timeout
+select omni_kube.watch('v1', 'pods', timeout => 30);
+
+-- Watch multiple resources simultaneously
+select *
+from omni_kube.watch(
+        array ['v1', 'apps/v1'],
+        array ['pods', 'deployments'],
+        timeout => 60
+     );
+```
+
+## Authentication & Certificates
 
 **token** and **cacert** are automatically inferred from default pod's
-paths (`var/run/secrets/kubernetes.io/serviceaccount/token` and `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
-respectively) to enable
-seamless use of API from within pods (through `omni_kube.pod_credentials()` function). They can be overriden by
-corresponding
-function parameters or `omni_kube.token` and `omni_kube.cacert` settings. In addition
+paths (`/var/run/secrets/kubernetes.io/serviceaccount/token` and `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
+respectively) to enable seamless use of API from within pods (through `omni_kube.pod_credentials()` function). They can
+be overridden by corresponding function parameters or `omni_kube.token` and `omni_kube.cacert` settings. In addition,
 `omni_kube.clientcert` and `omni_kube.client_private_key` settings can be used to override
 the `clientcert` parameter.

--- a/extensions/omni_kube/docs/resources.md
+++ b/extensions/omni_kube/docs/resources.md
@@ -199,6 +199,29 @@ The system includes comprehensive validation:
 - **UID Restrictions**: Prevents manual UID assignment for new resources
 - **Resource Existence**: Validates resources exist before update/delete operations
 
+Add this section to your **Resource Discovery Functions** section, after the `omni_kube.resources()` function:
+
+### `omni_kube.resources_metadata(group_version text, resource text)`
+
+Retrieves only the metadata section from a Kubernetes resource collection, which is useful for getting information like
+resource versions without fetching the entire resource list.
+
+**Parameters:**
+
+- `group_version`: The group/version identifier (e.g., 'v1', 'apps/v1')
+- `resource`: The resource type name
+
+**Returns:**
+
+- `jsonb`: The metadata object from the Kubernetes API response, typically containing fields like `resourceVersion`.
+
+**Example:**
+
+```postgresql
+-- Get the current resource version for pods
+select omni_kube.resources_metadata('v1', 'pods') ->> 'resourceVersion' as current_version;
+```
+
 ## Usage Examples
 
 ### Working with Deployments

--- a/extensions/omni_kube/src/api.sql
+++ b/extensions/omni_kube/src/api.sql
@@ -1,18 +1,20 @@
-create function api(path text,
+create function api(paths text[],
                     server text default coalesce(current_setting('omni_kube.server', true),
                                                  'https://kubernetes.default.svc'),
                     cacert text default current_setting('omni_kube.cacert', true),
                     clientcert omni_httpc.client_certificate default row (current_setting('omni_kube.clientcert', true), current_setting('omni_kube.client_private_key', true))::omni_httpc.client_certificate,
                     token text default current_setting('omni_kube.token', true),
-                    method omni_http.http_method default 'GET',
-                    body jsonb default null) returns jsonb
+                    methods omni_http.http_method[] default null,
+                    bodies jsonb[] default null, stream boolean default false)
+    returns table
+            (
+                response jsonb,
+                status   int2
+            )
     language plpgsql
 as
 $$
 declare
-    response omni_httpc.http_response;
-    request_digest  text;
-    cached_response jsonb;
 begin
     if cacert is null then
         select p.cacert into cacert from omni_kube.pod_credentials() p;
@@ -20,10 +22,53 @@ begin
     if token is null then
         select p.token into token from omni_kube.pod_credentials() p;
     end if;
+
+    return query
+        with request as (select (omni_httpc.http_request(
+                                        format('%1$s%2$s', server, unnest(paths)),
+                                        unnest(methods),
+                                        array [
+                                            omni_http.http_header('Content-Type', 'application/json'),
+                                            omni_http.http_header('Accept', 'application/json'),
+                                            omni_http.http_header('Authorization', 'Bearer ' || token)
+                                            ],
+                                        convert_to(unnest(bodies::text[]), 'UTF8')
+                                 )) as req),
+             agg_request as (select array_agg(req) agg_req from request)
+        select case
+                   when response.body = '' then null
+                   when stream then
+                       to_jsonb(string_to_array(rtrim(convert_from(response.body, 'utf-8'), E'\n'), E'\n')::jsonb[])
+                   else convert_from(response.body, 'utf-8')::jsonb end,
+               response.status
+        from agg_request,
+        omni_httpc.http_execute_with_options(
+                omni_httpc.http_execute_options(allow_self_signed_cert => cacert is null,
+                                                cacerts => case when cacert is null then null else array [cacert] end,
+                                                clientcert => case when clientcert is null then null else clientcert end),
+                variadic agg_req) response;
+end;
+$$;
+
+create function api(path text,
+                    server text default coalesce(current_setting('omni_kube.server', true),
+                                                 'https://kubernetes.default.svc'),
+                    cacert text default current_setting('omni_kube.cacert', true),
+                    clientcert omni_httpc.client_certificate default row (current_setting('omni_kube.clientcert', true), current_setting('omni_kube.client_private_key', true))::omni_httpc.client_certificate,
+                    token text default current_setting('omni_kube.token', true),
+                    method omni_http.http_method default 'GET',
+                    body jsonb default null, stream boolean default false) returns jsonb
+    language plpgsql as
+$$
+declare
+    result          jsonb;
+    response_status int2;
+    request_digest  text;
+    cached_response jsonb;
+begin
     if substring(path, 1, 1) != '/' then
         raise exception 'path must start with a leading slash';
     end if;
-
 
     request_digest := encode(digest(method || ' ' || server || path || coalesce(cacert, 'NULL_CACERT') ||
                                     coalesce(token, 'NULL_TOKEN') || coalesce(body, 'null'), 'sha256'), 'hex');
@@ -31,30 +76,13 @@ begin
     if cached_response is not null then
         return cached_response;
     end if;
-    select *
-    into response
-    from
-        omni_httpc.http_execute_with_options(
-                omni_httpc.http_execute_options(allow_self_signed_cert => cacert is null,
-                                                cacerts => case when cacert is null then null else array [cacert] end,
-                                                clientcert => case when clientcert is null then null else clientcert end),
-                omni_httpc.http_request(
-                        format('%1$s%2$s', server, path),
-                        method,
-                        array [
-                            omni_http.http_header('Content-Type', 'application/json'),
-                            omni_http.http_header('Accept', 'application/json'),
-                            omni_http.http_header('Authorization', 'Bearer ' || token)
-                            ],
-                        convert_to(body::text, 'UTF8')
-                ));
-    if response.error is not null then
-        raise exception 'error: %', response.error;
+    select response, status
+    into result, response_status
+    from api(array [path], server, cacert, clientcert, token, array [method],
+             array [body], stream);
+    if response_status >= 400 then
+        raise exception '%', result ->> 'reason' using detail = result ->> 'message';
     end if;
-    body := convert_from(response.body, 'utf-8')::jsonb;
-    if response.status >= 400 then
-        raise exception '%', body ->> 'reason' using detail = body ->> 'message';
-    end if;
-    return omni_var.set_statement('omni_kube.request_' || request_digest, body);
+    return omni_var.set_statement('omni_kube.request_' || request_digest, result);
 end;
 $$;

--- a/extensions/omni_kube/src/instantiate.sql
+++ b/extensions/omni_kube/src/instantiate.sql
@@ -9,6 +9,12 @@ begin
     perform set_config('search_path', schema::text || ',public', true);
 
     /*{% include "api.sql" %}*/
+    execute format(
+            'alter function api(text[], text, text, omni_httpc.client_certificate, text, omni_http.http_method[], jsonb[], boolean) set search_path = %L, public',
+            schema::text);
+    execute format(
+            'alter function api(text, text, text, omni_httpc.client_certificate, text, omni_http.http_method, jsonb, boolean) set search_path = %L, public',
+            schema::text);
     /*{% include "pod_credentials.sql" %}*/
     /*{% include "load_kubeconfig.sql" %}*/
 
@@ -52,8 +58,11 @@ begin
     execute format('alter function group_resources set search_path = %s', schema::text || ',public');
     /*{% include "resources.sql" %}*/
     execute format('alter function resources set search_path = %s', schema::text || ',public');
+    /*{% include "resources_metadata.sql" %}*/
+    execute format('alter function resources_metadata set search_path = %s', schema::text || ',public');
     /*{% include "resource_view.sql" %}*/
     execute format('alter function resource_view set omni_kube.search_path = %L', schema::text);
+    /*{% include "watch.sql" %}*/
 
     -- Restore the path
     perform

--- a/extensions/omni_kube/src/resources_metadata.sql
+++ b/extensions/omni_kube/src/resources_metadata.sql
@@ -1,0 +1,13 @@
+create function resources_metadata(group_version text, resource text)
+    returns jsonb
+    language plpgsql
+as
+$resources$
+declare
+    response jsonb = api('/' ||
+                         case when group_version in ('v1') then 'api/v1' else 'apis/' || group_version end || '/' ||
+                         resource);
+begin
+    return response -> 'metadata';
+end;
+$resources$;

--- a/extensions/omni_kube/src/watch.sql
+++ b/extensions/omni_kube/src/watch.sql
@@ -1,0 +1,39 @@
+create function watch(group_versions text[], resources text[], resource_versions text[] default null,
+                      timeout int default 1)
+    returns table
+            (
+                events jsonb[],
+                status   int2
+            )
+begin
+    atomic;
+    with resource_versions as (select resources_metadata(unnest(group_versions), unnest(resources)) ->>
+                                      'resourceVersion' as resource_version),
+         items as (select unnest(group_versions)                                        as group_version,
+                          unnest(resources)                                             as resource,
+                          unnest(array(select resource_version from resource_versions)) as resource_version,
+                          unnest(watch.resource_versions)                               as requested_version),
+         resp as (select api(array_agg('/' ||
+                                              case
+                                                  when group_version in ('v1')
+                                                      then 'api/v1'
+                                                  else 'apis/' || group_version end ||
+                                              '/' ||
+                                              resource || '?watch=1&resourceVersion=' ||
+                                              coalesce(requested_version, resource_version) || '&timeoutSeconds=' ||
+                                       timeout), stream => true) as e
+                             from items)
+    select array(select jsonb_array_elements((e).response)), (e).status
+    from resp;
+end;
+
+create function watch(group_version text, resource text, resource_version text default null, timeout int default 1)
+    returns table
+            (
+                events jsonb[],
+                status int2
+            )
+begin
+    atomic;
+    select watch(array [group_version], array [resource], array [resource_version], timeout);
+end;

--- a/extensions/omni_kube/tests/watch.yml
+++ b/extensions/omni_kube/tests/watch.yml
@@ -1,0 +1,53 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_kube cascade
+  - create extension omni_os cascade
+
+tests:
+
+- select omni_kube.load_kubeconfig((select value from omni_os.env where variable = 'HOME') || '/.kube/config')
+
+- name: watch smoke test
+  steps:
+  - name: establish a pod view
+    query: select omni_kube.resource_view('pods', 'v1', 'pods')
+  - name: clean up from previous failures
+    query: |
+      delete
+      from pods
+      where resource -> 'metadata' -> 'labels' -> 'omnigres.com/watch-test' is not null
+  - name: save the resource version
+    query: |
+      create table rv as
+      select omni_kube.resources_metadata('v1', 'pods') ->> 'resourceVersion' as resource_version
+  - name: insert into it
+    query: |
+      insert into pods (resource)
+      values ('{ "metadata": { "generateName": "nginx-pod-omni-kube-", "labels": {"omnigres.com/watch-test": "true"} }, "spec": { "containers": [{ "name": "test", "image": "nginx" }] } }')
+  - name: watch
+    query: |
+      select count(*)
+      from omni_kube.watch('v1', 'pods',
+                           resource_version => (select resource_version from rv)), lateral unnest(events) as event
+      where event -> 'object' -> 'metadata' -> 'labels' ->> 'omnigres.com/watch-test' = 'true'
+        and event ->> 'type' = 'ADDED'
+    results:
+    - count: 1
+  - name: update the meta resource version
+    query: |
+      create table rv1 as
+      select omni_kube.resources_metadata('v1', 'pods') ->> 'resourceVersion' as resource_version
+  - name: nothing should be added in the new version
+    query: |
+      select count(*)
+      from omni_kube.watch('v1', 'pods',
+                           resource_version => (select resource_version from rv1)), lateral unnest(events) as event
+      where event -> 'object' -> 'metadata' -> 'labels' ->> 'omnigres.com/watch-test' = 'true'
+        and event ->> 'type' = 'ADDED'
+    results:
+    - count: 0
+  - name: cleanup
+    query: delete
+           from pods
+           where resource -> 'metadata' -> 'labels' -> 'omnigres.com/watch-test' is not null


### PR DESCRIPTION
Right now the only operation possible is to list resources. It may be generally sufficient, but sometimes watching for event is more preferrable.

Solution: introduce a limited watching capability

It's not really "streaming" as it forces a timeout to finish and return the results (until we figure out a better model for it)

This also pushed me to make it possible to make multiple API requests at the same time to be able to watch on multiple resource collections at once.