### PR TITLE
Problem: developing Kubernetes operators/controllers

### DIFF
--- a/extensions/omni_kube/CHANGELOG.md
+++ b/extensions/omni_kube/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Support for `generateName` [#923](https://github.com/omnigres/omnigres/pull/923)
 * Basic support for watches [#924](https://github.com/omnigres/omnigres/pull/924)
 * Basic support for selectors [#925](https://github.com/omnigres/omnigres/pull/925)
+* Resource tables [#927](https://github.com/omnigres/omnigres/pull/927)
 
 ### Fixed
 

--- a/extensions/omni_kube/docs/resources.md
+++ b/extensions/omni_kube/docs/resources.md
@@ -228,6 +228,27 @@ resource versions without fetching the entire resource list.
 select omni_kube.resources_metadata('v1', 'pods') ->> 'resourceVersion' as current_version;
 ```
 
+## Resource Tables
+
+The `omni_kube.resource_table()` function provides an alternative to dynamic views by creating materialized tables that
+cache Kubernetes resource data locally. Like `resource_view()`, it accepts the same parameters for specifying the target
+API group, version, and resource type. The key advantage of resource tables is performance and a stable view – they
+store resource data locally in the database rather than making API calls on each query.
+
+Each generated table has a corresponding `refresh_<table_name>()` function that synchronizes the local data with the
+current state of the Kubernetes cluster.
+
+This refresh mechanism allows you to control when expensive API calls occur, making resource tables ideal for scenarios
+where you need to perform complex queries, joins, or analytics on Kubernetes data without the latency of repeated API
+requests. The refresh function can be called manually or scheduled for automated data synchronization.
+
+Resource tables are particularly valuable for building Kubernetes operators and controllers, where you need to maintain
+local state, perform complex reconciliation logic across multiple resource types, or implement sophisticated filtering
+and aggregation operations that would be inefficient when executed against live API endpoints.
+
+The function returns a table of `(type text, object jsonb)` where type is `ADDED`, `MODIFIED` or `DELETED` and object
+is the object in question.
+
 ## Usage Examples
 
 ### Working with Deployments

--- a/extensions/omni_kube/src/instantiate.sql
+++ b/extensions/omni_kube/src/instantiate.sql
@@ -62,6 +62,8 @@ begin
     execute format('alter function resources_metadata set search_path = %s', schema::text || ',public');
     /*{% include "resource_view.sql" %}*/
     execute format('alter function resource_view set omni_kube.search_path = %L', schema::text);
+    /*{% include "resource_table.sql" %}*/
+    execute format('alter function resource_table set omni_kube.search_path = %L', schema::text);
     /*{% include "watch.sql" %}*/
 
     -- Restore the path

--- a/extensions/omni_kube/src/resource_table.sql
+++ b/extensions/omni_kube/src/resource_table.sql
@@ -1,0 +1,191 @@
+create function resource_table(table_name name, group_version text, resource text, label_selector text default null,
+                               field_selector text default null)
+    returns regclass
+    language plpgsql
+as
+$resource_table$
+declare
+    ns              name := current_setting('omni_kube.search_path');
+    url             text;
+    is_namespaced   boolean;
+    resource_kind   text;
+    old_search_path text := current_setting('search_path');
+begin
+    execute format('set search_path to %I, public', ns);
+    select namespaced, kind into is_namespaced, resource_kind from group_resources(group_version) where name = resource;
+    perform
+        set_config('search_path', old_search_path, true);
+
+    if is_namespaced then
+        url := '/' ||
+               case when group_version in ('v1') then 'api/v1' else 'apis/' || group_version end || '/namespaces/%s/' ||
+               resource;
+    else
+        url := '/' ||
+               case when group_version in ('v1') then 'api/v1' else 'apis/' || group_version end || '/' ||
+               resource;
+    end if;
+    execute format($resource_table_$
+    create table %I as
+    select
+     resource->'metadata'->>'uid' as uid,
+     resource->'metadata'->>'name' as name,
+     resource->'metadata'->>'namespace' as namespace,
+     * from %I.resources(%L, %L, label_selector => %L, field_selector => %L) resource
+    $resource_table_$, table_name, ns, group_version, resource, label_selector, field_selector);
+
+    execute format($$create unique index %2$I on %1$I (uid) $$, table_name, table_name || '_index_uid');
+    execute format(
+            $$create unique index %2$I on %1$I (name, namespace) $$,
+            table_name,
+            table_name || '_index_name_space');
+
+    execute format($resource_table_refresh$
+    create function %1$I() returns table (type text, object jsonb)
+    set omni_kube.refresh = true
+    begin atomic;
+     with new as materialized (select
+     resource->'metadata'->>'uid' as uid,
+     resource->'metadata'->>'name' as name,
+     resource->'metadata'->>'namespace' as namespace,
+     resource from %3$I.resources(%4$L, %5$L, label_selector => %6$L, field_selector => %7$L) resource),
+       deletion as (delete from %2$I where not exists (select from new where new.uid = %2$I.uid) returning %2$I.*),
+       insertion as (insert into %2$I select * from new where not exists (select from %2$I x where x.uid = new.uid) returning %2$I.*),
+       updating as (update %2$I set uid = new.uid, name = new.name, namespace = new.namespace, resource = new.resource
+          from new where new.uid = %2$I.uid and (new) != (%2$I) returning %2$I.*)
+       select 'DELETED' as type, od.resource as object from deletion od
+       union all
+       select 'ADDED' as type, oi.resource as object from insertion oi
+       union all
+       select 'MODIFIED' as type, ou.resource as object from updating ou;
+    end;
+    $resource_table_refresh$, 'refresh_' || table_name, table_name, ns, group_version, resource, label_selector,
+                   field_selector);
+
+    execute format($resource_table_insert$
+    create or replace function %I() returns trigger
+    set search_path to %I, public
+    language plpgsql as
+    $$
+    declare
+      spec_ns text;
+      name text;
+      url text;
+      metadata jsonb;
+      result jsonb;
+    begin
+      if current_setting('omni_kube.refresh', true) = 'true' then
+        return new;
+      end if;
+      if new.uid is not null then
+         raise exception 'new resources can''t have uid';
+      end if;
+      metadata := coalesce(new.resource->'metadata','{"namespace": "default"}'::jsonb);
+      spec_ns := coalesce(metadata->>'namespace', 'default');
+      if new.namespace is not null and spec_ns != new.namespace then
+        raise exception 'namespace (%%) must match metadata (%%)', new.namespace, spec_ns;
+      end if;
+      name := coalesce(coalesce(metadata->>'name', metadata->>'generateName'), new.name);
+      if name is null then
+        raise exception 'resource is required to have `name` or `generateName`';
+      end if;
+      if new.name is not null and name != new.name then
+        raise exception 'name (%%) must match metadata (%%)', new.name, name;
+      end if;
+      new.resource := jsonb_set(new.resource, '{kind}', to_jsonb(%L::text));
+      new.resource := jsonb_set(new.resource, '{apiVersion}', to_jsonb(%L::text));
+      url := format(%L, spec_ns);
+      select api(url, body => new.resource, method => 'POST') into result;
+      new.uid := result->'metadata'->>'uid';
+      new.name := result->'metadata'->>'name';
+      new.namespace := result->'metadata'->>'namespace';
+      new.resource := result;
+      return new;
+    end;
+    $$
+    $resource_table_insert$, table_name || '_insert', ns, resource_kind, group_version, url);
+
+    execute format($resource_table_insert_t$
+    create trigger %1$I before insert on %2$I for each row
+    execute function %1$I()
+    $resource_table_insert_t$, table_name || '_insert', table_name);
+
+    execute format($resource_table_update$
+    create or replace function %I() returns trigger
+    set search_path to %I, public
+    language plpgsql as
+    $$
+    declare
+      spec_ns text;
+      name text;
+      url text;
+      result jsonb;
+    begin
+      if current_setting('omni_kube.refresh', true) = 'true' then
+        return new;
+      end if;
+      spec_ns := coalesce(coalesce(new.resource->'metadata','{"namespace": "default"}'::jsonb)->>'namespace', 'default');
+      if new.namespace is not null and spec_ns != new.namespace then
+        raise exception 'namespace (%%) must match metadata (%%)', new.namespace, spec_ns;
+      end if;
+      name := coalesce(coalesce(new.resource->'metadata','{}')->>'name', new.name);
+      if name is null then
+        raise exception 'resource is required to have a name';
+      end if;
+      if new.name is not null and name != new.name then
+        raise exception 'name (%%) must match metadata (%%)', new.name, name;
+      end if;
+      url := format(%L, spec_ns);
+      select api(url || '/' || name, body => new.resource, method => 'PUT') into result;
+      new.name := result->'metadata'->>'name';
+      new.namespace := result->'metadata'->>'namespace';
+      new.resource := result;
+      return new;
+    end;
+    $$
+    $resource_table_update$, table_name || '_update', ns, url);
+
+    execute format($resource_table_update_t$
+    create trigger %1$I before update on %2$I for each row
+    execute function %1$I()
+    $resource_table_update_t$, table_name || '_update', table_name);
+
+    execute format($resource_table_delete$
+    create or replace function %I() returns trigger
+    set search_path to %I, public
+    language plpgsql as
+    $$
+    declare
+      spec_ns text;
+      name text;
+      url text;
+    begin
+      if current_setting('omni_kube.refresh', true) = 'true' then
+        return old;
+      end if;
+      spec_ns := coalesce(coalesce(old.resource->'metadata','{"namespace": "default"}'::jsonb)->>'namespace', 'default');
+      if old.namespace is not null and spec_ns != old.namespace then
+        raise exception 'namespace (%%) must match metadata (%%)', old.namespace, spec_ns;
+      end if;
+      name := coalesce(coalesce(old.resource->'metadata','{}')->>'name', old.name);
+      if name is null then
+        raise exception 'resource is required to have a name';
+      end if;
+      if old.name is not null and name != old.name then
+        raise exception 'name (%%) must match metadata (%%)', old.name, name;
+      end if;
+      url := format(%L, spec_ns);
+      perform api(url || '/' || name, method => 'DELETE');
+      return old;
+    end;
+    $$
+    $resource_table_delete$, table_name || '_delete', ns, url);
+
+    execute format($resource_table_delete_t$
+    create trigger %1$I before delete on %2$I for each row
+    execute function %1$I()
+    $resource_table_delete_t$, table_name || '_delete', table_name);
+
+    return table_name;
+end;
+$resource_table$;

--- a/extensions/omni_kube/tests/test.yml
+++ b/extensions/omni_kube/tests/test.yml
@@ -82,11 +82,6 @@ tests:
       delete
       from pods
       where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
-  - name: should be clean
-    query: select
-           from pods
-           where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
-    results: [ ]
   - create table pod_uid
     (
         uid text not null
@@ -119,7 +114,7 @@ tests:
   - name: find it
     query: select true as found
            from pods
-           where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
+                    inner join pod_uid pu on pu.uid = pods.uid
     results:
     - found: true
   - name: field selector
@@ -158,7 +153,8 @@ tests:
           updating as (
       update pods
       set resource = jsonb_set(resource, '{metadata,labels,omnigres.com/test}', '"passed"')
-          where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null returning *)
+          from pod_uid
+          where pods.uid = pod_uid.uid returning *)
       select
           resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' as label
       from
@@ -168,7 +164,7 @@ tests:
   - name: check labels
     query: select resource -> 'metadata' -> 'labels' labels
            from pods
-           where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
+                    inner join pod_uid pu on pu.uid = pods.uid
     results:
     - labels:
         "omnigres.com/test": passed
@@ -182,4 +178,146 @@ tests:
   - name: cleanup
     query: delete
            from pods
+               using pod_uid pu
+           where pu.uid = pods.uid
+
+- name: resource table
+  steps:
+  - name: establish the table
+    query: select omni_kube.resource_table('pods', 'v1', 'pods')
+  - name: look at it
+    query: select count(*) > 0 as non_empty
+           from pods
+    results:
+    - non_empty: true
+  - name: clean up from previous failures
+    query: |
+      delete
+      from pods
+      where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
+  - name: should be clean
+    query: select
+           from pods
            where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
+    results: [ ]
+  - create table pod_uid
+    (
+        uid text not null
+    )
+  - name: insert into it
+    query: |
+      with insertion as (insert into pods (resource)
+          values ('{ "metadata": { "generateName": "nginx-pod-omni-kube-", "labels": {"omnigres.com/test": "true"} }, "spec": { "containers": [{ "name": "test", "image": "nginx" }] } }')
+          returning *)
+      insert
+      into pod_uid (uid)
+      select uid
+      from insertion
+  - name: ensure we got the uid (conditions satisfied)
+    query: select count(*) > 0 as non_empty
+           from pod_uid
+    results:
+    - non_empty: true
+  - name: find it
+    query: select true as found
+           from pods
+           where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
+    results:
+    - found: true
+  - name: wait for things to settle (to prevent Conflict)
+    query: select pg_sleep(1)
+  - name: refresh before updating
+    query: select refresh_pods()
+  - name: update it
+    query: |
+      with updating as (
+          update pods
+              set resource = jsonb_set(resource, '{metadata,labels,omnigres.com/test}', '"passed"')
+              from pod_uid
+              where pods.uid = pod_uid.uid returning *)
+      select resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' as label
+      from updating
+    results:
+    - label: passed
+  - name: check labels
+    query: select resource -> 'metadata' -> 'labels' labels
+           from pods
+                    inner join pod_uid pu on pu.uid = pods.uid
+    results:
+    - labels:
+        "omnigres.com/test": passed
+  - name: cleanup
+    query: delete
+           from pods
+               using pod_uid pu
+           where pu.uid = pods.uid
+
+- name: resource table refresh
+  steps:
+  - name: establish the table
+    query: select omni_kube.resource_table('configmap', 'v1', 'configmaps')
+  - name: establish a view
+    query: select omni_kube.resource_view('configmapv', 'v1', 'configmaps')
+  - name: clean up from previous failures
+    query: |
+      delete
+      from configmap
+      where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
+  - name: should be clean
+    query: select
+           from configmap
+           where resource -> 'metadata' -> 'labels' -> 'omnigres.com/test' is not null
+    results: [ ]
+  - create table cm_uid
+    (
+        uid text not null
+    )
+  - name: insert into view
+    query: |
+      with insertion as (insert into configmapv (resource)
+          values ('{ "metadata": { "generateName": "omni-kube-cm-test-", "labels": {"omnigres.com/test": "true"} }, "data": {} }')
+          returning *)
+      insert
+      into cm_uid (uid)
+      select uid
+      from insertion
+  - name: ensure we got the uid (conditions satisfied)
+    query: select count(*) > 0 as non_empty
+           from cm_uid
+    results:
+    - non_empty: true
+  - name: should not be in the table
+    query: select
+           from configmap
+                    inner join cm_uid c on c.uid = configmap.uid
+    results: [ ]
+  - name: refresh
+    query: select type
+           from refresh_configmap()
+                    inner join cm_uid c on c.uid = object -> 'metadata' ->> 'uid'
+    results:
+    - type: 'ADDED'
+  - name: new refresh
+    query: select
+           from refresh_configmap()
+    results: [ ]
+  - name: update through the view
+    query: |
+      update configmapv
+      set resource = jsonb_set(resource, '{data}', '{"new": "data"}')
+  - name: refresh
+    query: select type
+           from refresh_configmap()
+                    inner join cm_uid c on c.uid = object -> 'metadata' ->> 'uid'
+    results:
+    - type: 'MODIFIED'
+  - name: delete through the view
+    query: delete
+           from configmapv using cm_uid c
+           where c.uid = configmapv.uid
+  - name: refresh
+    query: select type
+           from refresh_configmap()
+                    inner join cm_uid c on c.uid = object -> 'metadata' ->> 'uid'
+    results:
+    - type: 'DELETED'


### PR DESCRIPTION
This is still fairly difficult. Resource views in omni_kube are helpful but they don't help managing state – they just represent what's there now.

Solution: add a concept of resource tables

These act as replicas and exhibit many properties of resource views (they are naturally updatable and the updates propagate back to Kubernetes), but they maintain a stable view that can be refreshed manually (or scheduled).

What's even more interesting is that they can be part of trigger cascades, enabling more logic to be embededded.

They are, however, not respecting the boundaries of transactions and changes are reflected in Kubernetes immediately.