### PR TITLE
Problem: omni_kube API doesn't compose well

### DIFF
--- a/extensions/omni_kube/CHANGELOG.md
+++ b/extensions/omni_kube/CHANGELOG.md
@@ -19,6 +19,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Inserting into and updating resource views should return new resource
   tuples [#926](https://github.com/omnigres/omnigres/pull/926)
 
+### Changed
+
+* Refactored API to make queries more composable [#928](https://github.com/omnigres/omnigres/pull/928)
+
 ## [0.2.0] - 2025-07-24
 
 ### Added

--- a/extensions/omni_kube/docs/internals_api.md
+++ b/extensions/omni_kube/docs/internals_api.md
@@ -20,8 +20,6 @@ omni_kube.api(path, [server], [cacert], [clientcert], [token], [method], [body],
 |         **method** | omni_http.http_method         | HTTP method, defaults to `GET`                                  |
 |           **body** | jsonb                         | Request body                                                    |
 |         **stream** | boolean                       | Stream mode for multiple JSON objects, defaults to `false`      |
-| **label_selector** | text                          | Optional label selector (e.g., 'app=web-app')                   |
-| **field_selector** | text                          | Optional field selector (e.g., 'metadata.name=web-app')         |
 
 **Returns:** `jsonb` - The response body
 
@@ -41,8 +39,6 @@ omni_kube.api(paths, [server], [cacert], [clientcert], [token], [methods], [bodi
 |         **methods** | omni_http.http_method[]       | Array of HTTP methods (defaults to `GET` for all requests)      |
 |          **bodies** | jsonb[]                       | Array of request bodies                                         |
 |          **stream** | boolean                       | Stream mode for multiple JSON objects, defaults to `false`      |
-| **label_selectors** | text[]                        | Optional label selectors (e.g., 'app=web-app')                  |
-| **field_selectors** | text[]                        | Optional field selectors (e.g., 'metadata.name=web-app')        |
 
 **Returns:** `TABLE(response jsonb, status int2)` - Response body and HTTP status for each request
 

--- a/extensions/omni_kube/docs/paths.md
+++ b/extensions/omni_kube/docs/paths.md
@@ -1,0 +1,158 @@
+# Composable Paths
+
+omni_kube provides a set of path helper functions to construct valid Kubernetes API URLs. These functions
+handle the complexity of Kubernetes API path conventions and query parameter encoding. They can be then used
+in [`api()`](internals_api.md#omni_kubeapi) calls.
+
+## Core Path Functions
+
+### `group_path(group_version text)`
+
+Constructs the base API path for a given API group version.
+
+**Parameters:**
+
+- `group_version` (text): The Kubernetes API group version
+
+**Returns:** Base API path as text
+
+**Examples:**
+
+```postgresql
+select group_path('v1');
+-- Returns: /api/v1
+
+select group_path('apps/v1');
+-- Returns: /apis/apps/v1
+
+select group_path('networking.k8s.io/v1');
+-- Returns: /apis/networking.k8s.io/v1
+```
+
+### `resources_path(group_version text, resource text, namespace text default null)`
+
+Constructs the full resource path, including optional namespace.
+
+**Parameters:**
+
+- `group_version` (text): The Kubernetes API group version
+- `resource` (text): The resource type (plural form)
+- `namespace` (text, optional): The namespace for namespaced resources
+
+**Returns:** Full resource path as text
+
+**Examples:**
+
+```postgresql
+-- Cluster-scoped resources
+select resources_path('v1', 'nodes');
+-- Returns: /api/v1/nodes
+
+-- Namespaced resources
+select resources_path('v1', 'pods', 'default');
+-- Returns: /api/v1/namespaces/default/pods
+
+select resources_path('apps/v1', 'deployments', 'kube-system');
+-- Returns: /apis/apps/v1/namespaces/kube-system/deployments
+```
+
+### `watch_path(path text, resource_version text default null)`
+
+Converts a regular API path to a watch path for streaming resource changes.
+
+**Parameters:**
+
+- `path` (text): The base API path
+- `resource_version` (text, optional): Starting resource version for the watch
+
+**Returns:** Watch-enabled path with query parameters
+
+**Examples:**
+
+```postgresql
+-- Basic watch path
+select watch_path('/api/v1/pods');
+-- Returns: /api/v1/pods?watch=1
+
+-- Watch from specific resource version
+select watch_path('/api/v1/pods', '12345');
+-- Returns: /api/v1/pods?watch=1&resourceVersion=12345
+
+-- Watch path with existing query parameters
+select watch_path('/api/v1/pods?limit=100', '12345');
+-- Returns: /api/v1/pods?limit=100&watch=1&resourceVersion=12345
+```
+
+###
+
+`path_with(path text, label_selector text default null, field_selector text default null, timeout_seconds int default null)`
+
+Adds common query parameters to API paths with proper URL encoding.
+
+**Parameters:**
+
+- `path` (text): The base API path
+- `label_selector` (text, optional): Label selector for filtering
+- `field_selector` (text, optional): Field selector for filtering
+- `timeout_seconds` (int, optional): Request timeout in seconds
+
+**Returns:** Path with encoded query parameters
+
+**Examples:**
+
+```postgresql
+-- Add label selector
+select path_with('/api/v1/pods', 'app=nginx');
+-- Returns: /api/v1/pods?labelSelector=app%3Dnginx
+
+-- Add multiple selectors
+select path_with('/api/v1/pods', 'app=nginx', 'status.phase=Running');
+-- Returns: /api/v1/pods?labelSelector=app%3Dnginx&fieldSelector=status.phase%3DRunning
+
+-- Add timeout
+select path_with('/api/v1/pods', timeout_seconds => 30);
+-- Returns: /api/v1/pods?timeoutSeconds=30
+
+-- Complex selector with encoding
+select path_with('/api/v1/pods', 'environment in (prod,staging)', 'metadata.name!=test-pod');
+-- Returns: /api/v1/pods?labelSelector=environment%20in%20%28prod%2Cstaging%29&fieldSelector=metadata.name%21%3Dtest-pod
+```
+
+## Resource Table Path Functions
+
+For each [resource table](resources.md#resource-tables) created by omni_kube, a dedicated path function is automatically
+generated with the naming pattern `{table_name}_resource_path()`.
+
+### Usage Examples
+
+```postgresql
+-- Get the resource path for pods table
+select pods_resource_path();
+-- Returns: /api/v1/pods
+
+-- Use in API calls
+select omni_kube.get(pods_resource_path());
+```
+
+## URL Encoding
+
+The path helper functions automatically handle URL encoding through `omni_web.url_encode()`:
+
+- **Spaces** → `%20`
+- **Equals** (`=`) → `%3D`
+- **Commas** (`,`) → `%2C`
+- **Parentheses** → `%28`, `%29`
+- **Exclamation marks** (`!`) → `%21`
+
+This ensures that complex label and field selectors work correctly with the Kubernetes API.
+
+## Best Practices
+
+1. **Use resource table path functions** when available for consistency
+2. **Combine functions** to build complex paths step by step
+3. **Let the functions handle encoding** - don't pre-encode parameters
+4. **Test complex selectors** with simple API calls before using in production
+5. **Cache frequently used paths** in variables or functions for performance
+
+These path helpers abstract away the complexity of Kubernetes API URL construction, making it easier to work with
+various resource types and query patterns.

--- a/extensions/omni_kube/mkdocs.yml
+++ b/extensions/omni_kube/mkdocs.yml
@@ -3,4 +3,5 @@ site_name: omni_kube
 nav:
 - 'credentials.md'
 - 'resources.md'
+- 'paths.md'
 - 'internals_api.md'

--- a/extensions/omni_kube/src/group_path.sql
+++ b/extensions/omni_kube/src/group_path.sql
@@ -1,0 +1,3 @@
+create function group_path(group_version text) returns text
+    immutable
+return '/' || case when group_version in ('v1') then 'api/v1' else 'apis/' || group_version end;

--- a/extensions/omni_kube/src/group_resources.sql
+++ b/extensions/omni_kube/src/group_resources.sql
@@ -12,8 +12,7 @@ create function group_resources(group_version text)
 as
 $group_resources$
 declare
-    response jsonb = api('/' ||
-                         case when group_version in ('v1') then 'api/v1' else 'apis/' || group_version end);
+    response jsonb = api(group_path(group_version));
 begin
     return query select data ->> 'name',
                         data ->> 'singularName',

--- a/extensions/omni_kube/src/instantiate.sql
+++ b/extensions/omni_kube/src/instantiate.sql
@@ -8,12 +8,15 @@ begin
     -- Set the search path to target schema and public
     perform set_config('search_path', schema::text || ',public', true);
 
+    /*{% include "group_path.sql" %}*/
+    /*{% include "resources_path.sql" %}*/
+    /*{% include "path_with.sql" %}*/
     /*{% include "api.sql" %}*/
     execute format(
-            'alter function api(text[], text, text, omni_httpc.client_certificate, text, omni_http.http_method[], jsonb[], boolean, text[], text[]) set search_path = %L, public',
+            'alter function api(text[], text, text, omni_httpc.client_certificate, text, omni_http.http_method[], jsonb[], boolean) set search_path = %L, public',
             schema::text);
     execute format(
-            'alter function api(text, text, text, omni_httpc.client_certificate, text, omni_http.http_method, jsonb, boolean, text, text) set search_path = %L, public',
+            'alter function api(text, text, text, omni_httpc.client_certificate, text, omni_http.http_method, jsonb, boolean) set search_path = %L, public',
             schema::text);
     /*{% include "pod_credentials.sql" %}*/
     /*{% include "load_kubeconfig.sql" %}*/
@@ -64,6 +67,7 @@ begin
     execute format('alter function resource_view set omni_kube.search_path = %L', schema::text);
     /*{% include "resource_table.sql" %}*/
     execute format('alter function resource_table set omni_kube.search_path = %L', schema::text);
+    /*{% include "watch_path.sql" %}*/
     /*{% include "watch.sql" %}*/
 
     -- Restore the path

--- a/extensions/omni_kube/src/path_with.sql
+++ b/extensions/omni_kube/src/path_with.sql
@@ -1,0 +1,14 @@
+create function path_with(path text, label_selector text default null, field_selector text default null,
+                          timeout_seconds int default null)
+    returns text
+    immutable
+return
+    path ||
+    (case
+         when label_selector is null and field_selector is null then ''
+         when position('?' in path) > 0 then '&'
+         else '?' end) ||
+    coalesce('labelSelector=' || omni_web.url_encode(label_selector), '') ||
+    coalesce('&fieldSelector=' ||
+             omni_web.url_encode(field_selector),
+             '') || coalesce('&timeoutSeconds=' || timeout_seconds, '');

--- a/extensions/omni_kube/src/resource_view.sql
+++ b/extensions/omni_kube/src/resource_view.sql
@@ -13,18 +13,11 @@ declare
 begin
     execute format('set search_path to %I, public', ns);
     select namespaced, kind into is_namespaced, resource_kind from group_resources(group_version) where name = resource;
+    url := resources_path(group_version, resource, namespace => case when is_namespaced then '%s' end);
     perform
         set_config('search_path', old_search_path, true);
 
-    if is_namespaced then
-        url := '/' ||
-               case when group_version in ('v1') then 'api/v1' else 'apis/' || group_version end || '/namespaces/%s/' ||
-               resource;
-    else
-        url := '/' ||
-               case when group_version in ('v1') then 'api/v1' else 'apis/' || group_version end || '/' ||
-               resource;
-    end if;
+
     execute format($resource_view_$
     create or replace view %I as
     select

--- a/extensions/omni_kube/src/resources.sql
+++ b/extensions/omni_kube/src/resources.sql
@@ -5,9 +5,8 @@ create function resources(group_version text, resource text, label_selector text
 as
 $resources$
 declare
-    response jsonb = api('/' ||
-                         case when group_version in ('v1') then 'api/v1' else 'apis/' || group_version end || '/' ||
-                         resource, label_selector => label_selector, field_selector => field_selector);
+    response jsonb = api(path_with(resources_path(group_version, resource), label_selector => label_selector,
+                                  field_selector => field_selector));
 begin
     return query select jsonb_array_elements(response -> 'items');
 end;

--- a/extensions/omni_kube/src/resources_path.sql
+++ b/extensions/omni_kube/src/resources_path.sql
@@ -1,0 +1,4 @@
+create function resources_path(group_version text, resource text, namespace text default null) returns text
+    immutable
+return group_path(group_version) || '/' || coalesce('namespaces/' || namespace || '/', '') ||
+       resource;

--- a/extensions/omni_kube/src/watch_path.sql
+++ b/extensions/omni_kube/src/watch_path.sql
@@ -1,0 +1,7 @@
+create function watch_path(path text, resource_version text default null)
+    returns text
+    immutable
+return
+    path || case
+                when position('?' in path) > 0 then '&'
+                else '?' end || 'watch=1' || coalesce('&resourceVersion=' || resource_version, '');


### PR DESCRIPTION
For example, api() special-cases things like fieldSelector and labelSelector and it's going to be hard to compose watches.

Solution: extract path helpers and make them composable