### PR TITLE
Problem: omni_kube resource tables aren't transactional

### DIFF
--- a/extensions/omni_kube/CHANGELOG.md
+++ b/extensions/omni_kube/CHANGELOG.md
@@ -12,7 +12,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Support for `generateName` [#923](https://github.com/omnigres/omnigres/pull/923)
 * Basic support for watches [#924](https://github.com/omnigres/omnigres/pull/924)
 * Basic support for selectors [#925](https://github.com/omnigres/omnigres/pull/925)
-* Resource tables [#927](https://github.com/omnigres/omnigres/pull/927)
+* Resource
+  tables [#927](https://github.com/omnigres/omnigres/pull/927), [#929](https://github.com/omnigres/omnigres/pull/929)
 
 ### Fixed
 
@@ -22,6 +23,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 * Refactored API to make queries more composable [#928](https://github.com/omnigres/omnigres/pull/928)
+
+### Removed
+
+* Per-statement API call caching [#929](https://github.com/omnigres/omnigres/pull/929)
 
 ## [0.2.0] - 2025-07-24
 

--- a/extensions/omni_kube/CMakeLists.txt
+++ b/extensions/omni_kube/CMakeLists.txt
@@ -15,4 +15,4 @@ add_postgresql_extension(
         COMMENT "Kubernetes (k8s) integration"
         SCHEMA omni_kube
         RELOCATABLE false
-        REQUIRES omni_httpc omni_web omni_var omni_yaml pgcrypto)
+        REQUIRES omni_httpc omni_web omni_var omni_yaml)

--- a/extensions/omni_kube/docs/resources.md
+++ b/extensions/omni_kube/docs/resources.md
@@ -249,6 +249,23 @@ and aggregation operations that would be inefficient when executed against live 
 The function returns a table of `(type text, object jsonb)` where type is `ADDED`, `MODIFIED` or `DELETED` and object
 is the object in question.
 
+### Transactional Resource Tables
+
+Resource tables can be made transactional by passing `transactional => true` to `omni_kube.resource_table()`. This
+**simulates** `read committed`-style isolation of changes to the cluster. That is, if you refresh a table within a
+transaction, it'll reflect current state of the cluster. All pending changes in the table are dry-run-verified but
+pooled until commit time. Subsequent changes to the same resource override the entry in the pool (so, for example, an
+update followed by another update is superseded; a deletion performed after update, wins, etc.)
+
+This enables an approximation of atomic operations – a best-effort approach.
+
+!!! warning "Important caveats"
+
+    Commits may still fail due to conflicts with the actual cluster (newer resource versions in the cluster, resource deleted, etc.)
+
+    Commit operation can also fail due to HTTP errors and leave transaction's pending changes in an inconsistent state.
+    A compensation mechanism can be devised (reconciling incomplete transaction). Future versions of this extension may provide tooling for this.
+
 ## Usage Examples
 
 ### Working with Deployments

--- a/extensions/omni_kube/src/path_with.sql
+++ b/extensions/omni_kube/src/path_with.sql
@@ -1,14 +1,15 @@
 create function path_with(path text, label_selector text default null, field_selector text default null,
-                          timeout_seconds int default null)
+                          timeout_seconds int default null, dry_run boolean default null)
     returns text
     immutable
 return
     path ||
     (case
-         when label_selector is null and field_selector is null then ''
          when position('?' in path) > 0 then '&'
          else '?' end) ||
-    coalesce('labelSelector=' || omni_web.url_encode(label_selector), '') ||
-    coalesce('&fieldSelector=' ||
-             omni_web.url_encode(field_selector),
-             '') || coalesce('&timeoutSeconds=' || timeout_seconds, '');
+    concat_ws('&',
+              case when dry_run then 'dryRun=All' end,
+              'labelSelector=' || omni_web.url_encode(label_selector),
+              'fieldSelector=' || omni_web.url_encode(field_selector),
+              'timeoutSeconds=' || timeout_seconds
+    );

--- a/extensions/omni_kube/src/resource_table.sql
+++ b/extensions/omni_kube/src/resource_table.sql
@@ -1,5 +1,5 @@
 create function resource_table(table_name name, group_version text, resource text, label_selector text default null,
-                               field_selector text default null)
+                               field_selector text default null, transactional boolean default false)
     returns regclass
     language plpgsql
 as
@@ -28,6 +28,46 @@ begin
      * from %I.resources(%L, %L, label_selector => %L, field_selector => %L) resource
     $resource_table_$, table_name, ns, group_version, resource, label_selector, field_selector);
 
+    if transactional then
+        execute format('alter table %1$I add column new boolean not null default false', table_name);
+        execute format('alter table %1$I add column committed boolean not null default true', table_name);
+        execute format($resource_queue_table_$
+            create table %1$I (
+               name text,
+               namespace text,
+               url text,
+               body jsonb,
+               method omni_http.http_method,
+               unique (name, namespace)
+            );
+            create or replace function %1$I()
+            returns trigger language plpgsql
+            as $$
+            declare
+             rec record;
+            begin
+              perform from %1$I;
+              if not found then
+                return new;
+              end if;
+              with i as (delete from %1$I returning url, method, body)
+                 select %3$I.api(array_agg(url), methods => array_agg(method), bodies => array_agg(body)) from i into rec;
+              perform %4$I();
+              return new;
+            end;
+            $$;
+
+            create constraint trigger %1$I
+                after insert or update or delete
+                on %2$I
+                deferrable initially deferred
+                for each row
+            execute function %1$I();
+            $resource_queue_table_$, 'omni_kube<' || table_name || '>', table_name, ns, 'refresh_' || table_name);
+
+    end if;
+
+
     execute format($$create unique index %2$I on %1$I (uid) $$, table_name, table_name || '_index_uid');
     execute format(
             $$create unique index %2$I on %1$I (name, namespace) $$,
@@ -51,7 +91,7 @@ begin
        deletion as (delete from %2$I where not exists (select from new where new.uid = %2$I.uid) returning %2$I.*),
        insertion as (insert into %2$I select * from new where not exists (select from %2$I x where x.uid = new.uid) returning %2$I.*),
        updating as (update %2$I set uid = new.uid, name = new.name, namespace = new.namespace, resource = new.resource
-          from new where new.uid = %2$I.uid and (new) != (%2$I) returning %2$I.*)
+          from new where new.uid = %2$I.uid and new.resource != %2$I.resource returning %2$I.*)
        select 'DELETED' as type, od.resource as object from deletion od
        union all
        select 'ADDED' as type, oi.resource as object from insertion oi
@@ -62,18 +102,22 @@ begin
                    field_selector);
 
     execute format($resource_table_insert$
-    create or replace function %I() returns trigger
-    set search_path to %I, public
+    create or replace function %1$I() returns trigger
+    set search_path to %2$I, public
     language plpgsql as
     $$
     declare
       spec_ns text;
-      name text;
+      name_ text;
+      canonical_url text;
       url text;
       metadata jsonb;
       result jsonb;
     begin
       if current_setting('omni_kube.refresh', true) = 'true' then
+        if %6$L::boolean then
+          delete from %7$I where name = new.name and namespace = new.namespace;
+        end if;
         return new;
       end if;
       if new.uid is not null then
@@ -84,25 +128,37 @@ begin
       if new.namespace is not null and spec_ns != new.namespace then
         raise exception 'namespace (%%) must match metadata (%%)', new.namespace, spec_ns;
       end if;
-      name := coalesce(coalesce(metadata->>'name', metadata->>'generateName'), new.name);
-      if name is null then
+      name_ := coalesce(coalesce(metadata->>'name', metadata->>'generateName'), new.name);
+      if name_ is null then
         raise exception 'resource is required to have `name` or `generateName`';
       end if;
-      if new.name is not null and name != new.name then
-        raise exception 'name (%%) must match metadata (%%)', new.name, name;
+      if new.name is not null and name_ != new.name then
+        raise exception 'name (%%) must match metadata (%%)', new.name, name_;
       end if;
-      new.resource := jsonb_set(new.resource, '{kind}', to_jsonb(%L::text));
-      new.resource := jsonb_set(new.resource, '{apiVersion}', to_jsonb(%L::text));
-      url := format(%L, spec_ns);
+      new.resource := jsonb_set(new.resource, '{kind}', to_jsonb(%3$L::text));
+      new.resource := jsonb_set(new.resource, '{apiVersion}', to_jsonb(%4$L::text));
+      canonical_url := format(%5$L, spec_ns);
+      url := canonical_url;
+      -- transactional?
+      if %6$L::boolean and not current_setting('omni_kube.refresh', true) = 'true' then
+        url := path_with(canonical_url, dry_run => true);
+        new.committed = false;
+        new.new := true;
+      end if;
       select api(url, body => new.resource, method => 'POST') into result;
       new.uid := result->'metadata'->>'uid';
       new.name := result->'metadata'->>'name';
       new.namespace := result->'metadata'->>'namespace';
       new.resource := result;
+      if %6$L::boolean and not current_setting('omni_kube.refresh', true) = 'true' then
+        insert into %7$I as t (name,namespace,url,method,body) values (new.name,new.namespace, canonical_url,'POST',new.resource)
+        on conflict (name, namespace) do update set name = new.name, namespace = new.namespace, url = canonical_url, method = 'POST', body = new.resource;
+      end if;
       return new;
     end;
     $$
-    $resource_table_insert$, table_name || '_insert', ns, resource_kind, group_version, url);
+    $resource_table_insert$, table_name || '_insert', ns, resource_kind, group_version, url, transactional,
+                   'omni_kube<' || table_name || '>');
 
     execute format($resource_table_insert_t$
     create trigger %1$I before insert on %2$I for each row
@@ -110,39 +166,63 @@ begin
     $resource_table_insert_t$, table_name || '_insert', table_name);
 
     execute format($resource_table_update$
-    create or replace function %I() returns trigger
-    set search_path to %I, public
+    create or replace function %1$I() returns trigger
+    set search_path to %2$I, public
     language plpgsql as
     $$
     declare
       spec_ns text;
-      name text;
+      name_ text;
       url text;
+      canonical_url text;
       result jsonb;
+      new_ boolean := false;
+      method_ omni_http.http_method := 'PUT';
     begin
       if current_setting('omni_kube.refresh', true) = 'true' then
+        if %4$L::boolean then
+          delete from %5$I where name = new.name and namespace = new.namespace;
+        end if;
         return new;
+      end if;
+      if %4$L::boolean then
+       new_ := new.new;
+       if new_ then
+         method_ := 'POST';
+       end if;
       end if;
       spec_ns := coalesce(coalesce(new.resource->'metadata','{"namespace": "default"}'::jsonb)->>'namespace', 'default');
       if new.namespace is not null and spec_ns != new.namespace then
         raise exception 'namespace (%%) must match metadata (%%)', new.namespace, spec_ns;
       end if;
-      name := coalesce(coalesce(new.resource->'metadata','{}')->>'name', new.name);
-      if name is null then
+      name_ := coalesce(coalesce(new.resource->'metadata','{}')->>'name', new.name);
+      if name_ is null then
         raise exception 'resource is required to have a name';
       end if;
-      if new.name is not null and name != new.name then
+      if new.name is not null and name_ != new.name then
         raise exception 'name (%%) must match metadata (%%)', new.name, name;
       end if;
-      url := format(%L, spec_ns);
-      select api(url || '/' || name, body => new.resource, method => 'PUT') into result;
+      canonical_url := format(%3$L, spec_ns);
+      if not new_ then
+        canonical_url := canonical_url || '/' || new.name;
+      end if;
+      url := canonical_url;
+      if %4$L::boolean then
+        url := path_with(canonical_url, dry_run => true);
+        new.committed := false;
+      end if;
+      select api(url, body => new.resource, method => method_) into result;
       new.name := result->'metadata'->>'name';
       new.namespace := result->'metadata'->>'namespace';
       new.resource := result;
+      if %4$L::boolean then
+        insert into %5$I as t (name,namespace,url,method,body) values (new.name,new.namespace, canonical_url,method_,new.resource)
+        on conflict (name, namespace) do update set name = new.name, namespace = new.namespace, url = canonical_url, method = method_, body = new.resource;
+      end if;
       return new;
     end;
     $$
-    $resource_table_update$, table_name || '_update', ns, url);
+    $resource_table_update$, table_name || '_update', ns, url, transactional, 'omni_kube<' || table_name || '>');
 
     execute format($resource_table_update_t$
     create trigger %1$I before update on %2$I for each row
@@ -150,35 +230,47 @@ begin
     $resource_table_update_t$, table_name || '_update', table_name);
 
     execute format($resource_table_delete$
-    create or replace function %I() returns trigger
-    set search_path to %I, public
+    create or replace function %1$I() returns trigger
+    set search_path to %2$I, public
     language plpgsql as
     $$
     declare
       spec_ns text;
-      name text;
-      url text;
+      name_ text;
+      canonical_url text;
     begin
       if current_setting('omni_kube.refresh', true) = 'true' then
+        if %4$L::boolean then
+          delete from %5$I where name = old.name and namespace = old.namespace;
+        end if;
         return old;
       end if;
       spec_ns := coalesce(coalesce(old.resource->'metadata','{"namespace": "default"}'::jsonb)->>'namespace', 'default');
       if old.namespace is not null and spec_ns != old.namespace then
         raise exception 'namespace (%%) must match metadata (%%)', old.namespace, spec_ns;
       end if;
-      name := coalesce(coalesce(old.resource->'metadata','{}')->>'name', old.name);
-      if name is null then
+      name_ := coalesce(coalesce(old.resource->'metadata','{}')->>'name', old.name);
+      if name_ is null then
         raise exception 'resource is required to have a name';
       end if;
-      if old.name is not null and name != old.name then
-        raise exception 'name (%%) must match metadata (%%)', old.name, name;
+      if old.name is not null and name_ != old.name then
+        raise exception 'name (%%) must match metadata (%%)', old.name, name_;
       end if;
-      url := format(%L, spec_ns);
-      perform api(url || '/' || name, method => 'DELETE');
+      canonical_url := format(%3$L, spec_ns);
+      if not %4$L::boolean then
+        perform api(canonical_url || '/' || name_, method => 'DELETE');
+      else
+        if not old.new then
+          insert into %5$I as t (name,namespace,url,method,body) values (old.name,old.namespace, canonical_url,'DELETE','{}')
+          on conflict (name, namespace) do update set name = old.name, namespace = old.namespace, url = canonical_url, method = 'DELETE', body = null;
+        else
+          delete from %5$I where name = old.name and namespace = old.namespace;
+        end if;
+      end if;
       return old;
     end;
     $$
-    $resource_table_delete$, table_name || '_delete', ns, url);
+    $resource_table_delete$, table_name || '_delete', ns, url, transactional, 'omni_kube<' || table_name || '>');
 
     execute format($resource_table_delete_t$
     create trigger %1$I before delete on %2$I for each row

--- a/extensions/omni_kube/tests/transactional.yml
+++ b/extensions/omni_kube/tests/transactional.yml
@@ -1,0 +1,218 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_kube cascade
+  - create extension omni_os cascade
+
+tests:
+
+- select omni_kube.load_kubeconfig((select value from omni_os.env where variable = 'HOME') || '/.kube/config')
+
+- name: establish the table
+  commit: true
+  query: select omni_kube.resource_table('cm', 'v1', 'configmaps', transactional => true)
+
+- name: establish the immediate view
+  commit: true
+  query: select omni_kube.resource_view('cmv', 'v1', 'configmaps')
+
+- name: clean up from potential previous failures
+  commit: true
+  query: delete
+         from cmv
+         where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+
+- name: resource table insertion + rollback
+  tests:
+  - steps:
+    - name: insert
+      query: |
+        insert into cm (resource)
+        values ('{ "metadata": { "generateName": "omni-kube-cm-test-transactional-", "labels": {"omnigres.com/test": "transaction"} }, "data": {} }')
+    - name: should not be visible in the cluster
+      query: select
+             from cmv
+             where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+      results: [ ]
+  - name: after rollback, still not visible
+    query: select
+           from cmv
+           where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+    results: [ ]
+
+- name: resource table insertion + commit
+  tests:
+  - commit: true
+    steps:
+    - name: insert
+      query: |
+        insert into cm (resource)
+        values ('{ "metadata": { "generateName": "omni-kube-cm-test-transactional-", "labels": {"omnigres.com/test": "transaction"} }, "data": {} }')
+    - name: should not be visible in the cluster
+      query: select
+             from cmv
+             where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+      results: [ ]
+  - name: after commit, visible
+    query: select count(*)
+           from cmv
+           where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+    results:
+    - count: 1
+
+- name: clean up
+  commit: true
+  query: delete
+         from cmv
+         where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+
+- name: resource table insertion + update + commit
+  tests:
+  - commit: true
+    steps:
+    - name: insert
+      query: |
+        insert into cm (resource)
+        values ('{ "metadata": { "generateName": "omni-kube-cm-test-transactional-", "labels": {"omnigres.com/test": "transaction"} }, "data": {"test": "failed"} }')
+    - name: update
+      query: |
+        update cm
+        set resource = jsonb_set(resource, '{data,test}', '"passed"')
+        where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+          and new
+    - name: should not be visible in the cluster
+      query: select
+             from cmv
+             where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+      results: [ ]
+  - name: after commit, visible
+    query: select resource -> 'data' as value
+           from cmv
+           where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+    results:
+    - value:
+        test: passed
+
+- name: clean up
+  commit: true
+  query: delete
+         from cmv
+         where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+
+- name: resource table insertion + deletion + commit
+  tests:
+  - commit: true
+    steps:
+    - name: insert
+      query: |
+        insert into cm (resource)
+        values ('{ "metadata": { "generateName": "omni-kube-cm-test-transactional-", "labels": {"omnigres.com/test": "transaction"} }, "data": {"test": "failed"} }')
+    - name: delete
+      query: |
+        delete
+        from cm
+        where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+          and new
+    - name: should not be visible in the cluster
+      query: select
+             from cmv
+             where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+      results: [ ]
+  - name: after commit, not visible
+    query: select count(*)
+           from cmv
+           where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+    results:
+    - count: 0
+
+- name: clean up
+  commit: true
+  query: delete
+         from cmv
+         where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+
+- name: insert committed
+  commit: true
+  query: |
+    insert into cm (resource)
+    values ('{ "metadata": { "generateName": "omni-kube-cm-test-transactional-", "labels": {"omnigres.com/test": "transaction"} }, "data": {"test": "passed"} }')
+
+- name: resource table update + rollback
+  tests:
+  - steps:
+    - query: |
+        update cm
+        set resource = jsonb_set(resource, '{data,test}', '"failed"')
+        where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+  - name: after rollback, still not changed
+    query: select resource -> 'data' as data
+           from cmv
+           where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+    results:
+    - data:
+        test: passed
+
+- name: clean up
+  commit: true
+  query: delete
+         from cmv
+         where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+
+- name: insert committed
+  commit: true
+  query: |
+    insert into cm (resource)
+    values ('{ "metadata": { "generateName": "omni-kube-cm-test-transactional-", "labels": {"omnigres.com/test": "transaction"} }, "data": {"test": "passed"} }')
+
+- name: resource table update + commit
+  tests:
+  - commit: true
+    steps:
+    - query: |
+        update cm
+        set resource = jsonb_set(resource, '{data,test}', '"surpassed"')
+        where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+  - name: after commit, changed
+    query: select resource -> 'data' as data
+           from cmv
+           where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+    results:
+    - data:
+        test: surpassed
+
+- name: clean up
+  commit: true
+  query: delete
+         from cmv
+         where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+
+- name: insert committed
+  commit: true
+  query: |
+    insert into cm (resource)
+    values ('{ "metadata": { "generateName": "omni-kube-cm-test-transactional-", "labels": {"omnigres.com/test": "transaction"} }, "data": {"test": "passed"} }')
+
+- name: resource table update + delete + commit
+  tests:
+  - commit: true
+    steps:
+    - query: |
+        update cm
+        set resource = jsonb_set(resource, '{data,test}', '"surpassed"')
+        where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+    - query: |
+        delete
+        from cm
+        where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+  - name: after commit, gone
+    query: select count(*)
+           from cmv
+           where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'
+    results:
+    - count: 0
+
+- name: clean up
+  commit: true
+  query: delete
+         from cmv
+         where resource -> 'metadata' -> 'labels' ->> 'omnigres.com/test' = 'transaction'


### PR DESCRIPTION
While it is not a huge issue, it is not perfect either – in some cases it is desirable to at least imitate some sort of transactional boundaries.

Solution: simulate read-committed isolation
by dry-running changes and pooling them up until commit time.