### PR TITLE
Problem: some extensions no longer compile on Postgres master (🚀 omni_httpd 0.4.10, omni 0.2.12)

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.12] - 2025-08-28
+
+### Fixed
+
+* Support for Postgres 19 [#931](https://github.com/omnigres/omnigres/pull/931)
+
 ## [0.2.11] - 2025-07-17
 
 ### Fixed
@@ -171,3 +177,5 @@ Initial release following a few months of iterative development.
 [0.2.10]: [https://github.com/omnigres/omnigres/pull/878]
 
 [0.2.11]: [https://github.com/omnigres/omnigres/pull/883]
+
+[0.2.12]: [https://github.com/omnigres/omnigres/pull/931]

--- a/extensions/omni/test/omni__test.c
+++ b/extensions/omni/test/omni__test.c
@@ -11,6 +11,7 @@
 #include <storage/latch.h>
 #include <storage/lwlock.h>
 #include <utils/builtins.h>
+#include <utils/lsyscache.h>
 #if PG_MAJORVERSION_NUM >= 14
 #include <utils/wait_event.h>
 #else

--- a/extensions/omni_httpd/CHANGELOG.md
+++ b/extensions/omni_httpd/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.10] - 2025-08-28
+
+### Fixed
+
+* Support for Postgres 19 [#931](https://github.com/omnigres/omnigres/pull/931)
+
 ## [0.4.9] - 2025-07-31
 
 ### Added
@@ -257,3 +263,5 @@ Initial release following a few months of iterative development.
 [0.4.8]: [https://github.com/omnigres/omnigres/pull/878]
 
 [0.4.9]: [https://github.com/omnigres/omnigres/pull/887]
+
+[0.4.10]: [https://github.com/omnigres/omnigres/pull/931]

--- a/extensions/omni_httpd/omni_httpd.c
+++ b/extensions/omni_httpd/omni_httpd.c
@@ -38,6 +38,7 @@
 #include <utils/inet.h>
 #include <utils/json.h>
 #include <utils/jsonb.h>
+#include <utils/lsyscache.h>
 #include <utils/memutils.h>
 #include <utils/snapmgr.h>
 #include <utils/uuid.h>

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
-omni=0.2.11
+omni=0.2.12
 omni_aws=0.1.2
 omni_auth=0.1.3
 omni_containers=0.2.0
@@ -8,7 +8,7 @@ omni_csv=0.1.1
 omni_datasets=0.1.0
 omni_http=0.1.0
 omni_httpc=0.1.9
-omni_httpd=0.4.9
+omni_httpd=0.4.10
 omni_id=0.4.2
 omni_json=0.1.1
 omni_kube=0.2.0


### PR DESCRIPTION
They can't find get_database_name()

Solution: add utils/lsyscache.h to get the definition again

Relevant change: https://github.com/postgres/postgres/commit/325fc0ab14d11fc87da594857ffbb6636affe7c0