### PR TITLE
Problem: omni no longer compiles on Postgres master

### DIFF
--- a/extensions/omni/CHANGELOG.md
+++ b/extensions/omni/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.14] - 2025-09-04
+
+### Fixed
+
+* Support for Postgres 19 [#937](https://github.com/omnigres/omnigres/pull/937)
+
 ## [0.2.13] - 2025-08-29
 
 ### Fixed
@@ -187,3 +193,5 @@ Initial release following a few months of iterative development.
 [0.2.12]: [https://github.com/omnigres/omnigres/pull/931]
 
 [0.2.13]: [https://github.com/omnigres/omnigres/pull/933]
+
+[0.2.14]: [https://github.com/omnigres/omnigres/pull/937]

--- a/extensions/omni/init.c
+++ b/extensions/omni/init.c
@@ -219,7 +219,11 @@ static void shmem_hook() {
   }
 
   LWLockRelease(AddinShmemInitLock);
+#if PG_MAJORVERSION_NUM < 19
   OMNI_DSA_TRANCHE = LWLockNewTrancheId();
+#else
+  OMNI_DSA_TRANCHE = LWLockNewTrancheId("omni:dsa");
+#endif
 }
 
 /**

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
-omni=0.2.13
+omni=0.2.14
 omni_aws=0.1.2
 omni_auth=0.1.3
 omni_containers=0.2.0


### PR DESCRIPTION
LWLockNewTrancheId() now takes an argument. Relevant change: https://github.com/postgres/postgres/commit/38b602b0289fe1dbaf31d5737fba2d42a1e90371

Solition: start supporting the new API