### PR TITLE
Problem: oink fails to build on some setups (🚀 omni_worker 0.1.4)

### DIFF
--- a/extensions/omni_worker/CHANGELOG.md
+++ b/extensions/omni_worker/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2025-09-04
+
+### Fixed
+
+* Potential build failure (missing std::optional) [#938](https://github.com/omnigres/omnigres/pull/938)
+
 ## [0.1.3] - 2025-08-24
 
 ### Fixed
@@ -36,3 +42,5 @@ Initial release
 [0.1.2]: [https://github.com/omnigres/omnigres/pull/884]
 
 [0.1.3]: [https://github.com/omnigres/omnigres/pull/915]
+
+[0.1.4]: [https://github.com/omnigres/omnigres/pull/938]

--- a/versions.txt
+++ b/versions.txt
@@ -33,6 +33,6 @@ omni_var=0.3.0
 omni_vfs_types_v1=0.1.0
 omni_vfs=0.2.2
 omni_web=0.3.0
-omni_worker=0.1.3
+omni_worker=0.1.4
 omni_xml=0.1.2
 omni_yaml=0.1.0


### PR DESCRIPTION
Solution: update it so that it includes the necessary header (`<optional>`)