### PR TITLE
Problem: omni_worker's sql privileged execution

### DIFF
--- a/extensions/omni_worker/CHANGELOG.md
+++ b/extensions/omni_worker/CHANGELOG.md
@@ -12,6 +12,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * SQL autostart functionality [#932](https://github.com/omnigres/omnigres/pull/932)
 * Timer handler for worker tasks [#943](https://github.com/omnigres/omnigres/pull/943)
 
+### Fixed
+
+* SQL execution role restriction [#945](https://github.com/omnigres/omnigres/pull/945)
+
 ## [0.1.4] - 2025-09-04
 
 ### Fixed

--- a/extensions/omni_worker/tests/sql.yml
+++ b/extensions/omni_worker/tests/sql.yml
@@ -6,6 +6,24 @@ instance:
     omni_worker.workers: 10
   init:
   - create extension omni_worker cascade
+  - create table report ()
+  - |
+    create or replace function _reset_role() returns void
+    language plpgsql as $$
+    begin
+    reset role;
+    insert into report default values;
+    end;
+    $$
+  - |
+    create or replace function _set_role() returns void
+    language plpgsql as $$
+    begin
+    set role yregress;
+    insert into report default values;
+    end;
+    $$
+
 
 tests:
 
@@ -33,3 +51,42 @@ tests:
   query: select omni_worker.sql('wrong')
   results:
   - sql: false
+
+- name: SQL role change
+  transaction: false
+  tests:
+  - create role runner
+  - grant omni_worker_sql_user to runner
+  - grant usage on schema omni_worker to runner
+  - grant all on schema public to runner
+  - grant all on all tables in schema public to runner
+  - grant all on all sequences in schema public to runner
+  - select omni_worker.sql('create table role_change as select current_role::regrole', wait_ms => 10000, run_as => 'runner')
+  - query: select  * from role_change
+    results:
+    - current_role: runner
+
+- name: role escape prevention
+  transaction: false
+  tests:
+  - delete from report
+  - query: select omni_worker.sql('select _set_role', run_as => 'runner', wait_ms => 10000)
+    results:
+    - sql: false
+  - query: select omni_worker.sql('select _reset_role', run_as => 'runner', wait_ms => 10000)
+    results:
+    - sql: false
+  - query: select count(*) from report
+    results:
+    - count: 0
+
+- name: SQL role escalation prevention
+  transaction: false
+  tests:
+  - create role restricted
+  - grant omni_worker_sql_user to restricted
+  - set role restricted
+  - query: select omni_worker.sql('select', run_as => 'yregress')
+    error: "exception: Role restricted is not a member of yregress"
+  - reset role
+

--- a/extensions/omni_worker/tests/sql_autostart.yml
+++ b/extensions/omni_worker/tests/sql_autostart.yml
@@ -11,12 +11,21 @@ instance:
 
 tests:
 
+- name: prepare a test role
+  transaction: false
+  tests:
+  - create role runner
+  - grant all on schema public to runner
+  - grant all on all tables in schema public to runner
+  - grant all on all sequences in schema public to runner
+
 - name: add autostart operations
   commit: true
   query: |
-    insert into omni_worker.sql_autostart_stmt (stmt, position)
-    values ('create table if not exists test2 as select * from test1', 2),
-           ('create table if not exists test1 as select 1 as val', 1)
+    insert into omni_worker.sql_autostart_stmt (stmt, role, position)
+    values ('create table if not exists test2 as select * from test1', current_role::regrole, 2),
+           ('create table if not exists test1 as select 1 as val', current_role::regrole, 1),
+           ('create table if not exists testr as select current_role::regrole', 'runner'::regrole, 3)
 
 - name: restart
   restart: true
@@ -30,19 +39,21 @@ tests:
             attempt      int := 0;
             test1_exists boolean;
             test2_exists boolean;
+            testr_exists boolean;
         begin
             loop
                 attempt := attempt + 1;
                 
                 select exists(select 1 from pg_tables where tablename = 'test1') into test1_exists;
                 select exists(select 1 from pg_tables where tablename = 'test2') into test2_exists;
-                
-                exit when (test1_exists and test2_exists) or attempt >= max_attempts;
+                select exists(select 1 from pg_tables where tablename = 'testr') into testr_exists;
+    
+                exit when (test1_exists and test2_exists and testr_exists) or attempt >= max_attempts;
                 
                 perform pg_sleep(0.1);
             end loop;
-            
-            if not (test1_exists and test2_exists) then
+    
+            if not (test1_exists and test2_exists and testr_exists) then
                 raise exception 'Tables not created after % attempts', max_attempts;
             end if;
         end
@@ -59,3 +70,8 @@ tests:
          from test2
   results:
   - val: 1
+
+- name: check testr
+  query: select * from testr
+  results:
+  - current_role: runner


### PR DESCRIPTION
It will currently execute SQL statements as a privileged user, which is undesirable as this is a huge escape hatch for underprivileged users.

Solution: only allow scheduling under accessible roles