### PR TITLE
Problem: spurious failures in omni_worker sql tests

### DIFF
--- a/extensions/omni_worker/CHANGELOG.md
+++ b/extensions/omni_worker/CHANGELOG.md
@@ -15,6 +15,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * SQL execution role restriction [#945](https://github.com/omnigres/omnigres/pull/945)
+* SQL handler should return after committing [#946](https://github.com/omnigres/omnigres/pull/946)
 
 ## [0.1.4] - 2025-09-04
 

--- a/extensions/omni_worker/tests/sql.yml
+++ b/extensions/omni_worker/tests/sql.yml
@@ -61,7 +61,9 @@ tests:
   - grant all on schema public to runner
   - grant all on all tables in schema public to runner
   - grant all on all sequences in schema public to runner
-  - select omni_worker.sql('create table role_change as select current_role::regrole', wait_ms => 10000, run_as => 'runner')
+  - query: select omni_worker.sql('create table role_change as select current_role::regrole', wait_ms => 10000, run_as => 'runner')
+    results:
+    - sql: true
   - query: select  * from role_change
     results:
     - current_role: runner


### PR DESCRIPTION
Solution: ensure we return from sql handler after commit
    
We were sending the notification when we performed the statement, but
before we actually comitted it. It was causing tests to not see
committed data (because it wasn't yet!)