### PR TITLE
 Problem: how do users find their sql autostart statements?

### DIFF
--- a/extensions/omni_worker/CHANGELOG.md
+++ b/extensions/omni_worker/CHANGELOG.md
@@ -9,7 +9,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-* SQL autostart functionality [#932](https://github.com/omnigres/omnigres/pull/932)
+* SQL autostart
+  functionality [#932](https://github.com/omnigres/omnigres/pull/932), [#947](https://github.com/omnigres/omnigres/pull/947)
 * Timer handler for worker tasks [#943](https://github.com/omnigres/omnigres/pull/943)
 
 ### Fixed

--- a/extensions/omni_worker/tests/sql_autostart.yml
+++ b/extensions/omni_worker/tests/sql_autostart.yml
@@ -75,3 +75,18 @@ tests:
   query: select * from testr
   results:
   - current_role: runner
+
+- name: allow changing labels from null
+  commit: true
+  query: update omni_worker.sql_autostart_stmt set label = gen_random_uuid()
+
+- name: do not allow changing labels otherwise
+  query: update omni_worker.sql_autostart_stmt set label = gen_random_uuid()
+  error: sql_autostart_stmt labels are immutable
+
+- name: labels are unique
+  query: |
+    with l as (select label as old_label from omni_worker.sql_autostart_stmt limit 1)
+    insert into omni_worker.sql_autostart_stmt (stmt, label, position)
+    select 'select',old_label,1 from l
+  error: duplicate key value violates unique constraint "sql_autostart_stmt_label_key"


### PR DESCRIPTION
They can find them by the statement itself, but this is rather
overboard.

Solution: introduce statement labels

Labels are made immutable so that users don't rename them