### PR TITLE
Problem: container image build fails on arm64 for pg14-15 (🚀 omni_worker 0.2.1)

### DIFF
--- a/extensions/omni_worker/CHANGELOG.md
+++ b/extensions/omni_worker/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-09-15
+
+### Fixed
+
+* Potential compilation issues on x86_64 (Postgres 14/15) [#955](https://github.com/omnigres/omnigres/pull/955)
+
 ## [0.2.0] - 2025-09-13
 
 ### Added
@@ -59,3 +65,5 @@ Initial release
 [0.1.4]: [https://github.com/omnigres/omnigres/pull/938]
 
 [0.2.0]: [https://github.com/omnigres/omnigres/pull/865]
+
+[0.2.1]: [https://github.com/omnigres/omnigres/pull/955]

--- a/extensions/omni_worker/handlers.cpp
+++ b/extensions/omni_worker/handlers.cpp
@@ -3,11 +3,11 @@
 #include <oink.hpp>
 #include <type_traits>
 
+#include <cppgres.hpp>
+
 extern "C" {
 #include <omni/omni_v0.h>
 }
-
-#include <cppgres.hpp>
 
 #include "omni_worker.hpp"
 

--- a/versions.txt
+++ b/versions.txt
@@ -33,6 +33,6 @@ omni_var=0.3.0
 omni_vfs_types_v1=0.1.0
 omni_vfs=0.2.2
 omni_web=0.3.0
-omni_worker=0.2.0
+omni_worker=0.2.1
 omni_xml=0.1.2
 omni_yaml=0.1.0


### PR DESCRIPTION
```
 #51 35.44 /omni/.pg/Linux-RelWithDebInfo/15.14/build/include/postgresql/server/port/atomics/arch-x86.h:143:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
 #51 35.44         register char _res = 1;
```

Solution: ensure we include cppgres.hpp prior to omni

The reason for that is that cppgres has accommodations for this issue in the form of disabling this error when including Postgres headers.

By letting cppgres.hpp include Postgres headers first, we should be able to avoid the issue.