### PR TITLE
Fix: omni_schema execution order to respect priority

### DIFF
--- a/extensions/omni_schema/src/assemble_schema.sql
+++ b/extensions/omni_schema/src/assemble_schema.sql
@@ -144,7 +144,7 @@ begin
         while true
             loop
                 <<file>>
-                for current_filename in select distinct filepath from omni_schema_execution_status order by filepath
+                for current_filename in select filepath from omni_schema_execution_status group by filepath order by min(id)
                     loop
                         <<statement>>
                         for rec in select *


### PR DESCRIPTION
Related Issue
Fixes #739

Description
This PR fixes an issue where omni_schema.assemble_schema was executing files in alphabetical order by filename, ignoring the priority defined by language or auxiliary tools (e.g., requirements.txt should run before hello.py).

The fix updates the execution loop to order by min(id) from omni_schema_execution_status, which correctly respects the insertion order (and thus the priority) determined earlier in the function.

Changes
Modified 
extensions/omni_schema/src/assemble_schema.sql
 to change the iteration order from ORDER BY filepath to GROUP BY filepath ORDER BY min(id).