### PR TITLE
feat(omni_txn): add timeout parameter to retry procedure

### DIFF
--- a/extensions/omni_txn/docs/retry.md
+++ b/extensions/omni_txn/docs/retry.md
@@ -13,6 +13,7 @@ to handle such typical cases.
 | **collect_backoff_values** | boolean | Collect actual backoff values for inspection. False by default.                           |
 |                 **params** | record  | A record of parameters to pass to the statement. NULL by default                          |
 |              **linearize** | boolean | If a transaction should be [linearized](linearize.md) (_experimental_). False by default. |
+|                **timeout** | float   | Maximum duration in seconds to keep retrying. 0 means no timeout (default). When both `max_attempts` and `timeout` are specified, whichever limit is reached first stops the retries. |
 
 ## Retry attempt
 
@@ -77,6 +78,26 @@ call omni_txn.retry($$
 update inventory set quantity = quantity - 10
        where product_name = 'Widgert'
 $$);
+```
+
+## Timeout
+
+Instead of (or in addition to) limiting by number of attempts, you can limit by wall-clock time:
+
+```postgresql
+--- Retry for at most 5 seconds
+call omni_txn.retry($$
+  update inventory set quantity = quantity + 1 where product_name = 'Widget'
+$$, timeout => 5.0);
+```
+
+When both `max_attempts` and `timeout` are specified, whichever limit is reached first will stop the retries:
+
+```postgresql
+--- Stop after 10 attempts OR 2 seconds, whichever comes first
+call omni_txn.retry($$
+  update inventory set quantity = quantity + 1 where product_name = 'Widget'
+$$, max_attempts => 10, timeout => 2.0);
 ```
 
 ## Parameterized statements

--- a/extensions/omni_txn/migrate/7_retry_timeout.sql
+++ b/extensions/omni_txn/migrate/7_retry_timeout.sql
@@ -1,0 +1,17 @@
+drop procedure retry(stmts text, max_attempts int, repeatable_read boolean,
+                     collect_backoff_values boolean, params record, linearize boolean);
+
+create procedure retry(stmts text, max_attempts int default 10, repeatable_read boolean default false,
+                       collect_backoff_values boolean default false,
+                       params record default null::record, linearize boolean default false,
+                       timeout float default 0)
+    language c as
+'MODULE_PATHNAME';
+
+comment on procedure retry is $$
+Retry serializable transaction on statements `stmts`, `max_attempt` number of times (10 by default).
+`collect_backoff_values` controls if the backoff values used for sleeping will be recorded for
+debugging/testing purposes (false in order to increase performance).
+`timeout` specifies the maximum duration in seconds to keep retrying (0 means no timeout, default).
+When both `max_attempts` and `timeout` are specified, whichever limit is reached first will stop the retries.
+$$;

--- a/extensions/omni_txn/retry.c
+++ b/extensions/omni_txn/retry.c
@@ -20,6 +20,8 @@
 #include <nodes/pg_list.h>
 #include <utils/memutils.h>
 
+#include <utils/timestamp.h>
+
 #include <omni/omni_v0.h>
 
 #include "omni_txn.h"
@@ -116,6 +118,15 @@ Datum retry(PG_FUNCTION_ARGS) {
   if (!PG_ARGISNULL(3)) {
     collect_backoff_values = PG_GETARG_BOOL(3);
   }
+
+  float8 timeout_secs = 0;
+  if (!PG_ARGISNULL(6)) {
+    timeout_secs = PG_GETARG_FLOAT8(6);
+    if (timeout_secs < 0) {
+      ereport(ERROR, errmsg("timeout must be non-negative"));
+    }
+  }
+  TimestampTz start_time = GetCurrentTimestamp();
 
   text *stmts = PG_GETARG_TEXT_PP(0);
   char *cstmts = MemoryContextStrdup(RetryPreparedStatementMemoryContext, text_to_cstring(stmts));
@@ -231,6 +242,24 @@ Datum retry(PG_FUNCTION_ARGS) {
         error_context_stack = previous_error_context;
         FlushErrorState();
         if (++retry_attempts <= max_attempts) {
+          // Check timeout
+          if (timeout_secs > 0) {
+            TimestampTz now = GetCurrentTimestamp();
+            long elapsed_secs;
+            int elapsed_microsecs;
+            TimestampDifference(start_time, now, &elapsed_secs, &elapsed_microsecs);
+            float8 elapsed = (float8)elapsed_secs + (float8)elapsed_microsecs / 1000000.0;
+            if (elapsed >= timeout_secs) {
+              if (GetCurrentTransactionNestLevel() >= 2) {
+                RollbackAndReleaseCurrentSubTransaction();
+              }
+              MemoryContextSwitchTo(current_mcxt);
+              CurrentResourceOwner = oldowner;
+              SPI_rollback();
+              ereport(ERROR, errcode(sqlerrcode),
+                      errmsg("retry timeout (%.3f seconds) has been exceeded", timeout_secs));
+            }
+          }
 
           int64 backoff_with_jitter_in_microsecs =
               backoff_jitter(cap_sleep_microsecs, base_sleep_microsecs, retry_attempts);

--- a/extensions/omni_txn/tests/retry_timeout.yml
+++ b/extensions/omni_txn/tests/retry_timeout.yml
@@ -1,0 +1,78 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  init:
+  - create extension omni_txn cascade
+  - create extension dblink
+  - select dblink_connect('another_session', 'hostaddr=127.0.0.1 dbname=yregress user=yregress port=' || (select setting
+                                                                                                          from pg_settings
+                                                                                                          where name = 'port'))
+  - create table inventory
+    (
+        id           serial primary key,
+        product_name text,
+        quantity     int
+    )
+  - insert into inventory (product_name, quantity)
+    values ('Widget', 100)
+  - |
+    create or replace function call_other_session() returns void
+        language plpgsql as
+    $$
+    begin
+        perform dblink_exec('another_session',
+                            'call omni_txn.retry($other$update inventory set quantity = quantity - 10$other$)');
+        return;
+    end;
+    $$
+
+tests:
+
+- name: timeout exceeded
+  transaction: false
+  tests:
+  - query: |
+      call omni_txn.retry($$select quantity from inventory where product_name = 'Widget';
+      select call_other_session();
+      update inventory set quantity = quantity + 20 where product_name = 'Widget';
+      $$, max_attempts => 1000, timeout => 0.001);
+    transaction: false
+    error: retry timeout
+  - rollback
+
+- name: negative timeout rejected
+  transaction: false
+  tests:
+  - query: call omni_txn.retry($$select 1$$, timeout => -1.0)
+    transaction: false
+    error: timeout must be non-negative
+  - rollback
+
+- name: zero timeout means no timeout (default behavior)
+  transaction: false
+  tests:
+  - query: |
+      call omni_txn.retry($$select quantity from inventory where product_name = 'Widget';
+      select call_other_session() where omni_txn.current_retry_attempt() = 0;
+      update inventory set quantity = quantity + 20 where product_name = 'Widget';
+      $$, timeout => 0);
+    transaction: false
+  - query: select quantity
+           from inventory
+           where product_name = 'Widget'
+    results:
+    - quantity: 110
+
+- name: sufficient timeout allows completion
+  transaction: false
+  tests:
+  - query: |
+      call omni_txn.retry($$select quantity from inventory where product_name = 'Widget';
+      select call_other_session() where omni_txn.current_retry_attempt() = 0;
+      update inventory set quantity = quantity + 20 where product_name = 'Widget';
+      $$, timeout => 30.0);
+    transaction: false
+  - query: select quantity
+           from inventory
+           where product_name = 'Widget'
+    results:
+    - quantity: 110


### PR DESCRIPTION
## Summary

Adds a `timeout` parameter (float, in seconds) to `omni_txn.retry` that limits the wall-clock duration of retry attempts. This addresses #669 — `max_attempts` alone doesn't tell us *how long* we should be trying.

## Changes

| File | Description |
|------|-------------|
| `retry.c` | Read timeout arg, track start time via `GetCurrentTimestamp()`, check elapsed time before each retry |
| `migrate/7_retry_timeout.sql` | New migration: drop/recreate procedure with `timeout float default 0` |
| `docs/retry.md` | Document new parameter with examples |
| `tests/retry_timeout.yml` | 4 test cases: timeout exceeded, negative rejected, zero=default, sufficient timeout allows completion |

## Behavior

- `timeout => 0` (default): no timeout — fully backward compatible
- `timeout => 5.0`: stop retrying after 5 seconds
- When both `max_attempts` and `timeout` are set, whichever limit is reached first stops retries
- Negative values produce an error

## Example

```sql
-- Retry for at most 5 seconds
call omni_txn.retry($$
  update inventory set quantity = quantity + 1 where product_name = 'Widget'
$$, timeout => 5.0);

-- Stop after 10 attempts OR 2 seconds, whichever comes first
call omni_txn.retry($$
  update inventory set quantity = quantity + 1 where product_name = 'Widget'
$$, max_attempts => 10, timeout => 2.0);
```

Closes #669